### PR TITLE
fix(elements|ino-card): render slots only when used

### DIFF
--- a/packages/elements/src/components/ino-card/ino-card.tsx
+++ b/packages/elements/src/components/ino-card/ino-card.tsx
@@ -1,4 +1,4 @@
-import { Component, ComponentInterface, Element, Host, Prop, h } from '@stencil/core';
+import { Component, ComponentInterface, Element, h, Host, Prop } from '@stencil/core';
 import classnames from 'classnames';
 
 @Component({
@@ -27,6 +27,10 @@ export class Card implements ComponentInterface {
       'ino-card--selected': this.inoSelected
     });
 
+    const hasHeader = Boolean(this.el.querySelector('[slot="header"]'));
+    const hasContent = Boolean(this.el.querySelector('[slot="content"]'));
+    const hasFooter = Boolean(this.el.querySelector('[slot="footer"]'));
+
     return (
       <Host>
         <div class={classList}>
@@ -37,15 +41,21 @@ export class Card implements ComponentInterface {
               </div>
             )}
           </div>
-          <div class="ino-card__header">
-            <slot name="header"/>
-          </div>
-          <div class="ino-card__content">
-            <slot name="content"/>
-          </div>
-          <div class="ino-card__footer">
-            <slot name="footer"/>
-          </div>
+          {hasHeader && (
+            <div class="ino-card__header">
+              <slot name="header"/>
+            </div>
+          )}
+          {hasContent && (
+            <div class="ino-card__content">
+              <slot name="content"/>
+            </div>
+          )}
+          {hasFooter && (
+            <div class="ino-card__footer">
+              <slot name="footer"/>
+            </div>
+          )}
         </div>
       </Host>
     );

--- a/packages/storybook/src/stories/ino-card/ino-card.stories.js
+++ b/packages/storybook/src/stories/ino-card/ino-card.stories.js
@@ -1,4 +1,4 @@
-import { boolean, select } from '@storybook/addon-knobs';
+import { boolean } from '@storybook/addon-knobs';
 
 import componentReadme from '_local-elements/src/components/ino-card/readme.md';
 import withStencilReadme from '_local-storybookcore/with-stencil-readme';


### PR DESCRIPTION
Closes #206 

## Proposed Changes

- The slots and its containers will only be rendered if there are elements inside the slot