### PR TITLE
fix(elements|ino-table): disable shadow dom

### DIFF
--- a/packages/elements/src/components/ino-table/ino-table.scss
+++ b/packages/elements/src/components/ino-table/ino-table.scss
@@ -2,7 +2,7 @@
 @use '@material/data-table/data-table';
 @use '../styles/colors';
 
-:host {
+ino-table {
   @include data-table.core-styles;
   @include data-table.theme-baseline;
 

--- a/packages/elements/src/components/ino-table/ino-table.tsx
+++ b/packages/elements/src/components/ino-table/ino-table.tsx
@@ -3,7 +3,7 @@ import { Component, ComponentInterface, Element, Host, h } from '@stencil/core';
 @Component({
   tag: 'ino-table',
   styleUrl: 'ino-table.scss',
-  shadow: true
+  shadow: false
 })
 export class InoTable implements ComponentInterface {
 


### PR DESCRIPTION
⚙️ **Changes:**
* `ino-table`: disabled the shadow dom

🎟️ **Closes #162**