### PR TITLE
ci: disable publishing via Gitlab CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -56,18 +56,3 @@ link-latest:
     - deploy
   only:
     - tags
-
-publish-package:
-  stage: publish-package
-  script:
-    - yarn install
-    - yarn config set //registry.npmjs.org/:_authToken $NPM_TOKEN --silent
-    - yarn lerna publish from-package --yes
-  cache:
-    paths:
-      - node_modules/
-      - .yarn
-  tags:
-    - shared
-  only:
-    - tags


### PR DESCRIPTION
Relates to #110 

## Proposed Changes

- disable the publishing part of the GitLab ci because it is currently not working and we will probably switch to publishing our packages manually