### PR TITLE
chore: check for any semantic commit

### DIFF
--- a/.github/semantic.yml
+++ b/.github/semantic.yml
@@ -1,4 +1,5 @@
-titleOnly: true
+titleAndCommits: true
+anyCommit: true
 types:
   - feat
   - fix


### PR DESCRIPTION
❗ **Problem/Ticket:** If a Pull Requests contains one commit only, this commit message is used as the commit message when merged into master. This way it is currently possible to have a non-semantic commit but a semantic PR title which marks the PR as correct and in result will lead to a non-semantic commit message in the `master` branch.

⚙️  **Change(s)**:
- Check title and commit messages
- Mark as checked if there are any semantic commit messages and the title is semantic