### PR TITLE
fix(elements|ino-fab): ensure creation of tooltip after fab loaded

### DIFF
--- a/packages/elements/src/components/ino-fab-set/readme.md
+++ b/packages/elements/src/components/ino-fab-set/readme.md
@@ -127,8 +127,8 @@ The ino-fab-set has a controlled (unmanaged) attribute `inoOpenDial`. For this r
 graph TD;
   ino-fab-set --> ino-fab
   ino-fab-set --> ino-icon
-  ino-fab --> ino-icon
   ino-fab --> ino-tooltip
+  ino-fab --> ino-icon
   style ino-fab-set fill:#f9f,stroke:#333,stroke-width:4px
 ```
 

--- a/packages/elements/src/components/ino-fab/ino-fab.tsx
+++ b/packages/elements/src/components/ino-fab/ino-fab.tsx
@@ -77,13 +77,22 @@ export class Fab implements ComponentInterface {
       this.el.shadowRoot.querySelector('.mdc-fab')
     );
 
-    if (this.tooltipRef) {
-      this.tooltipRef.getTippyInstance().then(instance =>
-        instance.setProps({
-          appendTo: this.el.shadowRoot
-        })
-      );
+    if (!this.inoExtended && this.inoTooltipPlacement !== 'none') {
+      this.renderTooltip();
     }
+  }
+
+  private renderTooltip() {
+    const attributes = {
+      'ino-for': this.uniqueHelperId,
+      'ino-label': this.inoLabel,
+      'ino-placement': this.inoTooltipPlacement,
+      'ino-trigger': 'mouseenter focus'
+    };
+
+    const tooltip = document.createElement('ino-tooltip');
+    Object.keys(attributes).forEach(key => tooltip.setAttribute(key, attributes[key]));
+    this.el.appendChild(tooltip);
   }
 
   componentWillUnload() {
@@ -125,15 +134,6 @@ export class Fab implements ComponentInterface {
             <span class="mdc-fab__label">{this.inoLabel}</span>
           )}
         </button>
-        {!this.inoExtended && this.inoTooltipPlacement !== 'none' && (
-          <ino-tooltip
-            ref={(el: HTMLInoTooltipElement) => (this.tooltipRef = el)}
-            ino-for={this.uniqueHelperId}
-            ino-label={this.inoLabel}
-            ino-placement={this.inoTooltipPlacement}
-            ino-trigger="mouseenter focus"
-          />
-        )}
       </Host>
     );
   }

--- a/packages/elements/src/components/ino-fab/readme.md
+++ b/packages/elements/src/components/ino-fab/readme.md
@@ -114,14 +114,14 @@ class MyComponent extends Component {
 
 ### Depends on
 
-- [ino-icon](../ino-icon)
 - [ino-tooltip](../ino-tooltip)
+- [ino-icon](../ino-icon)
 
 ### Graph
 ```mermaid
 graph TD;
-  ino-fab --> ino-icon
   ino-fab --> ino-tooltip
+  ino-fab --> ino-icon
   ino-fab-set --> ino-fab
   style ino-fab fill:#f9f,stroke:#333,stroke-width:4px
 ```


### PR DESCRIPTION
Closes #155 

## Proposed Changes

- Wait for `ino-fab` to finish loading
- Create and append `ino-tooltip` element afterward