### PR TITLE
chore(*): build angular repo before publishing

### DIFF
--- a/packages/elements-angular/elements/package.json
+++ b/packages/elements-angular/elements/package.json
@@ -18,6 +18,9 @@
     "@angular/common": "^10.1.4",
     "@angular/core": "^10.1.4"
   },
+  "scripts": {
+    "prepublishOnly": "cd ../ && yarn build"
+  },
   "publishConfig": {
     "directory": "../dist"
   }


### PR DESCRIPTION
Resolves the following problem in the lerna releasing workflow:

1. Lerna pumps the version of all packages
2. We try to deploy the Angular package with respective `packages/elements-angular/elements/package.json` configuration
3. The configuration states that the distribution config remains within the `../dist` folder.
4. However, in the `../dist` folder there is an outdated package.json

To resolve this, rebuild `elements-angular` before publishing.