### PR TITLE
feat(elements|ino-snackbar): add property to set custom timeout

### DIFF
--- a/packages/elements-angular/elements/src/directives/proxies.ts
+++ b/packages/elements-angular/elements/src/directives/proxies.ts
@@ -438,8 +438,8 @@ export class InoSidebar {
 }
 export declare interface InoSnackbar extends Components.InoSnackbar {
 }
-@ProxyCmp({ inputs: ["inoActionText", "inoAlignment", "inoMessage"] })
-@Component({ selector: "ino-snackbar", changeDetection: ChangeDetectionStrategy.OnPush, template: "<ng-content></ng-content>", inputs: ["inoActionText", "inoAlignment", "inoMessage"] })
+@ProxyCmp({ inputs: ["inoActionText", "inoAlignment", "inoMessage", "inoTimeout"] })
+@Component({ selector: "ino-snackbar", changeDetection: ChangeDetectionStrategy.OnPush, template: "<ng-content></ng-content>", inputs: ["inoActionText", "inoAlignment", "inoMessage", "inoTimeout"] })
 export class InoSnackbar {
     inoActionClick!: EventEmitter<CustomEvent>;
     hideEl!: EventEmitter<CustomEvent>;

--- a/packages/elements/src/components.d.ts
+++ b/packages/elements/src/components.d.ts
@@ -926,7 +926,7 @@ export namespace Components {
          */
         "inoMessage"?: string;
         /**
-          * Sets the timeout in ms until the snackbar disappears. The timeout can be disabled by setting it to -1.
+          * Sets the timeout in ms until the snackbar disappears. The timeout can be disabled by setting it to a negative value.
          */
         "inoTimeout"?: number;
     }
@@ -2410,7 +2410,7 @@ declare namespace LocalJSX {
          */
         "inoMessage"?: string;
         /**
-          * Sets the timeout in ms until the snackbar disappears. The timeout can be disabled by setting it to -1.
+          * Sets the timeout in ms until the snackbar disappears. The timeout can be disabled by setting it to a negative value.
          */
         "inoTimeout"?: number;
         /**

--- a/packages/elements/src/components.d.ts
+++ b/packages/elements/src/components.d.ts
@@ -925,6 +925,10 @@ export namespace Components {
           * The text message to display.
          */
         "inoMessage"?: string;
+        /**
+          * Sets the timeout in ms until the snackbar disappears. The timeout can be disabled by setting it to -1.
+         */
+        "inoTimeout"?: number;
     }
     interface InoSpinner {
         /**
@@ -2405,6 +2409,10 @@ declare namespace LocalJSX {
           * The text message to display.
          */
         "inoMessage"?: string;
+        /**
+          * Sets the timeout in ms until the snackbar disappears. The timeout can be disabled by setting it to -1.
+         */
+        "inoTimeout"?: number;
         /**
           * Event that emits as soon as the snackbar hides. Listen to this event to hide or destroy this element.
          */

--- a/packages/elements/src/components/ino-snackbar/ino-snackbar.tsx
+++ b/packages/elements/src/components/ino-snackbar/ino-snackbar.tsx
@@ -53,7 +53,9 @@ export class Snackbar implements ComponentInterface {
     );
     this.snackbarInstance.open();
     this.snackbarInstance.timeoutMs = -1;
-    setTimeout(() => this.snackbarInstance.close(), this.inoTimeout);
+    if (this.inoTimeout >= 0) {
+      setTimeout(() => this.snackbarInstance.close(), this.inoTimeout);
+    }
   }
 
   componentWillUnload() {

--- a/packages/elements/src/components/ino-snackbar/ino-snackbar.tsx
+++ b/packages/elements/src/components/ino-snackbar/ino-snackbar.tsx
@@ -51,11 +51,8 @@ export class Snackbar implements ComponentInterface {
     this.snackbarElement.addEventListener('MDCSnackbar:closing', e =>
       this.handleSnackbarHide(e)
     );
+    this.configureTimeout();
     this.snackbarInstance.open();
-    this.snackbarInstance.timeoutMs = -1;
-    if (this.inoTimeout >= 0) {
-      setTimeout(() => this.snackbarInstance.close(), this.inoTimeout);
-    }
   }
 
   componentWillUnload() {
@@ -68,6 +65,13 @@ export class Snackbar implements ComponentInterface {
   private handleSnackbarHide(e) {
     this.hideEl!.emit(true);
     e.stopPropagation();
+  }
+
+  private configureTimeout() {
+    this.snackbarInstance.timeoutMs = -1;
+    if (this.inoTimeout >= 0) {
+      setTimeout(() => this.snackbarInstance.close(), this.inoTimeout);
+    }
   }
 
   render() {

--- a/packages/elements/src/components/ino-snackbar/ino-snackbar.tsx
+++ b/packages/elements/src/components/ino-snackbar/ino-snackbar.tsx
@@ -60,11 +60,7 @@ export class Snackbar implements ComponentInterface {
     this.snackbarElement.removeEventListener('MDCSnackbar:closing', e =>
       this.handleSnackbarHide(e)
     );
-  }
 
-  private handleSnackbarHide(e) {
-    this.hideEl!.emit(true);
-    e.stopPropagation();
   }
 
   private configureTimeout() {
@@ -72,6 +68,11 @@ export class Snackbar implements ComponentInterface {
     if (this.inoTimeout >= 0) {
       setTimeout(() => this.snackbarInstance.close(), this.inoTimeout);
     }
+  }
+
+  private handleSnackbarHide(e) {
+    this.hideEl!.emit(true);
+    e.stopPropagation();
   }
 
   render() {

--- a/packages/elements/src/components/ino-snackbar/ino-snackbar.tsx
+++ b/packages/elements/src/components/ino-snackbar/ino-snackbar.tsx
@@ -30,6 +30,12 @@ export class Snackbar implements ComponentInterface {
   @Prop() inoAlignment?: 'left' | 'right' | 'center' = 'center';
 
   /**
+   * Sets the timeout in ms until the snackbar disappears. The timeout can
+   * be disabled by setting it to -1.
+   */
+  @Prop() inoTimeout?: number = 5000;
+
+  /**
    * Event that emits as soon as the action button is clicked.
    */
   @Event() inoActionClick!: EventEmitter;
@@ -46,6 +52,8 @@ export class Snackbar implements ComponentInterface {
       this.handleSnackbarHide(e)
     );
     this.snackbarInstance.open();
+    this.snackbarInstance.timeoutMs = -1;
+    setTimeout(() => this.snackbarInstance.close(), this.inoTimeout);
   }
 
   componentWillUnload() {

--- a/packages/elements/src/components/ino-snackbar/ino-snackbar.tsx
+++ b/packages/elements/src/components/ino-snackbar/ino-snackbar.tsx
@@ -31,7 +31,7 @@ export class Snackbar implements ComponentInterface {
 
   /**
    * Sets the timeout in ms until the snackbar disappears. The timeout can
-   * be disabled by setting it to -1.
+   * be disabled by setting it to a negative value.
    */
   @Prop() inoTimeout?: number = 5000;
 

--- a/packages/elements/src/components/ino-snackbar/readme.md
+++ b/packages/elements/src/components/ino-snackbar/readme.md
@@ -107,7 +107,7 @@ Snackbar is displayed when ino-show is changed to checked.
 | `inoActionText` | `ino-action-text` | The text to display for the action button. If no text is defined, the snack bar is displayed in an alternative feedback style. | `string`                        | `''`        |
 | `inoAlignment`  | `ino-alignment`   | Controls if Snackbar is centered or left-aligned or right-aligned.                                                             | `"center" \| "left" \| "right"` | `'center'`  |
 | `inoMessage`    | `ino-message`     | The text message to display.                                                                                                   | `string`                        | `undefined` |
-| `inoTimeout`    | `ino-timeout`     | Sets the timeout in ms until the snackbar disappears. The timeout can be disabled by setting it to -1.                         | `number`                        | `5000`      |
+| `inoTimeout`    | `ino-timeout`     | Sets the timeout in ms until the snackbar disappears. The timeout can be disabled by setting it to a negative value.           | `number`                        | `5000`      |
 
 
 ## Events

--- a/packages/elements/src/components/ino-snackbar/readme.md
+++ b/packages/elements/src/components/ino-snackbar/readme.md
@@ -107,6 +107,7 @@ Snackbar is displayed when ino-show is changed to checked.
 | `inoActionText` | `ino-action-text` | The text to display for the action button. If no text is defined, the snack bar is displayed in an alternative feedback style. | `string`                        | `''`        |
 | `inoAlignment`  | `ino-alignment`   | Controls if Snackbar is centered or left-aligned or right-aligned.                                                             | `"center" \| "left" \| "right"` | `'center'`  |
 | `inoMessage`    | `ino-message`     | The text message to display.                                                                                                   | `string`                        | `undefined` |
+| `inoTimeout`    | `ino-timeout`     | Sets the timeout in ms until the snackbar disappears. The timeout can be disabled by setting it to -1.                         | `number`                        | `5000`      |
 
 
 ## Events

--- a/packages/storybook/src/stories/ino-snackbar/ino-snackbar.stories.js
+++ b/packages/storybook/src/stories/ino-snackbar/ino-snackbar.stories.js
@@ -1,4 +1,4 @@
-import { select, text } from '@storybook/addon-knobs';
+import { number, select, text } from '@storybook/addon-knobs';
 import withStencilReadme from '_local-storybookcore/with-stencil-readme';
 import componentReadme from '_local-elements/src/components/ino-snackbar/readme.md';
 import './ino-snackbar.scss';
@@ -52,6 +52,7 @@ export const DefaultUsage = () => /*html*/ `
                 id="custom-snackbar"
                 ino-message="${text('ino-message', sampleText)}"
                 ino-action-text="${text('ino-action-text', 'Anlegen')}"
+                ino-timeout="${number('ino-timeout', 5000)}"
                 ino-alignment="${select(
                   'ino-alignment',
                   ['center', 'leading', 'trailing'],


### PR DESCRIPTION
✨ **Features:**
* Added a new `inoTimeout` property to the `ino-snackbar` component that can be used to modify the time it takes until the snackbar disappears

🎟️ **Resolves:** [ELEMENTS-699](https://jira.inovex.de/browse/ELEMENTS-699)

**Note:** Does not resolve `#81`