### PR TITLE
fix(elements|ino-datepicker): use date format to improve validation

### DIFF
--- a/packages/elements/src/components/ino-datepicker/ino-datepicker.e2e.ts
+++ b/packages/elements/src/components/ino-datepicker/ino-datepicker.e2e.ts
@@ -158,12 +158,12 @@ describe('InoDatepicker', () => {
       const inoDatepickerEl = await page.find(DATEPICKER);
       const buttonEl = await page.find('button');
       const flatpickrInputEl = await page.find('.flatpickr-input');
-    
+
       inoDatepickerEl.setAttribute('required', true);
       await page.waitForChanges();
 
       expect(flatpickrInputEl).not.toHaveClass('mdc-text-field--invalid');
-      
+
       inoDatepickerEl.click();
       await page.waitForChanges();
       buttonEl.click();
@@ -181,10 +181,10 @@ describe('InoDatepicker', () => {
 
       await input.type('1');
       await page.waitForChanges();
-      
+
       expect(valueChangeEvent).toHaveReceivedEvent();
     });
-    
+
     it('should not emit a valueChange event if datepicker is disabled', async () => {
       let page = await setupPageWithContent(INO_DATEPICKER);
       const datepicker = await page.find(DATEPICKER);
@@ -218,29 +218,30 @@ describe('InoDatepicker', () => {
       expect(flatpickrCalEl).not.toHaveClass('hasTime');
       expect(flatpickrCalEl).not.toHaveClass('noCalendar');
     })
+  })
 
-    it('should set invalid state', async () => {
+  describe('Validation', () => {
+    it('should be invalid if wrong date format provided', async () => {
       const page = await setupPageWithContent(INO_DATEPICKER_WITH_FORMAT);
       const inoDatepickerEl = await page.find(DATEPICKER);
       const flatpickrInputEl = await page.find('.flatpickr-input');
-    
+
       inoDatepickerEl.setAttribute('value','01-1970-01');
       await page.waitForChanges();
 
       expect(flatpickrInputEl).not.toHaveClass('mdc-text-field--invalid');
-      
+
       inoDatepickerEl.setAttribute('value', '01.03.1970');
       await page.waitForChanges();
 
       expect(flatpickrInputEl).toHaveClass('mdc-text-field--invalid');
     });
 
-    it('should set invalid state only if value is set', async () => {
-      const page = await setupPageWithContent(INO_DATEPICKER_WITH_FORMAT);
+    it('should be valid if not required and empty value', async () => {
+      const page = await setupPageWithContent(INO_DATEPICKER);
       const inoDatepickerEl = await page.find(DATEPICKER);
       const flatpickrInputEl = await page.find('.flatpickr-input');
-    
-      inoDatepickerEl.setAttribute('ino-date-format', 'd-Y-m');
+
       inoDatepickerEl.setAttribute('required',false);
       inoDatepickerEl.setAttribute('value','');
       await page.waitForChanges();
@@ -248,6 +249,44 @@ describe('InoDatepicker', () => {
       expect(flatpickrInputEl).not.toHaveClass('mdc-text-field--invalid');
     });
 
-  
+    it('should be invalid if value is set before min date', async () => {
+      const page = await setupPageWithContent(INO_DATEPICKER);
+      const inoDatepickerEl = await page.find(DATEPICKER);
+      const flatpickrInputEl = await page.find('.flatpickr-input');
+
+      inoDatepickerEl.setAttribute('ino-date-format', 'd-m-Y');
+      inoDatepickerEl.setAttribute('min', '10-10-2020');
+      inoDatepickerEl.setAttribute('value','09-10-2020');
+      await page.waitForChanges();
+
+      expect(flatpickrInputEl).toHaveClass('mdc-text-field--invalid');
+    });
+
+    it('should be invalid if value is set after max date', async () => {
+      const page = await setupPageWithContent(INO_DATEPICKER);
+      const inoDatepickerEl = await page.find(DATEPICKER);
+      const flatpickrInputEl = await page.find('.flatpickr-input');
+
+      inoDatepickerEl.setAttribute('ino-date-format', 'd-m-Y');
+      inoDatepickerEl.setAttribute('max', '10-10-2020');
+      inoDatepickerEl.setAttribute('value','11-10-2020');
+      await page.waitForChanges();
+
+      expect(flatpickrInputEl).toHaveClass('mdc-text-field--invalid');
+    });
+
+    it('should be valid with min and max date set', async () => {
+      const page = await setupPageWithContent(INO_DATEPICKER);
+      const inoDatepickerEl = await page.find(DATEPICKER);
+      const flatpickrInputEl = await page.find('.flatpickr-input');
+
+      inoDatepickerEl.setAttribute('ino-date-format', 'd-m-Y');
+      inoDatepickerEl.setAttribute('min', '09-10-2020');
+      inoDatepickerEl.setAttribute('max', '11-10-2020');
+      inoDatepickerEl.setAttribute('value','10-10-2020');
+      await page.waitForChanges();
+
+      expect(flatpickrInputEl).not.toHaveClass('mdc-text-field--invalid');
+    });
   })
 });

--- a/packages/elements/src/components/ino-datepicker/ino-datepicker.e2e.ts
+++ b/packages/elements/src/components/ino-datepicker/ino-datepicker.e2e.ts
@@ -295,7 +295,7 @@ describe('InoDatepicker', () => {
       const flatpickrInputEl = await page.find('.flatpickr-input');
 
       inoDatepickerEl.setAttribute('ino-date-format', 'd.m.Y');
-      inoDatepickerEl.setAttribute('inio-range', 'true');
+      inoDatepickerEl.setAttribute('ino-range', 'true');
       inoDatepickerEl.setAttribute('value','11-10-2020 to 13.10.2020');
       await page.waitForChanges();
 

--- a/packages/elements/src/components/ino-datepicker/ino-datepicker.e2e.ts
+++ b/packages/elements/src/components/ino-datepicker/ino-datepicker.e2e.ts
@@ -288,5 +288,18 @@ describe('InoDatepicker', () => {
 
       expect(flatpickrInputEl).not.toHaveClass('mdc-text-field--invalid');
     });
+
+    it('should be invalid if wrong date format is used inside range', async () => {
+      const page = await setupPageWithContent(INO_DATEPICKER);
+      const inoDatepickerEl = await page.find(DATEPICKER);
+      const flatpickrInputEl = await page.find('.flatpickr-input');
+
+      inoDatepickerEl.setAttribute('ino-date-format', 'd.m.Y');
+      inoDatepickerEl.setAttribute('inio-range', 'true');
+      inoDatepickerEl.setAttribute('value','11-10-2020 to 13.10.2020');
+      await page.waitForChanges();
+
+      expect(flatpickrInputEl).toHaveClass('mdc-text-field--invalid');
+    });
   })
 });

--- a/packages/elements/src/components/ino-datepicker/ino-datepicker.e2e.ts
+++ b/packages/elements/src/components/ino-datepicker/ino-datepicker.e2e.ts
@@ -1,6 +1,7 @@
 import { setupPageWithContent } from '../../util/e2etests-setup';
 
 const INO_DATEPICKER = `<ino-datepicker></ino-datepicker>`;
+const INO_DATEPICKER_WITH_SIBLING = `<ino-datepicker></ino-datepicker><button>Click Me</button>`;
 const INO_DATEPICKER_WITH_MIN_DATE = `<ino-datepicker min='today'></ino-datepicker>`;
 const INO_DATEPICKER_WITH_FORMAT = `<ino-datepicker ino-date-format='m-Y-d'></ino-datepicker>`;
 const DATEPICKER = 'ino-datepicker';
@@ -152,9 +153,10 @@ describe('InoDatepicker', () => {
       expect(datepicker).toHaveAttribute('ino-show-label-hint');
     });
 
-    it('should set invalid state for required inputs', async () => {
-      const page = await setupPageWithContent(INO_DATEPICKER);
+    it.only('should set invalid state for required inputs', async () => {
+      const page = await setupPageWithContent(INO_DATEPICKER_WITH_SIBLING);
       const inoDatepickerEl = await page.find(DATEPICKER);
+      const buttonEl = await page.find('button');
       const flatpickrInputEl = await page.find('.flatpickr-input');
     
       inoDatepickerEl.setAttribute('required', true);
@@ -162,9 +164,11 @@ describe('InoDatepicker', () => {
 
       expect(flatpickrInputEl).not.toHaveClass('mdc-text-field--invalid');
       
-      inoDatepickerEl.setAttribute('value',' ');
+      inoDatepickerEl.click();
       await page.waitForChanges();
-      
+      buttonEl.click();
+      await page.waitForChanges();
+
       expect(flatpickrInputEl).toHaveClass('mdc-text-field--invalid');
     })
   });

--- a/packages/elements/src/components/ino-datepicker/ino-datepicker.e2e.ts
+++ b/packages/elements/src/components/ino-datepicker/ino-datepicker.e2e.ts
@@ -153,7 +153,7 @@ describe('InoDatepicker', () => {
       expect(datepicker).toHaveAttribute('ino-show-label-hint');
     });
 
-    it.only('should set invalid state for required inputs', async () => {
+    it('should set invalid state for required inputs', async () => {
       const page = await setupPageWithContent(INO_DATEPICKER_WITH_SIBLING);
       const inoDatepickerEl = await page.find(DATEPICKER);
       const buttonEl = await page.find('button');

--- a/packages/elements/src/components/ino-datepicker/ino-datepicker.tsx
+++ b/packages/elements/src/components/ino-datepicker/ino-datepicker.tsx
@@ -58,8 +58,8 @@ export class Datepicker implements ComponentInterface {
 
   @Watch('value')
   valueChanged(value: string) {
-    this.setValidState(value);
     if (this.flatpickr) {
+      this.setValidState(value);
       this.flatpickr.setDate(value, false, this.inoDateFormat);
     }
   }
@@ -338,15 +338,14 @@ export class Datepicker implements ComponentInterface {
   private setValidState(value: string): void {
     let formattedDate: string;
     let parsedDate: Date;
-
-    try {
+       
+    if (value) {
       parsedDate = this.flatpickr.parseDate(value);
       formattedDate = this.flatpickr.formatDate(parsedDate, this.flatpickr.config.dateFormat);
       this.isInValid = formattedDate !== value ?  true : false;
-    } catch(e) {
-      if(value) this.isInValid = true;
     }
-    
+
+    if(!value && !this.required) this.isInValid = false;
   }
 
   private getTypeSpecificOptions(): Partial<BaseOptions> {

--- a/packages/elements/src/components/ino-datepicker/ino-datepicker.tsx
+++ b/packages/elements/src/components/ino-datepicker/ino-datepicker.tsx
@@ -58,9 +58,14 @@ export class Datepicker implements ComponentInterface {
 
   @Watch('value')
   valueChanged(value: string) {
-    if (this.flatpickr) {
-      this.setValidState(value);
-      this.flatpickr.setDate(value, false, this.inoDateFormat);
+    try {
+      if (this.flatpickr) {
+        this.setValidState(value);
+        this.flatpickr.setDate(value, false, this.inoDateFormat)
+      }
+    } catch(e) {
+      // Input could not be parsed e.g. empty spaces
+      this.isInValid = true;
     }
   }
 
@@ -338,7 +343,7 @@ export class Datepicker implements ComponentInterface {
   private setValidState(value: string): void {
     let formattedDate: string;
     let parsedDate: Date;
-       
+    
     if (value) {
       parsedDate = this.flatpickr.parseDate(value);
       formattedDate = this.flatpickr.formatDate(parsedDate, this.flatpickr.config.dateFormat);

--- a/packages/elements/src/components/ino-datepicker/ino-datepicker.tsx
+++ b/packages/elements/src/components/ino-datepicker/ino-datepicker.tsx
@@ -58,9 +58,13 @@ export class Datepicker implements ComponentInterface {
 
   @Watch('value')
   valueChanged(value: string) {
+    
     try {
       if (this.flatpickr) {
         this.setValidState(value);
+      }
+
+      if (this.flatpickr && this.isValid) {
         this.flatpickr.setDate(value, false, this.inoDateFormat)
       }
     } catch(e) {
@@ -286,7 +290,8 @@ export class Datepicker implements ComponentInterface {
 
   private static WEEKDAYS_SHORT = ['So', 'Mo', 'Di', 'Mi', 'Do', 'Fr', 'Sa'];
   private static MONTHS_LONG = ['Januar', 'Februar', 'März', 'April', 'Mai', 'Juni', 'Juli', 'August', 'September', 'Oktober', 'November', 'Dezember'];
-  
+  private static NUMBERS_WITH_SPECIAL_CHARS = /(\d[^a-z]+)/g
+
   private create() {
     const sharedOptions: Partial<BaseOptions> = {
       allowInput: true,
@@ -342,8 +347,11 @@ export class Datepicker implements ComponentInterface {
 
   private setValidState(value: string): void {
     if(this.inoRange) {
-      let arr = value.match(/(\d[^a-z]+)/g).map(match => this.validateInput(match.trim()));
-      this.isValid = !arr.includes(false);
+      this.isValid =  !value
+        .match(Datepicker.NUMBERS_WITH_SPECIAL_CHARS)
+        .map(match => this.validateInput(match.trim()))
+        .includes(false);
+      
       return;
     };
 
@@ -359,12 +367,10 @@ export class Datepicker implements ComponentInterface {
   }
 
   private validateInput(value: string): boolean {
-    let formattedDate: string;
-    let parsedDate: Date; 
-    parsedDate = this.flatpickr.parseDate(value);
-    formattedDate = this.flatpickr.formatDate(parsedDate, this.flatpickr.config.dateFormat);
+    const parsedDate: Date = this.flatpickr.parseDate(value);
+    const formattedDate: string = this.flatpickr.formatDate(parsedDate, this.flatpickr.config.dateFormat);
     
-    return formattedDate !== value ?  false : true;
+    return formattedDate == value;
   }
 
   private getTypeSpecificOptions(): Partial<BaseOptions> {

--- a/packages/elements/src/components/ino-datepicker/ino-datepicker.tsx
+++ b/packages/elements/src/components/ino-datepicker/ino-datepicker.tsx
@@ -58,7 +58,7 @@ export class Datepicker implements ComponentInterface {
 
   @Watch('value')
   valueChanged(value: string) {
-    
+
     try {
       if (this.flatpickr) {
         this.setValidState(value);
@@ -211,7 +211,7 @@ export class Datepicker implements ComponentInterface {
   @Prop() hourStep = 1;
 
   @State() isValid: boolean = true;
-  
+
   @Watch('hourStep')
   hourStepChanged(value: number) {
     this.updateFlatpickr('hourIncrement', value);
@@ -346,30 +346,46 @@ export class Datepicker implements ComponentInterface {
   });
 
   private setValidState(value: string): void {
+
     if(this.inoRange) {
       this.isValid =  !value
         .match(Datepicker.NUMBERS_WITH_SPECIAL_CHARS)
-        .map(match => this.validateInput(match.trim()))
+        .map(match => this.hasCorrectFormat(match.trim()))
         .includes(false);
-      
-      return;
-    };
 
-    if (value) {
-      this.isValid = this.validateInput(value);
       return;
     }
 
-    if(!value && !this.required) {
-      this.isValid = true; 
+    if(value) {
+
+      let isValueValid = true;
+      const parsedValue: Date = this.flatpickr.parseDate(value);
+
+      if(this.min) {
+        const minDate = this.flatpickr.parseDate(this.min);
+        isValueValid = isValueValid && (minDate <= parsedValue);
+      }
+
+      if(this.max) {
+        const maxDate = this.flatpickr.parseDate(this.max);
+        isValueValid = isValueValid && (maxDate >= parsedValue);
+      }
+
+      this.isValid = isValueValid && this.hasCorrectFormat(value);
       return;
-    };
+    }
+
+
+    if(!value && !this.required) {
+      this.isValid = true;
+      return;
+    }
   }
 
-  private validateInput(value: string): boolean {
+  private hasCorrectFormat(value: string): boolean {
     const parsedDate: Date = this.flatpickr.parseDate(value);
     const formattedDate: string = this.flatpickr.formatDate(parsedDate, this.flatpickr.config.dateFormat);
-    
+
     return formattedDate == value;
   }
 

--- a/packages/elements/src/components/ino-datepicker/ino-datepicker.tsx
+++ b/packages/elements/src/components/ino-datepicker/ino-datepicker.tsx
@@ -65,7 +65,7 @@ export class Datepicker implements ComponentInterface {
       }
     } catch(e) {
       // Input could not be parsed e.g. empty spaces
-      this.isInValid = true;
+      this.isValid = false;
     }
   }
 
@@ -206,7 +206,7 @@ export class Datepicker implements ComponentInterface {
    */
   @Prop() hourStep = 1;
 
-  @State() isInValid: boolean = false;
+  @State() isValid: boolean = true;
   
   @Watch('hourStep')
   hourStepChanged(value: number) {
@@ -341,16 +341,30 @@ export class Datepicker implements ComponentInterface {
   });
 
   private setValidState(value: string): void {
-    let formattedDate: string;
-    let parsedDate: Date;
-    
+    if(this.inoRange) {
+      let arr = value.match(/(\d[^a-z]+)/g).map(match => this.validateInput(match.trim()));
+      this.isValid = !arr.includes(false);
+      return;
+    };
+
     if (value) {
-      parsedDate = this.flatpickr.parseDate(value);
-      formattedDate = this.flatpickr.formatDate(parsedDate, this.flatpickr.config.dateFormat);
-      this.isInValid = formattedDate !== value ?  true : false;
+      this.isValid = this.validateInput(value);
+      return;
     }
 
-    if(!value && !this.required) this.isInValid = false;
+    if(!value && !this.required) {
+      this.isValid = true; 
+      return;
+    };
+  }
+
+  private validateInput(value: string): boolean {
+    let formattedDate: string;
+    let parsedDate: Date; 
+    parsedDate = this.flatpickr.parseDate(value);
+    formattedDate = this.flatpickr.formatDate(parsedDate, this.flatpickr.config.dateFormat);
+    
+    return formattedDate !== value ?  false : true;
   }
 
   private getTypeSpecificOptions(): Partial<BaseOptions> {
@@ -394,7 +408,7 @@ export class Datepicker implements ComponentInterface {
           name={this.name}
           required={this.required}
           ino-label={this.inoLabel}
-          ino-error={this.isInValid}
+          ino-error={!this.isValid}
           ino-icon-leading
           value={this.value}
           ino-helper={this.inoHelper}

--- a/packages/elements/src/components/ino-datepicker/readme.md
+++ b/packages/elements/src/components/ino-datepicker/readme.md
@@ -99,30 +99,34 @@ class MyComponent extends Component {
 ```
 
 ## Additional Hints
+### Types
+This datepicker can be used as a picker for ...
+- date
+- time
+- datetime
+- month
 
-### Examples
-
-The correct picker is automatically chosen based on the `ino-date-format`.
-
-The picker can be used as date picker
-
+The type of the picker is selected based on the `ino-type` property. See the examples below.
+ 
+#### Datepicker
 ```html
-<ino-datepicker ino-date-format="d-m-Y" ino-label="Date"></ino-datepicker>
+<ino-datepicker ino-type="date" ino-label="Date"></ino-datepicker>
 ```
-
-or as time picker
-
+#### Timepicker
 ```html
-<ino-datepicker ino-date-format="H:i" ino-label="Time"></ino-datepicker>
+<ino-datepicker ino-type="time" ino-label="Time"></ino-datepicker>
 ```
-
-or as datetime picker
-
+#### Date-Time-Picker
 ```html
 <ino-datepicker
-  ino-date-format="d-m-Y H:i"
+  ino-type="datetime"
   ino-label="Datetime"
-></ino-datepicker>
+>
+</ino-datepicker>
+```
+#### Monthpicker
+```html
+<ino-datepicker ino-type="month" ino-label="Month"></ino-datepicker>
 ```
 
 ## Demo

--- a/packages/elements/stencil.config.ts
+++ b/packages/elements/stencil.config.ts
@@ -15,6 +15,11 @@ export const config: Config = {
     cloneNodeFix: false,
     slotChildNodesFix: true
   },
+  testing: {
+    browserHeadless: false,
+    browserSlowMo: 2000,
+    browserDevtools: true
+  },
   globalStyle: './src/components/styles/variables.scss',
   globalScript: './src/util/import-fonts.ts',
   enableCache: true,

--- a/packages/elements/stencil.config.ts
+++ b/packages/elements/stencil.config.ts
@@ -15,11 +15,6 @@ export const config: Config = {
     cloneNodeFix: false,
     slotChildNodesFix: true
   },
-  testing: {
-    browserHeadless: false,
-    browserSlowMo: 2000,
-    browserDevtools: true
-  },
   globalStyle: './src/components/styles/variables.scss',
   globalScript: './src/util/import-fonts.ts',
   enableCache: true,

--- a/packages/storybook/src/stories/ino-datepicker/ino-datepicker.stories.js
+++ b/packages/storybook/src/stories/ino-datepicker/ino-datepicker.stories.js
@@ -61,7 +61,6 @@ export const DefaultUsage = () => /*html*/ `
         ino-outline="${boolean('ino-outline', false, 'STANDARD')}"
         min="${text('min', minDate, 'STANDARD')}"
         max="${text('max', maxDate, 'STANDARD')}"
-        ino-pattern="${text('ino-pattern', '', 'STANDARD')}"
         disabled="${boolean('disabled', false, 'STANDARD')}"
         required="${boolean('required', false, 'STANDARD')}"
         ino-show-label-hint="${boolean('ino-show-label-hint', false, 'STANDARD')}"
@@ -95,7 +94,6 @@ export const DefaultUsage = () => /*html*/ `
       <ino-datepicker ino-type="time" ino-date-format="h:i K" ino-label="Twelve hour time" ino-twelve-hour-time></ino-datepicker>
 
       <h4>States</h4>
-      <ino-datepicker ino-label="Pattern numbers from 1 - 6" ino-pattern="[1-6]+"></ino-datepicker>
       <ino-datepicker ino-label="Disabled" disabled></ino-datepicker>
       <ino-datepicker ino-label="Required" required ino-show-label-hint></ino-datepicker>
       <ino-datepicker ino-label="Optional" ino-show-label-hint></ino-datepicker>

--- a/packages/storybook/src/stories/ino-datepicker/ino-datepicker.stories.js
+++ b/packages/storybook/src/stories/ino-datepicker/ino-datepicker.stories.js
@@ -65,7 +65,7 @@ export const DefaultUsage = () => /*html*/ `
         disabled="${boolean('disabled', false, 'STANDARD')}"
         required="${boolean('required', false, 'STANDARD')}"
         ino-show-label-hint="${boolean('ino-show-label-hint', false, 'STANDARD')}"
-        ino-date-format="${text('ino-date-format', 'Y-m-d H:i', 'DATE CONFIG')}"
+        ino-date-format="${text('ino-date-format', 'Y-m-d', 'DATE CONFIG')}"
         ino-range="${boolean('ino-range', false, 'DATE CONFIG')}"
         ino-default-date="${text('ino-default-date', defaultDate, 'DATE CONFIG')}"
         ino-twelve-hour-time="${boolean('ino-twelve-hour-time', false, 'DATE CONFIG')}"


### PR DESCRIPTION
Closes #225 


- A debounce was not possible, because of the multiple possibilities to enter values (e.g. copy/paste, flatpicker)
- It also turned out that validating on blur leads to a worse user experience
- Only validate if flatpicker is set
- Also ino-range validation is fixed