### PR TITLE
fix(elements|ino-switch): fix color-schemes not working correctly

### DIFF
--- a/packages/elements/src/components/ino-switch/ino-switch.scss
+++ b/packages/elements/src/components/ino-switch/ino-switch.scss
@@ -1,6 +1,6 @@
 @use '@material/switch/mdc-switch';
 @use '@material/switch';
-@use 'styles/colors';
+@use '../styles/colors';
 
 // Shadows
 $small-shadow: 0 4px 8px 0 rgba(61, 64, 245, 0.3),
@@ -41,6 +41,18 @@ ino-switch {
   --switch-disabled-color: var(--ino-switch-disabled-color, #{colors.ino-color(light, base)});
   --switch-disabled-thumb-color: var(--ino-switch-disabled-thumb-color, #{colors.ino-color(light, base)});
   --switch-disabled-track-color: var(--ino-switch-disabled-track-color, #{colors.ino-color(light, base)});
+}
+
+@each $color in colors.$ino-colors {
+  ino-switch[ino-color-scheme="#{$color}"] {
+    --switch-toggled-on-color: #{colors.ino-color($color, base)};
+    --switch-toggled-on-thumb-color: #{colors.ino-color($color, base)};
+    --switch-toggled-on-track-color: #{colors.ino-color($color, light)};
+    --switch-hover-color: #{colors.ino-color($color, light)};
+    --switch-hover-track-color: #{colors.ino-color($color, light)};
+    --switch-active-color: #{colors.ino-color($color, dark)};
+    --switch-active-track-color: #{colors.ino-color($color, dark)};
+  }
 }
 
 /** colors **/

--- a/packages/elements/src/components/styles/colors.scss
+++ b/packages/elements/src/components/styles/colors.scss
@@ -21,6 +21,8 @@ $error: #eb003b;
 $light: #c1c1c1;
 $dark: #777777;
 
+$ino-colors: "primary", "secondary", "success", "warning", "error", "light", "dark";
+
 $ino-color-scheme: (
   primary: (
     base: $primary,

--- a/packages/storybook/src/stories/ino-switch/ino-switch.stories.js
+++ b/packages/storybook/src/stories/ino-switch/ino-switch.stories.js
@@ -66,7 +66,6 @@ export const DefaultUsage = () => /*html*/ `
    <ino-switch
      id="custom-switch"
      class="customizable-switch"
-     ino-color-scheme="${select('ino-color-scheme', INO_COLOR_SCHEMES, 'primary')}"
      checked="${boolean('checked', false)}"
      disabled="${boolean('disabled', false)}"
    >


### PR DESCRIPTION
⚙️ **Changes:**
* Added color schemes back to `ino-switch` stylesheet

**Closes #84**