### PR TITLE
chore(deps): bump marked from 0.6.0 to 0.7.0

### DIFF
--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -63,7 +63,7 @@
     "jest": "24.8.0",
     "jest-cli": "24.8.0",
     "jest-environment-node": "23.4.0",
-    "marked": "^0.6.0",
+    "marked": "^0.7.0",
     "node-sass": "^4.12.0",
     "prettier": "^1.16.4",
     "react": "^16.8.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -15077,10 +15077,10 @@ markdown-to-jsx@^6.11.4:
     prop-types "^15.6.2"
     unquote "^1.1.0"
 
-marked@^0.6.0:
-  version "0.6.3"
-  resolved "https://registry.npmjs.org/marked/-/marked-0.6.3.tgz#79babad78af638ba4d522a9e715cdfdd2429e946"
-  integrity sha512-Fqa7eq+UaxfMriqzYLayfqAE40WN03jf+zHjT18/uXNuzjq3TY0XTbrAoPeqSJrAmPz11VuUA+kBPYOhHt9oOQ==
+marked@^0.7.0:
+  version "0.7.0"
+  resolved "https://registry.npmjs.org/marked/-/marked-0.7.0.tgz#b64201f051d271b1edc10a04d1ae9b74bb8e5c0e"
+  integrity sha512-c+yYdCZJQrsRjTPhUx7VKkApw9bwDkNbHUKo1ovgcfDjb2kc8rLuRbIFyXL5WOEUwzSSKo3IXpph2K6DqB/KZg==
 
 matcher@^1.0.0:
   version "1.1.1"


### PR DESCRIPTION
## Proposed Changes

- update dep `marked` to 0.7.0
- fixes vulnerability of `marked` in versions 0.4.0 to < 0.7.0 (see: https://github.com/advisories/GHSA-ch52-vgq2-943f)