### PR TITLE
feat(elements|ino-chip): add slot for trailing icon

### DIFF
--- a/packages/elements/src/components/ino-chip/ino-chip.scss
+++ b/packages/elements/src/components/ino-chip/ino-chip.scss
@@ -15,6 +15,18 @@ ino-chip {
   .mdc-chip {
     @include chips.fill-color-accessible($default-chip-color);
 
+    .mdc-chip__icon--trailing {
+      width: 20px;
+      height: 20px;
+      font-size: 20px;
+    }
+
+    ino-icon {
+      --icon-width: .75em;
+      --icon-height: .75em;
+      --icon-color: currentColor;
+    }
+
     ino-icon {
       --icon-width: 0.75em;
       --icon-height: 0.75em;

--- a/packages/elements/src/components/ino-chip/ino-chip.scss
+++ b/packages/elements/src/components/ino-chip/ino-chip.scss
@@ -22,12 +22,6 @@ ino-chip {
     }
 
     ino-icon {
-      --icon-width: .75em;
-      --icon-height: .75em;
-      --icon-color: currentColor;
-    }
-
-    ino-icon {
       --icon-width: 0.75em;
       --icon-height: 0.75em;
       --icon-color: currentColor;

--- a/packages/elements/src/components/ino-chip/ino-chip.tsx
+++ b/packages/elements/src/components/ino-chip/ino-chip.tsx
@@ -147,7 +147,7 @@ export class Chip implements ComponentInterface {
           <span class="mdc-chip__text">{this.inoLabel}</span>
 
           {this.inoIconTrailing && (
-            <span class="mdc-chip__icon mdc-chip__icon--trailing">
+            <span class="mdc-chip__icon ">
               <slot name="ino-icon-trailing"/>
             </span>
           )}

--- a/packages/elements/src/components/ino-chip/ino-chip.tsx
+++ b/packages/elements/src/components/ino-chip/ino-chip.tsx
@@ -45,7 +45,10 @@ export class Chip implements ComponentInterface {
   @Prop() inoIcon?: string;
 
   /**
-   * If enabled, appends the slotted icon to the chip label
+   * If enabled, appends the slotted icon to the chip label.
+   *
+   * Please be aware that enabling this property will disable the inoRemovable
+   * property.
    */
   @Prop() inoIconTrailing = false;
 

--- a/packages/elements/src/components/ino-chip/ino-chip.tsx
+++ b/packages/elements/src/components/ino-chip/ino-chip.tsx
@@ -45,6 +45,11 @@ export class Chip implements ComponentInterface {
   @Prop() inoIcon?: string;
 
   /**
+   * If enabled, appends the slotted icon to the chip label
+   */
+  @Prop() inoIconTrailing = false;
+
+  /**
    * The label of this chip (**required**).
    */
   @Prop() inoLabel?: string;
@@ -102,7 +107,8 @@ export class Chip implements ComponentInterface {
     const iconClasses = classNames({
       'mdc-chip__icon': true,
       'mdc-chip__icon--leading': true,
-      'mdc-chip__icon--leading-hidden': this.inoSelected && this.inoSelectable,
+      'mdc-chip__icon--trailing': this.inoIconTrailing,
+      'mdc-chip__icon--leading-hidden': this.inoSelected && this.inoSelectable
     });
 
     const leadingSlotHasContent = hasSlotContent(this.el, 'ino-icon-leading');
@@ -137,7 +143,13 @@ export class Chip implements ComponentInterface {
 
           <span class="mdc-chip__text">{this.inoLabel}</span>
 
-          {this.inoRemovable && (
+          {this.inoIconTrailing && (
+            <span class="mdc-chip__icon mdc-chip__icon--trailing">
+              <slot name="ino-icon-trailing"/>
+            </span>
+          )}
+
+          {this.inoRemovable && !this.inoIconTrailing && (
             <ino-icon
               class="mdc-chip__icon mdc-chip__icon--trailing"
               ino-icon="close"

--- a/packages/elements/src/components/ino-chip/ino-chip.tsx
+++ b/packages/elements/src/components/ino-chip/ino-chip.tsx
@@ -15,6 +15,7 @@ import { ChipSurface, ColorScheme } from '../types';
 
 /**
  * @slot ino-icon-leading - For the icon to be prepended
+ * @slot ino-icon-trailing - For the icon to be appended - disables the inoRemovable property
  */
 @Component({
   tag: 'ino-chip',
@@ -43,14 +44,6 @@ export class Chip implements ComponentInterface {
    * @deprecated This property is deprecated and will be removed with the next major release. Instead, use the ino-icon-leading slot.
    */
   @Prop() inoIcon?: string;
-
-  /**
-   * If enabled, appends the slotted icon to the chip label.
-   *
-   * Please be aware that enabling this property will disable the inoRemovable
-   * property.
-   */
-  @Prop() inoIconTrailing = false;
 
   /**
    * The label of this chip (**required**).
@@ -107,14 +100,19 @@ export class Chip implements ComponentInterface {
       'mdc-chip--selected': this.inoSelected,
     });
 
-    const iconClasses = classNames({
+    const leadingIconClasses = classNames({
       'mdc-chip__icon': true,
       'mdc-chip__icon--leading': true,
-      'mdc-chip__icon--trailing': this.inoIconTrailing,
       'mdc-chip__icon--leading-hidden': this.inoSelected && this.inoSelectable
     });
 
+    const trailingIconClasses = classNames({
+      'mdc-chip__icon': true,
+      'mdc-chip__icon--trailing': true,
+    });
+
     const leadingSlotHasContent = hasSlotContent(this.el, 'ino-icon-leading');
+    const trailingSlotHasContent = hasSlotContent(this.el, 'ino-icon-trailing');
 
     return (
       <Host>
@@ -122,11 +120,11 @@ export class Chip implements ComponentInterface {
           <div class="mdc-chip__ripple"></div>
 
           {this.inoIcon && (
-            <ino-icon class={iconClasses} ino-icon={this.inoIcon} />
+            <ino-icon class={leadingIconClasses} ino-icon={this.inoIcon} />
           )}
 
           {leadingSlotHasContent && !this.inoIcon && (
-            <span class={iconClasses}>
+            <span class={leadingIconClasses}>
               <slot name="ino-icon-leading" />
             </span>
           )}
@@ -146,15 +144,15 @@ export class Chip implements ComponentInterface {
 
           <span class="mdc-chip__text">{this.inoLabel}</span>
 
-          {this.inoIconTrailing && (
-            <span class="mdc-chip__icon ">
+          {trailingSlotHasContent && (
+            <span class={trailingIconClasses}>
               <slot name="ino-icon-trailing"/>
             </span>
           )}
 
-          {this.inoRemovable && !this.inoIconTrailing && (
+          {this.inoRemovable && !trailingSlotHasContent && (
             <ino-icon
-              class="mdc-chip__icon mdc-chip__icon--trailing"
+              class={trailingIconClasses}
               ino-icon="close"
               tabindex="0"
               role="button"

--- a/packages/elements/src/components/ino-chip/readme.md
+++ b/packages/elements/src/components/ino-chip/readme.md
@@ -142,9 +142,10 @@ However, the component will not be hidden or destroyed but instead emits a `remo
 
 ## Slots
 
-| Slot                 | Description                  |
-| -------------------- | ---------------------------- |
-| `"ino-icon-leading"` | For the icon to be prepended |
+| Slot                  | Description                                                      |
+| --------------------- | ---------------------------------------------------------------- |
+| `"ino-icon-leading"`  | For the icon to be prepended                                     |
+| `"ino-icon-trailing"` | For the icon to be appended - disables the inoRemovable property |
 
 
 ## Dependencies

--- a/packages/storybook/src/stories/ino-chip-set/ino-chip-set.stories.js
+++ b/packages/storybook/src/stories/ino-chip-set/ino-chip-set.stories.js
@@ -107,7 +107,7 @@ export const InoChip = () => /*html*/ `
     <ino-chip ino-color-scheme="secondary" ino-label="Trailing">
       <ino-icon slot="ino-icon-trailing" ino-icon="checkmark"></ino-icon>
     </ino-chip>
-    <ino-chip ino-color-scheme="error" ino-icon-leading ino-icon-trailing ino-label="Leading & Trailing">
+    <ino-chip ino-color-scheme="error" ino-label="Leading & Trailing">
         <ino-icon slot="ino-icon-leading" ino-icon="warning"></ino-icon>
         <ino-icon slot="ino-icon-trailing" ino-icon="warning"></ino-icon>
     </ino-chip>

--- a/packages/storybook/src/stories/ino-chip-set/ino-chip-set.stories.js
+++ b/packages/storybook/src/stories/ino-chip-set/ino-chip-set.stories.js
@@ -101,11 +101,15 @@ export const InoChip = () => /*html*/ `
 
   <h4>With icons</h4>
   <ino-chip-set>
-    <ino-chip ino-color-scheme="primary" ino-label="Info" ino-fill="outline">
+    <ino-chip ino-color-scheme="primary" ino-label="Leading" ino-fill="outline">
       <ino-icon slot="ino-icon-leading" ino-icon="info"></ino-icon>
     </ino-chip>
-    <ino-chip ino-color-scheme="error" ino-label="Error">
-      <ino-icon slot="ino-icon-leading" ino-icon="warning"></ino-icon>
+    <ino-chip ino-color-scheme="secondary" ino-label="Trailing">
+      <ino-icon slot="ino-icon-trailing" ino-icon="checkmark"></ino-icon>
+    </ino-chip>
+    <ino-chip ino-color-scheme="error" ino-icon-leading ino-icon-trailing ino-label="Leading & Trailing">
+        <ino-icon slot="ino-icon-leading" ino-icon="warning"></ino-icon>
+        <ino-icon slot="ino-icon-trailing" ino-icon="warning"></ino-icon>
     </ino-chip>
   </ino-chip-set>
 


### PR DESCRIPTION
✨ **Features:**
* Added `ino-icon-leading` slot to the `ino-chip` component

🎟️ **Closes #204**