### PR TITLE
refactor: move highlight.js to storybook

### DIFF
--- a/packages/elements/package.json
+++ b/packages/elements/package.json
@@ -83,7 +83,6 @@
     "classnames": "^2.2.6",
     "currency.js": "^1.2.2",
     "flatpickr": "^4.4.6",
-    "highlight.js": "^9.18.1",
     "tippy.js": "^6.2.3",
     "typeface-lato": "^0.0.75"
   },

--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -39,6 +39,7 @@
   ],
   "dependencies": {
     "@inovex.de/elements": "^2.2.1",
+    "highlight.js": "^9.18.1",
     "mermaid": "^8.2.6",
     "moment": "^2.24.0"
   },


### PR DESCRIPTION
Closes #228 

## Proposed Changes

- Moves dependency `highlight.js` to storybook instead of elements
