### PR TITLE
feat(elements|ino-input): add readonly textfield and datepicker

### DIFF
--- a/packages/elements-angular/elements/src/directives/proxies.ts
+++ b/packages/elements-angular/elements/src/directives/proxies.ts
@@ -181,13 +181,13 @@ export class InoControlItem {
 import { Datepicker as IDatepicker } from '@inovex.de/elements/dist/types/components/ino-datepicker/ino-datepicker';
 export declare interface InoDatepicker extends Components.InoDatepicker {}
 @ProxyCmp({
-  inputs: ['autoFocus', 'disabled', 'hourStep', 'inoDateFormat', 'inoDefaultDate', 'inoDefaultHour', 'inoDefaultMinute', 'inoHelper', 'inoHelperPersistent', 'inoHelperValidation', 'inoLabel', 'inoOutline', 'inoRange', 'inoShowLabelHint', 'inoTwelveHourTime', 'inoType', 'max', 'min', 'minuteStep', 'name', 'required', 'value']
+  inputs: ['autoFocus', 'disabled', 'hourStep', 'inoDateFormat', 'inoDefaultDate', 'inoDefaultHour', 'inoDefaultMinute', 'inoHelper', 'inoHelperPersistent', 'inoHelperValidation', 'inoLabel', 'inoOutline', 'inoRange', 'inoShowLabelHint', 'inoTwelveHourTime', 'inoType', 'max', 'min', 'minuteStep', 'name', 'readonly', 'required', 'value']
 })
 @Component({
   selector: 'ino-datepicker',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
-  inputs: ['autoFocus', 'disabled', 'hourStep', 'inoDateFormat', 'inoDefaultDate', 'inoDefaultHour', 'inoDefaultMinute', 'inoHelper', 'inoHelperPersistent', 'inoHelperValidation', 'inoLabel', 'inoOutline', 'inoRange', 'inoShowLabelHint', 'inoTwelveHourTime', 'inoType', 'max', 'min', 'minuteStep', 'name', 'required', 'value'],
+  inputs: ['autoFocus', 'disabled', 'hourStep', 'inoDateFormat', 'inoDefaultDate', 'inoDefaultHour', 'inoDefaultMinute', 'inoHelper', 'inoHelperPersistent', 'inoHelperValidation', 'inoLabel', 'inoOutline', 'inoRange', 'inoShowLabelHint', 'inoTwelveHourTime', 'inoType', 'max', 'min', 'minuteStep', 'name', 'readonly', 'required', 'value'],
   outputs: ['valueChange']
 })
 export class InoDatepicker {
@@ -389,14 +389,14 @@ export class InoImgList {
 import { Input as IInput } from '@inovex.de/elements/dist/types/components/ino-input/ino-input';
 export declare interface InoInput extends Components.InoInput {}
 @ProxyCmp({
-  inputs: ['autoFocus', 'autocomplete', 'disabled', 'inoDataList', 'inoDecimalPlaces', 'inoError', 'inoHelper', 'inoHelperCharacterCounter', 'inoHelperPersistent', 'inoHelperValidation', 'inoIconLeading', 'inoIconTrailing', 'inoLabel', 'inoOutline', 'inoShowLabelHint', 'inoThousandsSeparator', 'inoUnit', 'max', 'maxlength', 'min', 'name', 'pattern', 'placeholder', 'required', 'size', 'step', 'type', 'value'],
+  inputs: ['autoFocus', 'autocomplete', 'disabled', 'inoDataList', 'inoDecimalPlaces', 'inoError', 'inoHelper', 'inoHelperCharacterCounter', 'inoHelperPersistent', 'inoHelperValidation', 'inoIconLeading', 'inoIconTrailing', 'inoLabel', 'inoOutline', 'inoShowLabelHint', 'inoThousandsSeparator', 'inoUnit', 'max', 'maxlength', 'min', 'name', 'pattern', 'placeholder', 'readonly', 'required', 'size', 'step', 'type', 'value'],
   methods: ['getInputElement']
 })
 @Component({
   selector: 'ino-input',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
-  inputs: ['autoFocus', 'autocomplete', 'disabled', 'inoDataList', 'inoDecimalPlaces', 'inoError', 'inoHelper', 'inoHelperCharacterCounter', 'inoHelperPersistent', 'inoHelperValidation', 'inoIconLeading', 'inoIconTrailing', 'inoLabel', 'inoOutline', 'inoShowLabelHint', 'inoThousandsSeparator', 'inoUnit', 'max', 'maxlength', 'min', 'name', 'pattern', 'placeholder', 'required', 'size', 'step', 'type', 'value'],
+  inputs: ['autoFocus', 'autocomplete', 'disabled', 'inoDataList', 'inoDecimalPlaces', 'inoError', 'inoHelper', 'inoHelperCharacterCounter', 'inoHelperPersistent', 'inoHelperValidation', 'inoIconLeading', 'inoIconTrailing', 'inoLabel', 'inoOutline', 'inoShowLabelHint', 'inoThousandsSeparator', 'inoUnit', 'max', 'maxlength', 'min', 'name', 'pattern', 'placeholder', 'readonly', 'required', 'size', 'step', 'type', 'value'],
   outputs: ['valueChange', 'inoBlur', 'inoFocus']
 })
 export class InoInput {
@@ -441,13 +441,13 @@ export class InoInputFile {
 
 export declare interface InoLabel extends Components.InoLabel {}
 @ProxyCmp({
-  inputs: ['inoDisabled', 'inoOutline', 'inoRequired', 'inoShowHint', 'inoText']
+  inputs: ['inoDisabled', 'inoFloatAbove', 'inoOutline', 'inoRequired', 'inoShowHint', 'inoText']
 })
 @Component({
   selector: 'ino-label',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
-  inputs: ['inoDisabled', 'inoOutline', 'inoRequired', 'inoShowHint', 'inoText']
+  inputs: ['inoDisabled', 'inoFloatAbove', 'inoOutline', 'inoRequired', 'inoShowHint', 'inoText']
 })
 export class InoLabel {
   protected el: HTMLElement;

--- a/packages/elements/src/components.d.ts
+++ b/packages/elements/src/components.d.ts
@@ -314,6 +314,10 @@ export namespace Components {
          */
         "name"?: string;
         /**
+          * Marks this element as readonly.
+         */
+        "readonly"?: boolean;
+        /**
           * Marks this element as required.
          */
         "required"?: boolean;
@@ -598,6 +602,10 @@ export namespace Components {
          */
         "placeholder"?: string;
         /**
+          * Marks this element as readonly.
+         */
+        "readonly"?: boolean;
+        /**
           * Marks this element as required.
          */
         "required"?: boolean;
@@ -653,6 +661,10 @@ export namespace Components {
           * Colors the label in an light grey to indicate the disabled status for this element
          */
         "inoDisabled": boolean;
+        /**
+          * Marks the label as floated above.
+         */
+        "inoFloatAbove": boolean;
         /**
           * Styles the label in an outlined style
          */
@@ -1816,6 +1828,10 @@ declare namespace LocalJSX {
          */
         "onValueChange"?: (event: CustomEvent<string>) => void;
         /**
+          * Marks this element as readonly.
+         */
+        "readonly"?: boolean;
+        /**
           * Marks this element as required.
          */
         "required"?: boolean;
@@ -2117,6 +2133,10 @@ declare namespace LocalJSX {
          */
         "placeholder"?: string;
         /**
+          * Marks this element as readonly.
+         */
+        "readonly"?: boolean;
+        /**
           * Marks this element as required.
          */
         "required"?: boolean;
@@ -2179,6 +2199,10 @@ declare namespace LocalJSX {
           * Colors the label in an light grey to indicate the disabled status for this element
          */
         "inoDisabled"?: boolean;
+        /**
+          * Marks the label as floated above.
+         */
+        "inoFloatAbove"?: boolean;
         /**
           * Styles the label in an outlined style
          */

--- a/packages/elements/src/components/ino-datepicker/ino-datepicker.tsx
+++ b/packages/elements/src/components/ino-datepicker/ino-datepicker.tsx
@@ -40,6 +40,11 @@ export class Datepicker implements ComponentInterface {
   @Prop() name?: string;
 
   /**
+   * Marks this element as readonly.
+   */
+  @Prop() readonly?: boolean;
+
+  /**
    * Marks this element as required.
    */
   @Prop() required?: boolean;
@@ -214,6 +219,10 @@ export class Datepicker implements ComponentInterface {
     const tagName = target.tagName;
 
     if (!tagName || tagName !== 'INPUT' || this.elementIsInput(target)) {
+      return;
+    }
+
+    if (this.disabled || this.readonly) {
       return;
     }
 
@@ -397,13 +406,14 @@ export class Datepicker implements ComponentInterface {
           value={this.value}
           ino-helper={this.inoHelper}
           ino-outline={this.inoOutline}
+          readonly={this.readonly}
           ino-helper-persistent={this.inoHelperPersistent}
           ino-helper-validation={this.inoHelperValidation}
           ino-show-label-hint={this.inoShowLabelHint}
           onValueChange={e => this.valueChange.emit(e.detail)}
         >
           <ino-icon
-            ino-clickable={!this.disabled}
+            ino-clickable={!(this.disabled || this.readonly)}
             slot={'ino-icon-leading'}
             ino-icon={this.isTimePicker() ? 'time' : 'calendar'}
           >

--- a/packages/elements/src/components/ino-datepicker/readme.md
+++ b/packages/elements/src/components/ino-datepicker/readme.md
@@ -21,6 +21,7 @@ document
   autofocus
   disabled
   name="<string>"
+  readonly
   required
   value="<string>"
   min="<string>"
@@ -154,6 +155,7 @@ or as datetime picker
 | `min`                 | `min`                   | The minimum date that a user can start picking from (inclusive).                                                                                                                  | `string`                                    | `undefined` |
 | `minuteStep`          | `minute-step`           | Adjusts the step for the minute input (incl. scrolling) Default is 5                                                                                                              | `number`                                    | `5`         |
 | `name`                | `name`                  | The input name of this element.                                                                                                                                                   | `string`                                    | `undefined` |
+| `readonly`            | `readonly`              | Marks this element as readonly.                                                                                                                                                   | `boolean`                                   | `undefined` |
 | `required`            | `required`              | Marks this element as required.                                                                                                                                                   | `boolean`                                   | `undefined` |
 | `value`               | `value`                 | The currently selected date shown in the input field **unmanaged**. The given value will not be formatted as date.                                                                | `string`                                    | `''`        |
 

--- a/packages/elements/src/components/ino-input/ino-input.scss
+++ b/packages/elements/src/components/ino-input/ino-input.scss
@@ -4,6 +4,7 @@
 @use '@material/textfield/icon';
 @use '@material/textfield/helper-text';
 @use '@material/floating-label/mdc-floating-label';
+@use "@material/floating-label/mixins" as floating-label-mixins;
 @use '@material/notched-outline/mdc-notched-outline';
 @use '../styles/colors';
 @use '../styles/fonts';
@@ -30,11 +31,14 @@ ino-input {
   /**
    * @prop --ino-input-caret-color: color of the caret
    * @prop --ino-input-label-color: color of the label
+   * @prop --ino-input-label-floated-color: color of the label
    * @prop --ino-input-line-color: line color
    * @prop --ino-input-icon-color: icon color
    */
+
   --input-caret-color: var(--ino-input-caret-color, #{colors.ino-color(primary)});
-  --input-label-color: var(--ino-input-label-color, #{colors.ino-color(primary)});
+  --input-label-color: var(--ino-input-label-color, rgba(0,0,0,0.6));
+  --input-label-floated-color: var(--ino-input-floated-label-color, #{colors.ino-color(primary)});
   --input-line-color: var(--ino-input-line-color, #{colors.ino-color(primary)});
   --input-icon-color: var(--ino-input-icon-color, #{colors.ino-color(primary)});
 }
@@ -65,10 +69,12 @@ ino-input {
       --icon-color: #{$placeholder-color};
     }
 
-    &--focused:not(.mdc-text-field--invalid) {
-      @include textfield.label-color(var(--input-label-color));
-      @include textfield.caret-color(var(--input-caret-color));
+    &:not(.mdc-text-field--invalid) {
       @include textfield.line-ripple-color(var(--input-line-color));
+    }
+
+    &--focused:not(.mdc-text-field--invalid) {
+      @include textfield.caret-color(var(--input-caret-color));
 
       ino-icon {
         --icon-color: var(--input-icon-color);
@@ -105,6 +111,21 @@ ino-input {
       &:not([class*='--with-leading-icon']) {
         padding-left: 0;
         padding-right: 0;
+      }
+      
+      // Read-Only Texfield
+      &.ino-input--readonly:not(.mdc-text-field--disabled) {
+        .mdc-line-ripple {
+          &::before, &::after {
+            border-bottom-color: colors.ino-color(light);
+            border-bottom-style: dashed !important;
+          }
+          // After => Active
+          &::after {
+            border-bottom-width: 1px;
+            border-bottom-color: colors.ino-color(dark);
+          }
+        }
       }
 
       &[class*='--with-leading-icon'] {
@@ -149,6 +170,23 @@ ino-input {
 
     .mdc-text-field__affix.mdc-text-field__affix--suffix {
       margin-right: 12px;
+    }
+  }
+
+
+  // Label
+
+  .mdc-text-field:not(.mdc-text-field--disabled) {
+    // Default + Float above State
+    .mdc-floating-label {
+      @include floating-label-mixins.ink-color(var(--input-label-color));
+      &.mdc-floating-label--float-above {
+        @include floating-label-mixins.ink-color(var(--input-label-floated-color));
+      }
+    }
+    // Validation State
+    &.mdc-text-field--invalid .mdc-floating-label {
+      @include floating-label-mixins.ink-color(colors.ino-color(error));
     }
   }
 

--- a/packages/elements/src/components/ino-input/ino-input.tsx
+++ b/packages/elements/src/components/ino-input/ino-input.tsx
@@ -108,6 +108,11 @@ export class Input implements ComponentInterface {
   @Prop() required?: boolean;
 
   /**
+   * Marks this element as readonly.
+   */
+  @Prop() readonly?: boolean;
+
+  /**
    * The size of this element.
    */
   @Prop() size?: number;
@@ -421,6 +426,7 @@ export class Input implements ComponentInterface {
 
     const classTextfield = classNames({
       'ino-input__composer': true,
+      'ino-input--readonly': this.readonly,
       'mdc-text-field': true,
       'mdc-text-field--disabled': this.disabled,
       'mdc-text-field--focused': this.autoFocus,
@@ -429,7 +435,7 @@ export class Input implements ComponentInterface {
       'mdc-text-field--box': !this.inoOutline,
       'mdc-text-field--with-leading-icon': this.inoIconLeading,
       'mdc-text-field--with-trailing-icon': this.inoIconTrailing || this.inoUnit,
-      'mdc-text-field--no-label': !this.inoLabel
+      'mdc-text-field--no-label': !this.inoLabel,
     });
 
     return (
@@ -452,6 +458,7 @@ export class Input implements ComponentInterface {
             name={this.name}
             pattern={this.pattern}
             placeholder={this.placeholder}
+            readOnly={this.readonly}
             required={this.required}
             size={this.size}
             type={this.type}
@@ -469,7 +476,7 @@ export class Input implements ComponentInterface {
             <span class="mdc-text-field__affix mdc-text-field__affix--suffix">{this.inoUnit}</span>
           }
           {
-            this.type === 'number' &&
+            this.type === 'number' && !this.readonly &&
               <div class={'arrow-container'}>
                 <ino-icon class={'ino-num-arrows up'} onClick={() => this.handleInputNumberArrowClick(true)} ino-icon="_input_number_arrow_down"></ino-icon>
                 <ino-icon class={'ino-num-arrows down'} onClick={() => this.handleInputNumberArrowClick(false)} ino-icon="_input_number_arrow_down"></ino-icon>

--- a/packages/elements/src/components/ino-input/readme.md
+++ b/packages/elements/src/components/ino-input/readme.md
@@ -28,6 +28,7 @@ document
   pattern="<string>"
   placeholder="<string>"
   required
+  readonly
   size="<number>"
   type="<string>"
   value="<string>"
@@ -162,6 +163,7 @@ The component is based on a native input with additional features. Thus, the com
 | `name`                      | `name`                         | The name of this element.                                                                                                                                                                                                                                 | `string`          | `undefined` |
 | `pattern`                   | `pattern`                      | The validation pattern of this element.                                                                                                                                                                                                                   | `string`          | `undefined` |
 | `placeholder`               | `placeholder`                  | The placeholder of this element.                                                                                                                                                                                                                          | `string`          | `undefined` |
+| `readonly`                  | `readonly`                     | Marks this element as readonly.                                                                                                                                                                                                                           | `boolean`         | `undefined` |
 | `required`                  | `required`                     | Marks this element as required.                                                                                                                                                                                                                           | `boolean`         | `undefined` |
 | `size`                      | `size`                         | The size of this element.                                                                                                                                                                                                                                 | `number`          | `undefined` |
 | `step`                      | `step`                         | The step value of this element. Use `any` for decimal numbers                                                                                                                                                                                             | `"any" \| number` | `1`         |
@@ -193,12 +195,13 @@ Type: `Promise<HTMLInputElement>`
 
 ## CSS Custom Properties
 
-| Name                      | Description        |
-| ------------------------- | ------------------ |
-| `--ino-input-caret-color` | color of the caret |
-| `--ino-input-icon-color`  | icon color         |
-| `--ino-input-label-color` | color of the label |
-| `--ino-input-line-color`  | line color         |
+| Name                              | Description        |
+| --------------------------------- | ------------------ |
+| `--ino-input-caret-color`         | color of the caret |
+| `--ino-input-icon-color`          | icon color         |
+| `--ino-input-label-color`         | color of the label |
+| `--ino-input-label-floated-color` | color of the label |
+| `--ino-input-line-color`          | line color         |
 
 
 ## Dependencies

--- a/packages/elements/src/components/ino-label/ino-label.scss
+++ b/packages/elements/src/components/ino-label/ino-label.scss
@@ -1,7 +1,7 @@
-@use '../styles/mdc-customize';
+@use 'styles/mdc-customize';
+@use 'styles/colors';
 @use '@material/floating-label/mdc-floating-label';
 
-$label-color: rgba(0, 0, 0, 0.6);
 
 ino-label {
 
@@ -13,7 +13,6 @@ ino-label {
     &:not([ino-required]) .mdc-floating-label:after {
       content: ' - Optional' + '\a0';
       font-style: italic;
-      color: lighten($label-color, 30);
     }
   }
 
@@ -29,9 +28,5 @@ ino-label {
     ino-input &:not(.mdc-floating-label--float-above) {
       top: 70%;
     }
-  }
-
-  &:not([ino-disabled]) .mdc-floating-label:not(.mdc-floating-label--float-above) {
-    color: $label-color;
   }
 }

--- a/packages/elements/src/components/ino-label/ino-label.tsx
+++ b/packages/elements/src/components/ino-label/ino-label.tsx
@@ -1,4 +1,5 @@
 import { Component, Prop, h } from '@stencil/core';
+import classNames from 'classnames';
 
 @Component({
   tag: 'ino-label',
@@ -6,6 +7,11 @@ import { Component, Prop, h } from '@stencil/core';
   shadow: false
 })
 export class Label {
+  /**
+   * Marks the label as floated above.
+   */
+  @Prop() inoFloatAbove: boolean;
+
   /**
    * Styles the label in an outlined style
    */
@@ -33,8 +39,13 @@ export class Label {
   @Prop() inoDisabled: boolean;
 
   render() {
+    const classLabel = classNames({
+      'mdc-floating-label': true,
+      'mdc-floating-label--float-above': this.inoFloatAbove
+    });
+
     const label = this.inoText ? (
-      <label class={'mdc-floating-label'}>{this.inoText}</label>
+      <label class={classLabel}>{this.inoText}</label>
     ) : (
       ''
     );

--- a/packages/elements/src/components/ino-label/readme.md
+++ b/packages/elements/src/components/ino-label/readme.md
@@ -3,6 +3,7 @@
 This is an internally used component for various sorts of inputs like `ino-input`, `ino-select` and `ino-textarea`. It is used to display the label for each respective component.
 ```html
 <ino-label
+  ino-float-above="<boolean>"
   ino-outline="<boolean>"
   ino-label="<string>"
   ino-required="<boolean>"
@@ -16,13 +17,14 @@ This is an internally used component for various sorts of inputs like `ino-input
 
 ## Properties
 
-| Property      | Attribute       | Description                                                                        | Type      | Default     |
-| ------------- | --------------- | ---------------------------------------------------------------------------------- | --------- | ----------- |
-| `inoDisabled` | `ino-disabled`  | Colors the label in an light grey to indicate the disabled status for this element | `boolean` | `undefined` |
-| `inoOutline`  | `ino-outline`   | Styles the label in an outlined style                                              | `boolean` | `undefined` |
-| `inoRequired` | `ino-required`  | Appends * to the label to make it appear as an required input in a form            | `boolean` | `undefined` |
-| `inoShowHint` | `ino-show-hint` | Shows a "optional" message, when not inoRequired; Shows a * mark, when inoRequired | `boolean` | `undefined` |
-| `inoText`     | `ino-text`      | The text of the label itself                                                       | `string`  | `undefined` |
+| Property        | Attribute         | Description                                                                        | Type      | Default     |
+| --------------- | ----------------- | ---------------------------------------------------------------------------------- | --------- | ----------- |
+| `inoDisabled`   | `ino-disabled`    | Colors the label in an light grey to indicate the disabled status for this element | `boolean` | `undefined` |
+| `inoFloatAbove` | `ino-float-above` | Marks the label as floated above.                                                  | `boolean` | `undefined` |
+| `inoOutline`    | `ino-outline`     | Styles the label in an outlined style                                              | `boolean` | `undefined` |
+| `inoRequired`   | `ino-required`    | Appends * to the label to make it appear as an required input in a form            | `boolean` | `undefined` |
+| `inoShowHint`   | `ino-show-hint`   | Shows a "optional" message, when not inoRequired; Shows a * mark, when inoRequired | `boolean` | `undefined` |
+| `inoText`       | `ino-text`        | The text of the label itself                                                       | `string`  | `undefined` |
 
 
 ## Dependencies

--- a/packages/elements/src/components/styles/mdc-customize.scss
+++ b/packages/elements/src/components/styles/mdc-customize.scss
@@ -7,6 +7,7 @@
   $secondary: colors.ino-color(secondary),
   $on-primary: colors.ino-color(primary, contrast),
   $on-secondary: colors.ino-color(secondary, contrast),
+  $error: colors.ino-color(error),
 );
 
 // @material/typography

--- a/packages/storybook/src/stories/ino-datepicker/ino-datepicker.stories.js
+++ b/packages/storybook/src/stories/ino-datepicker/ino-datepicker.stories.js
@@ -98,6 +98,7 @@ export const DefaultUsage = () => /*html*/ `
       <ino-datepicker ino-label="Pattern numbers from 1 - 6" ino-pattern="[1-6]+"></ino-datepicker>
       <ino-datepicker ino-label="Disabled" disabled></ino-datepicker>
       <ino-datepicker ino-label="Required" required ino-show-label-hint></ino-datepicker>
+      <ino-datepicker ino-label="Readonly" value="${defaultDate}" readonly></ino-datepicker>
       <ino-datepicker ino-label="Optional" ino-show-label-hint></ino-datepicker>
     </div>
   `;

--- a/packages/storybook/src/stories/ino-input/ino-input.stories.js
+++ b/packages/storybook/src/stories/ino-input/ino-input.stories.js
@@ -55,6 +55,7 @@ export const DefaultUsage = () => /*html*/ `
     placeholder="${text('placeholder', '', 'STANDARD')}"
     ino-outline="${boolean('ino-outline', false, 'STANDARD')}"
     disabled="${boolean('disabled', false, 'STANDARD')}"
+    readonly="${boolean('readonly', false, 'STANDARD')}"
     required="${boolean('required', false, 'STANDARD')}"
     ino-show-label-hint="${boolean('ino-show-label-hint', false, 'STANDARD')}"
 
@@ -113,6 +114,9 @@ export const DefaultUsage = () => /*html*/ `
 
   <h4>States</h4>
   <ino-input placeholder="Disabled" disabled></ino-input>
+  <ino-input ino-label="Label" value="Readonly Value" readonly></ino-input>
+  <ino-input ino-label="Readonly wihout value" readonly></ino-input>
+  <ino-input ino-label="Readonly with -" value="-" readonly></ino-input>
   <ino-input ino-label="Optional" ino-show-label-hint></ino-input>
   <ino-input ino-label="Required" required ino-show-label-hint></ino-input>
 


### PR DESCRIPTION
Adds a readonly state to the input field and datepicker.


Requires some attention! Colors behavior changed:
* Floating Label Color changed
* Select has different label color than 