### PR TITLE
feat(elements|ino-input-file): add drag and drop window

### DIFF
--- a/packages/elements-angular/elements/src/directives/proxies.ts
+++ b/packages/elements-angular/elements/src/directives/proxies.ts
@@ -418,13 +418,13 @@ Contains typed input in `event.detail` */
 import { InputFile as IInputFile } from '@inovex.de/elements/dist/types/components/ino-input-file/ino-input-file';
 export declare interface InoInputFile extends Components.InoInputFile {}
 @ProxyCmp({
-  inputs: ['accept', 'autoFocus', 'disabled', 'inoLabel', 'multiple', 'name', 'required']
+  inputs: ['accept', 'autoFocus', 'disabled', 'inoDragAndDrop', 'inoDragAndDropSecondaryText', 'inoDragAndDropText', 'inoLabel', 'multiple', 'name', 'required']
 })
 @Component({
   selector: 'ino-input-file',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
-  inputs: ['accept', 'autoFocus', 'disabled', 'inoLabel', 'multiple', 'name', 'required'],
+  inputs: ['accept', 'autoFocus', 'disabled', 'inoDragAndDrop', 'inoDragAndDropSecondaryText', 'inoDragAndDropText', 'inoLabel', 'multiple', 'name', 'required'],
   outputs: ['changeFile']
 })
 export class InoInputFile {

--- a/packages/elements/src/components.d.ts
+++ b/packages/elements/src/components.d.ts
@@ -2215,7 +2215,7 @@ declare namespace LocalJSX {
          */
         "onChangeFile"?: (event: CustomEvent<{
     e: any;
-    files: object[];
+    files: File[];
   }>) => void;
         /**
           * Marks this element as required.

--- a/packages/elements/src/components.d.ts
+++ b/packages/elements/src/components.d.ts
@@ -644,6 +644,18 @@ export namespace Components {
          */
         "disabled"?: boolean;
         /**
+          * Enables drag-and-drop file input
+         */
+        "inoDragAndDrop"?: boolean;
+        /**
+          * Sets the secondary text of the drag and drop window
+         */
+        "inoDragAndDropSecondaryText"?: string;
+        /**
+          * Sets the primary text of the drag and drop window
+         */
+        "inoDragAndDropText"?: string;
+        /**
           * Sets the label of the select files button.
          */
         "inoLabel"?: string;
@@ -2174,6 +2186,18 @@ declare namespace LocalJSX {
           * Disables this element.
          */
         "disabled"?: boolean;
+        /**
+          * Enables drag-and-drop file input
+         */
+        "inoDragAndDrop"?: boolean;
+        /**
+          * Sets the secondary text of the drag and drop window
+         */
+        "inoDragAndDropSecondaryText"?: string;
+        /**
+          * Sets the primary text of the drag and drop window
+         */
+        "inoDragAndDropText"?: string;
         /**
           * Sets the label of the select files button.
          */

--- a/packages/elements/src/components/ino-input-file/ino-input-file.scss
+++ b/packages/elements/src/components/ino-input-file/ino-input-file.scss
@@ -1,7 +1,56 @@
+@use "../styles/colors";
+@use "../styles/fonts";
+
+ino-input-file {
+  /**
+   * @prop --ino-input-file-box-height: Height of the drag and drop window
+   * @prop --ino-input-file-box-width: Width of the drag and drop window
+   */
+  --input-file-box-height: var(--ino-input-file-box-height, 300px);
+  --input-file-box-width: var(--ino-input-file-box-width, 100%);
+}
+
 ino-input-file {
   .ino-input-file__native-element {
     visibility: hidden;
     height: 0;
     width: 0;
+  }
+
+  .ino-input-file__dnd {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    background-color: white;
+    border: 2px dashed colors.ino-color(primary);
+    border-radius: 20px;
+    height: var(--input-file-box-height);
+    width: var(--input-file-box-width);
+
+    .ino-input-file__dnd-text {
+      display: flex;
+      flex-direction: column;
+      justify-content: space-evenly;
+      align-items: center;
+      margin-bottom: 15px;
+
+      label {
+        color: colors.ino-color(primary);
+        @include fonts.ino-font($size: l);
+      }
+    }
+
+    &.ino-input-file__dnd-dragover:not(.ino-input-file__dnd-disabled) {
+      background-color: lighten(colors.ino-color(primary), 38%);
+    }
+
+    &.ino-input-file__dnd-disabled {
+      background-color: colors.ino-color(light, light);
+      border: 2px solid colors.ino-color(light, light);
+      label {
+        color: colors.ino-color(dark)
+      }
+    }
   }
 }

--- a/packages/elements/src/components/ino-input-file/ino-input-file.tsx
+++ b/packages/elements/src/components/ino-input-file/ino-input-file.tsx
@@ -67,7 +67,6 @@ export class InputFile implements ComponentInterface {
   }>;
 
   componentDidLoad(): void {
-    // TODO: check if browser supports dragAndDrop
     this.configureDragAndDrop();
   }
 

--- a/packages/elements/src/components/ino-input-file/readme.md
+++ b/packages/elements/src/components/ino-input-file/readme.md
@@ -76,15 +76,18 @@ class MyComponent extends Component {
 
 ## Properties
 
-| Property    | Attribute   | Description                                              | Type      | Default         |
-| ----------- | ----------- | -------------------------------------------------------- | --------- | --------------- |
-| `accept`    | `accept`    | The types of files accepted by the server.               | `string`  | `undefined`     |
-| `autoFocus` | `autofocus` | The autofocus of this element.                           | `boolean` | `undefined`     |
-| `disabled`  | `disabled`  | Disables this element.                                   | `boolean` | `undefined`     |
-| `inoLabel`  | `ino-label` | Sets the label of the select files button.               | `string`  | `'Select file'` |
-| `multiple`  | `multiple`  | Indicates whether the user can enter one or more values. | `boolean` | `undefined`     |
-| `name`      | `name`      | The name of this input field.                            | `string`  | `undefined`     |
-| `required`  | `required`  | Marks this element as required.                          | `boolean` | `undefined`     |
+| Property                      | Attribute                          | Description                                              | Type      | Default                  |
+| ----------------------------- | ---------------------------------- | -------------------------------------------------------- | --------- | ------------------------ |
+| `accept`                      | `accept`                           | The types of files accepted by the server.               | `string`  | `undefined`              |
+| `autoFocus`                   | `autofocus`                        | The autofocus of this element.                           | `boolean` | `undefined`              |
+| `disabled`                    | `disabled`                         | Disables this element.                                   | `boolean` | `undefined`              |
+| `inoDragAndDrop`              | `ino-drag-and-drop`                | Enables drag-and-drop file input                         | `boolean` | `false`                  |
+| `inoDragAndDropSecondaryText` | `ino-drag-and-drop-secondary-text` | Sets the secondary text of the drag and drop window      | `string`  | `'or'`                   |
+| `inoDragAndDropText`          | `ino-drag-and-drop-text`           | Sets the primary text of the drag and drop window        | `string`  | `'Drag your files here'` |
+| `inoLabel`                    | `ino-label`                        | Sets the label of the select files button.               | `string`  | `'Select file'`          |
+| `multiple`                    | `multiple`                         | Indicates whether the user can enter one or more values. | `boolean` | `undefined`              |
+| `name`                        | `name`                             | The name of this input field.                            | `string`  | `undefined`              |
+| `required`                    | `required`                         | Marks this element as required.                          | `boolean` | `undefined`              |
 
 
 ## Events
@@ -92,6 +95,14 @@ class MyComponent extends Component {
 | Event        | Description                   | Type                                        |
 | ------------ | ----------------------------- | ------------------------------------------- |
 | `changeFile` | Emits when the value changes. | `CustomEvent<{ e: any; files: object[]; }>` |
+
+
+## CSS Custom Properties
+
+| Name                          | Description                        |
+| ----------------------------- | ---------------------------------- |
+| `--ino-input-file-box-height` | Height of the drag and drop window |
+| `--ino-input-file-box-width`  | Width of the drag and drop window  |
 
 
 ## Dependencies

--- a/packages/elements/src/components/ino-input-file/readme.md
+++ b/packages/elements/src/components/ino-input-file/readme.md
@@ -97,14 +97,6 @@ class MyComponent extends Component {
 | `changeFile` | Emits when the value changes. | `CustomEvent<{ e: any; files: object[]; }>` |
 
 
-## CSS Custom Properties
-
-| Name                          | Description                        |
-| ----------------------------- | ---------------------------------- |
-| `--ino-input-file-box-height` | Height of the drag and drop window |
-| `--ino-input-file-box-width`  | Width of the drag and drop window  |
-
-
 ## Dependencies
 
 ### Depends on

--- a/packages/elements/src/components/ino-input-file/readme.md
+++ b/packages/elements/src/components/ino-input-file/readme.md
@@ -92,9 +92,17 @@ class MyComponent extends Component {
 
 ## Events
 
-| Event        | Description                   | Type                                        |
-| ------------ | ----------------------------- | ------------------------------------------- |
-| `changeFile` | Emits when the value changes. | `CustomEvent<{ e: any; files: object[]; }>` |
+| Event        | Description                   | Type                                      |
+| ------------ | ----------------------------- | ----------------------------------------- |
+| `changeFile` | Emits when the value changes. | `CustomEvent<{ e: any; files: File[]; }>` |
+
+
+## CSS Custom Properties
+
+| Name                          | Description                        |
+| ----------------------------- | ---------------------------------- |
+| `--ino-input-file-box-height` | Height of the drag and drop window |
+| `--ino-input-file-box-width`  | Width of the drag and drop window  |
 
 
 ## Dependencies

--- a/packages/storybook/src/stories/ino-input-file/ino-input-file.scss
+++ b/packages/storybook/src/stories/ino-input-file/ino-input-file.scss
@@ -1,6 +1,6 @@
 .story-input {
   .customizable-input {
-    margin-bottom: 32px;
+    margin-bottom: 50px;
   }
 
   h4.outline {

--- a/packages/storybook/src/stories/ino-input-file/ino-input-file.stories.js
+++ b/packages/storybook/src/stories/ino-input-file/ino-input-file.stories.js
@@ -8,7 +8,7 @@ import './ino-input-file.scss';
 // https://github.com/storybooks/storybook/issues/4337#issuecomment-428495664
 function subscribeToComponentEvents() {
   // == event block
-  const eventHandler = function (e) {
+  const eventHandler = function(e) {
     const el = e.target;
     if (el.tagName.toLowerCase() !== 'ino-input-file') {
       return;
@@ -41,20 +41,47 @@ export default {
     (story) => {
       subscribeToComponentEvents();
       return story();
-    },
-  ],
+    }
+  ]
 };
 
 export const DefaultUsage = () => /*html*/ `
 <div class="story-input customizable-input">
+  <style>
+    ino-input-file.customizable-input {
+      --ino-input-file-box-height: ${text(
+  '--ino-input-file-box-height',
+  '300px',
+  'Custom Properties'
+      )};
+      --ino-input-file-box-width: ${text(
+  '--ino-input-file-box-width',
+  '100%',
+  'Custom Properties'
+      )};
+    }
+  </style>
+  <h4>Customizable Input</h4>
   <ino-input-file
+    class="customizable-input"
     accept="${text('accept', '')}"
     autofocus="${boolean('autofocus', false)}"
     disabled="${boolean('disabled', false)}"
     multiple="${boolean('multiple', false)}"
     required="${boolean('required', false)}"
     ino-label="${text('ino-label', 'Select a file to upload')}"
-    ino-label-selected="${text('ino-label-selected', 'ausgewählt')}">
+    ino-label-selected="${text('ino-label-selected', 'ausgewählt')}"
+    ino-drag-and-drop="${boolean('ino-drag-and-drop', false)}"
+    ino-drag-and-drop-text="${text('ino-drag-and-drop-text', 'Drag your files here')}"
+    ino-drag-and-drop-secondary-text="${text('ino-drag-and-drop-secondary-text', 'or')}"
+    >
   </ino-input-file>
+</div>
+<div class="story-input customizable-input">
+    <h4>Drag and Drop Window</h4>
+    <ino-input-file
+        multiple
+        ino-drag-and-drop
+    ></ino-input-file>
 </div>
 `;


### PR DESCRIPTION
✨ **Features:**
* Added the ability to upload files using a drag and drop window to the `ino-input-file` component

ℹ️ **FYI:**
* There's currently a bug that will result in the event emitter used by the `ino-input-file` component to emit multiple events at once upon setting the action knobs in Storybook to a different value. This bug is also present in other components, such as the `ino-snackbar`(see #81). 

🎟️ **Closes #76**