### PR TITLE
refactor(elements|ino-input): cleanup styles

### DIFF
--- a/packages/elements/src/components/ino-input/ino-input.scss
+++ b/packages/elements/src/components/ino-input/ino-input.scss
@@ -42,7 +42,7 @@ $icon-padding-to-border: 6px;
   }
 
   /* Firefox */
-  input[type=number] {
+  input[type='number'] {
     -moz-appearance: textfield;
   }
 }
@@ -71,7 +71,6 @@ ino-input {
     box-sizing: initial;
   }
 
-
   & > .ino-input__composer {
     text-align: left;
     width: 100%;
@@ -91,7 +90,7 @@ ino-input {
   }
 
   .mdc-text-field--invalid {
-    @include setIconColors(colors.ino-color(error))
+    @include setIconColors(theme.color(error));
   }
 
   .mdc-text-field__affix.mdc-text-field__affix--suffix {
@@ -106,7 +105,7 @@ ino-input .mdc-text-field--filled {
   @include textfield.line-ripple-color(var(--input-line-color));
 
   &.mdc-text-field--invalid {
-    @include textfield.line-ripple-color(colors.ino-color(error));
+    @include textfield.line-ripple-color(theme.color(error));
   }
 
   &:not([class*='--with-leading-icon']) {
@@ -142,8 +141,8 @@ ino-input .mdc-text-field--filled {
   }
 
   @include setIconMargins(
-        (0 $icon-padding-to-text 0 $icon-padding-to-border),
-        (0 $icon-padding-to-border 0 $icon-padding-to-text)
+    (0 $icon-padding-to-text 0 $icon-padding-to-border),
+    (0 $icon-padding-to-border 0 $icon-padding-to-text)
   );
 }
 
@@ -152,10 +151,11 @@ ino-input .mdc-text-field--outlined {
   @include textfield.focused-outline-color(var(--input-line-color));
 
   &.mdc-text-field--invalid {
-    @include textfield.focused-outline-color(colors.ino-color(error));
+    @include textfield.focused-outline-color(theme.color(error));
   }
 
-  &[class*='--with-leading-icon'] .mdc-floating-label:not(.mdc-floating-label--float-above) {
+  &[class*='--with-leading-icon']
+    .mdc-floating-label:not(.mdc-floating-label--float-above) {
     left: 24px;
   }
 
@@ -164,9 +164,7 @@ ino-input .mdc-text-field--outlined {
     width: 16px;
   }
 
-  @include setIconMargins(
-        (0 $icon-padding-to-text 0 $icon-padding-to-text)
-  );
+  @include setIconMargins((0 $icon-padding-to-text 0 $icon-padding-to-text));
 }
 
 ino-input {
@@ -177,7 +175,6 @@ ino-input {
 
 // Custom number arrows
 ino-input[type='number'] {
-
   @include hideNativeNumberInputArrows();
 
   .arrow-container {

--- a/packages/elements/src/components/ino-input/ino-input.scss
+++ b/packages/elements/src/components/ino-input/ino-input.scss
@@ -65,7 +65,6 @@ ino-input {
   @include typography.font(sans-serif, m, regular);
   @include textfield.label-color(var(--input-label-color));
   @include textfield.caret-color(var(--input-caret-color));
-  @include textfield.placeholder-color($placeholder-color);
 
   & * {
     box-sizing: initial;
@@ -91,6 +90,10 @@ ino-input {
 
   .mdc-text-field--invalid {
     @include setIconColors(theme.color(error));
+  }
+
+  :not(.mdc-text-field--disabled) {
+    @include textfield.placeholder-color($placeholder-color);
   }
 
   .mdc-text-field__affix.mdc-text-field__affix--suffix {

--- a/packages/elements/src/components/ino-input/ino-input.scss
+++ b/packages/elements/src/components/ino-input/ino-input.scss
@@ -18,7 +18,7 @@ $icon-padding-to-border: 6px;
 @mixin setIconColors($color) {
   .mdc-text-field__icon {
     ino-icon {
-      --icon-color: $color;
+      --icon-color: #{$color};
     }
   }
 }
@@ -153,6 +153,10 @@ ino-input .mdc-text-field--outlined {
 
   &.mdc-text-field--invalid {
     @include textfield.focused-outline-color(colors.ino-color(error));
+  }
+
+  &[class*='--with-leading-icon'] .mdc-floating-label:not(.mdc-floating-label--float-above) {
+    left: 24px;
   }
 
   .mdc-text-field__icon {

--- a/packages/elements/src/components/ino-input/ino-input.scss
+++ b/packages/elements/src/components/ino-input/ino-input.scss
@@ -63,7 +63,6 @@ ino-input {
   display: block;
   @include icon.icon-core-styles;
   @include typography.font(sans-serif, m, regular);
-  @include textfield.label-color(var(--input-label-color));
   @include textfield.caret-color(var(--input-caret-color));
 
   & * {
@@ -85,10 +84,12 @@ ino-input {
 
   @include setIconColors($placeholder-color);
 
+  @include textfield.label-color(var(--input-label-color));
   .mdc-text-field--focused {
     @include setIconColors(var(--input-icon-color));
   }
 
+  @include textfield.label-color(theme.color(error));
   .mdc-text-field--invalid {
     @include setIconColors(theme.color(error));
   }

--- a/packages/elements/src/components/ino-input/ino-input.scss
+++ b/packages/elements/src/components/ino-input/ino-input.scss
@@ -76,7 +76,8 @@ ino-input {
     box-sizing: border-box;
   }
 
-  .mdc-text-field__icon {
+  .mdc-text-field__icon,
+  .mdc-text-field__icon:not([tabindex]) {
     cursor: auto;
     pointer-events: auto;
     padding: 0;

--- a/packages/elements/src/components/ino-input/ino-input.scss
+++ b/packages/elements/src/components/ino-input/ino-input.scss
@@ -12,6 +12,19 @@ $default-text-field: 'not(.mdc-text-field--outlined):not(.mdc-text-field--textar
 $placeholder-color: rgba(0, 0, 0, 0.6);
 $padding-top: 24px;
 
+$icon-padding-to-text: 12px;
+$icon-padding-to-border: 6px;
+
+@mixin setIconMargins($margin-leading, $margin-trailing: $margin-leading) {
+  .mdc-text-field__icon.mdc-text-field__icon--leading {
+    margin: $margin-leading;
+  }
+
+  .mdc-text-field__icon.mdc-text-field__icon--trailing {
+    margin: $margin-trailing;
+  }
+}
+
 @mixin hideNativeNumberInputArrows() {
   /* Chrome, Safari, Edge, Opera */
   input::-webkit-outer-spin-button,
@@ -40,12 +53,14 @@ ino-input {
 }
 
 ino-input {
+
   display: block;
   @include icon.icon-core-styles;
 
   & * {
     box-sizing: initial;
   }
+
 
   & > .ino-input__composer {
     text-align: left;
@@ -60,6 +75,7 @@ ino-input {
   }
 
   .mdc-text-field {
+
     @include textfield.focused-outline-color(var(--input-line-color));
 
     ino-icon {
@@ -95,8 +111,35 @@ ino-input {
       }
     }
 
+    .mdc-text-field__icon {
+      cursor: auto;
+      pointer-events: auto;
+      padding: 0;
+    }
+
+    @include setIconMargins(
+          (0 $icon-padding-to-text 0 $icon-padding-to-border),
+          (0 $icon-padding-to-border 0 $icon-padding-to-text)
+    );
+
+    &.mdc-text-field--outlined {
+
+      .mdc-text-field__icon {
+        height: 16px;
+        width: 16px;
+      }
+
+      @include setIconMargins(
+            (0 $icon-padding-to-text 0 $icon-padding-to-text)
+      );
+    }
+
     &:#{$default-text-field} {
       @include textfield.fill-color(transparent);
+
+      .mdc-text-field__icon {
+        padding: $padding-top 0 0 0;
+      }
 
       // change background von greyish to transparent
       &:before {
@@ -114,21 +157,6 @@ ino-input {
         .mdc-floating-label,
         .mdc-floating-label--float-above {
           left: $padding-to-left;
-        }
-      }
-
-      .mdc-text-field__icon {
-        cursor: auto;
-        pointer-events: auto;
-        padding-top: 12px;
-
-        &--leading {
-          margin-left: 6px;
-          margin-right: 12px;
-        }
-
-        &--trailing {
-          margin-right: 6px;
         }
       }
 
@@ -153,8 +181,10 @@ ino-input {
     }
   }
 
+
   // Custom number arrows
   &[type='number'] {
+
     @include hideNativeNumberInputArrows();
 
     .arrow-container {
@@ -173,13 +203,6 @@ ino-input {
         &.up {
           transform: scaleY(-1);
         }
-      }
-    }
-
-    .mdc-text-field:#{$default-text-field},
-    .mdc-text-field.mdc-text-field--outlined {
-      .mdc-text-field__icon.mdc-text-field__icon--trailing {
-        right: 25px;
       }
     }
   }

--- a/packages/elements/src/components/ino-input/ino-input.scss
+++ b/packages/elements/src/components/ino-input/ino-input.scss
@@ -15,6 +15,14 @@ $padding-top: 24px;
 $icon-padding-to-text: 12px;
 $icon-padding-to-border: 6px;
 
+@mixin setIconColors($color) {
+  .mdc-text-field__icon {
+    ino-icon {
+      --icon-color: $color;
+    }
+  }
+}
+
 @mixin setIconMargins($margin-leading, $margin-trailing: $margin-leading) {
   .mdc-text-field__icon.mdc-text-field__icon--leading {
     margin: $margin-leading;
@@ -34,11 +42,12 @@ $icon-padding-to-border: 6px;
   }
 
   /* Firefox */
-  input[type='number'] {
+  input[type=number] {
     -moz-appearance: textfield;
   }
 }
 
+/* Shared Styles */
 ino-input {
   /**
    * @prop --ino-input-caret-color: color of the caret
@@ -50,12 +59,13 @@ ino-input {
   --input-label-color: var(--ino-input-label-color, #{theme.color(primary)});
   --input-line-color: var(--ino-input-line-color, #{theme.color(primary)});
   --input-icon-color: var(--ino-input-icon-color, #{theme.color(primary)});
-}
-
-ino-input {
 
   display: block;
   @include icon.icon-core-styles;
+  @include typography.font(sans-serif, m, regular);
+  @include textfield.label-color(var(--input-label-color));
+  @include textfield.caret-color(var(--input-caret-color));
+  @include textfield.placeholder-color($placeholder-color);
 
   & * {
     box-sizing: initial;
@@ -68,141 +78,121 @@ ino-input {
     box-sizing: border-box;
   }
 
-  @include typography.font(sans-serif, m, regular);
-
-  &:hover {
-    @include textfield.fill-color(transparent);
+  .mdc-text-field__icon {
+    cursor: auto;
+    pointer-events: auto;
+    padding: 0;
   }
 
-  .mdc-text-field {
+  @include setIconColors($placeholder-color);
 
-    @include textfield.focused-outline-color(var(--input-line-color));
+  .mdc-text-field--focused {
+    @include setIconColors(var(--input-icon-color));
+  }
+
+  .mdc-text-field--invalid {
+    @include setIconColors(colors.ino-color(error))
+  }
+
+  .mdc-text-field__affix.mdc-text-field__affix--suffix {
+    margin-right: 12px;
+  }
+}
+
+// Filled textfield specific
+ino-input .mdc-text-field--filled {
+  @include textfield.fill-color(transparent);
+  @include textfield.disabled-fill-color(transparent);
+  @include textfield.line-ripple-color(var(--input-line-color));
+
+  &.mdc-text-field--invalid {
+    @include textfield.line-ripple-color(colors.ino-color(error));
+  }
+
+  &:not([class*='--with-leading-icon']) {
+    padding-left: 0;
+    padding-right: 0;
+  }
+
+  &[class*='--with-leading-icon'] {
+    $padding-to-left: 32px;
+
+    .mdc-floating-label,
+    .mdc-floating-label--float-above {
+      left: $padding-to-left;
+    }
+  }
+
+  .mdc-text-field__input {
+    padding-bottom: 0;
+    padding-top: $padding-top;
+  }
+
+  &.mdc-text-field--no-label .mdc-text-field__input {
+    padding-top: 10px;
+  }
+
+  .mdc-text-field__icon {
+    padding: $padding-top 0 0 0;
 
     ino-icon {
-      --icon-color: #{$placeholder-color};
-    }
-
-    &--focused:not(.mdc-text-field--invalid) {
-      @include textfield.label-color(var(--input-label-color));
-      @include textfield.caret-color(var(--input-caret-color));
-      @include textfield.line-ripple-color(var(--input-line-color));
-
-      ino-icon {
-        --icon-color: var(--input-icon-color);
-      }
-    }
-
-    &--invalid ino-icon {
-      --icon-color: var(--mdc-theme-error, #b00020);
-    }
-
-    &--disabled {
-      background-color: transparent !important;
-    }
-
-    & + .mdc-text-field-helper-line {
-      padding: 0;
-    }
-
-    // Placeholder color
-    &:not(.mdc-text-field--disabled) {
-      & input::placeholder {
-        color: $placeholder-color;
-      }
-    }
-
-    .mdc-text-field__icon {
-      cursor: auto;
-      pointer-events: auto;
-      padding: 0;
-    }
-
-    @include setIconMargins(
-          (0 $icon-padding-to-text 0 $icon-padding-to-border),
-          (0 $icon-padding-to-border 0 $icon-padding-to-text)
-    );
-
-    &.mdc-text-field--outlined {
-
-      .mdc-text-field__icon {
-        height: 16px;
-        width: 16px;
-      }
-
-      @include setIconMargins(
-            (0 $icon-padding-to-text 0 $icon-padding-to-text)
-      );
-    }
-
-    &:#{$default-text-field} {
-      @include textfield.fill-color(transparent);
-
-      .mdc-text-field__icon {
-        padding: $padding-top 0 0 0;
-      }
-
-      // change background von greyish to transparent
-      &:before {
-        background-color: transparent;
-      }
-
-      &:not([class*='--with-leading-icon']) {
-        padding-left: 0;
-        padding-right: 0;
-      }
-
-      &[class*='--with-leading-icon'] {
-        $padding-to-left: 32px;
-
-        .mdc-floating-label,
-        .mdc-floating-label--float-above {
-          left: $padding-to-left;
-        }
-      }
-
-      .mdc-text-field__input {
-        padding-bottom: 0;
-        padding-top: $padding-top;
-      }
-      &.mdc-text-field--no-label .mdc-text-field__input {
-        padding-top: 12px;
-      }
-    }
-
-    .mdc-text-field__icon {
-      ino-icon {
-        --icon-height: 1em;
-        --icon-width: 1em;
-      }
-    }
-
-    .mdc-text-field__affix.mdc-text-field__affix--suffix {
-      margin-right: 12px;
+      --icon-height: 1em;
+      --icon-width: 1em;
     }
   }
 
+  @include setIconMargins(
+        (0 $icon-padding-to-text 0 $icon-padding-to-border),
+        (0 $icon-padding-to-border 0 $icon-padding-to-text)
+  );
+}
 
-  // Custom number arrows
-  &[type='number'] {
+// Outlined textfield specific
+ino-input .mdc-text-field--outlined {
+  @include textfield.focused-outline-color(var(--input-line-color));
 
-    @include hideNativeNumberInputArrows();
+  &.mdc-text-field--invalid {
+    @include textfield.focused-outline-color(colors.ino-color(error));
+  }
 
-    .arrow-container {
-      position: relative;
-      display: flex;
-      flex-direction: column;
-      right: 5px;
-      top: -15%;
-      height: 50%;
+  .mdc-text-field__icon {
+    height: 16px;
+    width: 16px;
+  }
 
-      .ino-num-arrows {
-        --ino-icon-height: 5px;
-        padding: 2px 0;
-        cursor: pointer;
+  @include setIconMargins(
+        (0 $icon-padding-to-text 0 $icon-padding-to-text)
+  );
+}
 
-        &.up {
-          transform: scaleY(-1);
-        }
+ino-input {
+  .mdc-text-field + .mdc-text-field-helper-line {
+    padding-left: 0;
+  }
+}
+
+// Custom number arrows
+ino-input[type='number'] {
+
+  @include hideNativeNumberInputArrows();
+
+  .arrow-container {
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    right: 5px;
+    top: -15%;
+    height: 50%;
+
+    .ino-num-arrows {
+      --ino-icon-height: 5px;
+      --icon-color: #{$placeholder-color};
+
+      padding: 2px 0;
+      cursor: pointer;
+
+      &.up {
+        transform: scaleY(-1);
       }
     }
   }

--- a/packages/storybook/src/stories/ino-input/ino-input.stories.js
+++ b/packages/storybook/src/stories/ino-input/ino-input.stories.js
@@ -65,8 +65,6 @@ export const DefaultUsage = () => /*html*/ `
     disabled="${boolean('disabled', false, 'STANDARD')}"
     required="${boolean('required', false, 'STANDARD')}"
     ino-show-label-hint="${boolean('ino-show-label-hint', false, 'STANDARD')}"
-
-    pattern="${text('pattern', '', 'STANDARD')}"
     ino-error="${boolean('ino-error', false, 'STANDARD')}"
     ino-helper="${text('ino-helper', 'Helper message', 'HELPER TEXT')}"
     ino-helper-persistent="${boolean(


### PR DESCRIPTION
Cleaned up and restructured the `ino-input.scss` in the hope to make it easier to work on. I structured the stylesheet by text-field variants (default, filled, outlined). There also were some new mixins with the new mdc versions which replaced some complicated selectors.