### PR TITLE
feat(elements|ino-textarea): use filled text field style as default

### DIFF
--- a/packages/elements-angular/elements/src/directives/proxies.ts
+++ b/packages/elements-angular/elements/src/directives/proxies.ts
@@ -985,13 +985,13 @@ export class InoTableRow {
 import { Textarea as ITextarea } from '@inovex.de/elements/dist/types/components/ino-textarea/ino-textarea';
 export declare interface InoTextarea extends Components.InoTextarea {}
 @ProxyCmp({
-  inputs: ['autoFocus', 'autogrow', 'cols', 'disabled', 'inoLabel', 'inoShowLabelHint', 'maxlength', 'minlength', 'name', 'placeholder', 'required', 'rows', 'showCharacterCounter', 'value']
+  inputs: ['autoFocus', 'autogrow', 'cols', 'disabled', 'inoLabel', 'inoOutline', 'inoShowLabelHint', 'maxlength', 'minlength', 'name', 'placeholder', 'required', 'rows', 'showCharacterCounter', 'value']
 })
 @Component({
   selector: 'ino-textarea',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
-  inputs: ['autoFocus', 'autogrow', 'cols', 'disabled', 'inoLabel', 'inoShowLabelHint', 'maxlength', 'minlength', 'name', 'placeholder', 'required', 'rows', 'showCharacterCounter', 'value'],
+  inputs: ['autoFocus', 'autogrow', 'cols', 'disabled', 'inoLabel', 'inoOutline', 'inoShowLabelHint', 'maxlength', 'minlength', 'name', 'placeholder', 'required', 'rows', 'showCharacterCounter', 'value'],
   outputs: ['valueChange']
 })
 export class InoTextarea {

--- a/packages/elements/src/components.d.ts
+++ b/packages/elements/src/components.d.ts
@@ -1115,6 +1115,10 @@ export namespace Components {
          */
         "inoLabel"?: string;
         /**
+          * Styles the input field as outlined element.
+         */
+        "inoOutline"?: boolean;
+        /**
           * If true, an *optional* message is displayed if not required, otherwise a * marker is displayed if required
          */
         "inoShowLabelHint"?: boolean;
@@ -2713,6 +2717,10 @@ declare namespace LocalJSX {
           * The optional floating label of this input field.
          */
         "inoLabel"?: string;
+        /**
+          * Styles the input field as outlined element.
+         */
+        "inoOutline"?: boolean;
         /**
           * If true, an *optional* message is displayed if not required, otherwise a * marker is displayed if required
          */

--- a/packages/elements/src/components/ino-input/ino-input.scss
+++ b/packages/elements/src/components/ino-input/ino-input.scss
@@ -187,4 +187,14 @@ ino-input {
       }
     }
   }
+
+  & ino-label {
+    &:not([ino-outline]) .mdc-floating-label {
+      left: 0;
+
+      &:not(.mdc-floating-label--float-above) {
+        top: 70%;
+      }
+    }
+  }
 }

--- a/packages/elements/src/components/ino-label/ino-label.scss
+++ b/packages/elements/src/components/ino-label/ino-label.scss
@@ -23,14 +23,6 @@ ino-label {
     }
   }
 
-  &:not([ino-outline]) .mdc-floating-label {
-    left: 0;
-
-    ino-input &:not(.mdc-floating-label--float-above) {
-      top: 70%;
-    }
-  }
-
   &:not([ino-disabled]) .mdc-floating-label:not(.mdc-floating-label--float-above) {
     color: $label-color;
   }

--- a/packages/elements/src/components/ino-textarea/ino-textarea.tsx
+++ b/packages/elements/src/components/ino-textarea/ino-textarea.tsx
@@ -96,6 +96,11 @@ export class Textarea implements ComponentInterface {
   @Prop() value?: string = '';
 
   /**
+   * Styles the input field as outlined element.
+   */
+  @Prop() inoOutline?: boolean;
+
+  /**
    * An optional flag to allow the textarea adjust its height to display all the content.
    * The `rows` attribute can also be used to specify a minimum height. Use CSS to specify
    * a max-height for the textarea element. Once the height exceeds the max-height, autogrow
@@ -185,7 +190,8 @@ export class Textarea implements ComponentInterface {
     const classes = classNames({
       'mdc-text-field': true,
       'mdc-text-field--textarea': true,
-      'mdc-text-field--outlined': true,
+      'mdc-text-field--outlined': this.inoOutline,
+      'mdc-text-field--filled': !this.inoOutline,
       'mdc-text-field-fullwidth': !Boolean(this.cols),
       'mdc-text-field--no-label': !this.inoLabel,
       'mdc-text-field--with-internal-counter': Boolean(this.maxlength)
@@ -210,10 +216,10 @@ export class Textarea implements ComponentInterface {
             onInput={this.handleNativeTextareaChange.bind(this)}
           />
           {this.maxlength && (
-              <div class="mdc-text-field-character-counter">{this.value.length} / {this.maxlength}</div>
+            <div class="mdc-text-field-character-counter">{this.value.length} / {this.maxlength}</div>
           )}
           <ino-label
-            ino-outline
+            ino-outline={this.inoOutline}
             ino-text={this.inoLabel}
             ino-required={this.required}
             ino-disabled={this.disabled}

--- a/packages/elements/src/components/ino-textarea/readme.md
+++ b/packages/elements/src/components/ino-textarea/readme.md
@@ -114,6 +114,7 @@ The component is based on a native input with additional features. Thus, the com
 | `cols`                 | `cols`                   | The number of cols of this textarea.                                                                                                                                                                                                                                                                      | `number`  | `undefined` |
 | `disabled`             | `disabled`               | Disables this element.                                                                                                                                                                                                                                                                                    | `boolean` | `undefined` |
 | `inoLabel`             | `ino-label`              | The optional floating label of this input field.                                                                                                                                                                                                                                                          | `string`  | `undefined` |
+| `inoOutline`           | `ino-outline`            | Styles the input field as outlined element.                                                                                                                                                                                                                                                               | `boolean` | `undefined` |
 | `inoShowLabelHint`     | `ino-show-label-hint`    | If true, an *optional* message is displayed if not required, otherwise a * marker is displayed if required                                                                                                                                                                                                | `boolean` | `undefined` |
 | `maxlength`            | `maxlength`              | The max length of this element.                                                                                                                                                                                                                                                                           | `number`  | `undefined` |
 | `minlength`            | `minlength`              | The min length of this element.                                                                                                                                                                                                                                                                           | `number`  | `undefined` |
@@ -130,15 +131,6 @@ The component is based on a native input with additional features. Thus, the com
 | Event         | Description                                                                    | Type                  |
 | ------------- | ------------------------------------------------------------------------------ | --------------------- |
 | `valueChange` | Emits when the user types something in. Contains typed input in `event.detail` | `CustomEvent<string>` |
-
-
-## CSS Custom Properties
-
-| Name                           | Description                   |
-| ------------------------------ | ----------------------------- |
-| `--ino-textarea-caret-color`   | color of the caret            |
-| `--ino-textarea-label-color`   | color of the label            |
-| `--ino-textarea-outline-color` | outline color of the textarea |
 
 
 ## Dependencies

--- a/packages/storybook/src/stories/ino-textarea/ino-textarea.stories.js
+++ b/packages/storybook/src/stories/ino-textarea/ino-textarea.stories.js
@@ -47,10 +47,10 @@ export const DefaultUsage = () => /*html*/ `
     <style>
       ino-textarea.customizable-textarea {
         --textarea-outline-color: ${text(
-          '--textarea-outline-color',
-          '#3d40f5',
-          'Custom Properties'
-        )};
+  '--textarea-outline-color',
+  '#3d40f5',
+  'Custom Properties'
+)};
         --textarea-caret-color: ${text('--textarea-caret-color', '#3d40f5', 'Custom Properties')};
         --textarea-label-color: ${text('--textarea-label-color', '#3d40f5', 'Custom Properties')};
       }
@@ -61,6 +61,7 @@ export const DefaultUsage = () => /*html*/ `
     placeholder="${text('placeholder', '')}"
     value="${text('value', '')}"
     ino-label="${text('ino-label', 'Customizable textarea')}"
+    ino-outline="${boolean('ino-outline', false)}"
     minlength="${number('minlength', 0)}"
     maxlength="${number('maxlength', 30)}"
     disabled="${boolean('disabled', false)}"
@@ -72,6 +73,9 @@ export const DefaultUsage = () => /*html*/ `
   <h4>Labels</h4>
   <ino-textarea ino-label="Floating label" cols="30" rows="3"></ino-textarea>
   <ino-textarea ino-label="Floating label" value="With value" cols="30" rows="3"></ino-textarea>
+
+  <h4>Outline</h4>
+  <ino-textarea ino-label="Outline" cols="30" rows="3" ino-outline="true"></ino-textarea>
 
   <h4>States</h4>
   <ino-textarea placeholder="Disabled" disabled cols="30" rows="3"></ino-textarea>


### PR DESCRIPTION
Closes #142

## Proposed Changes

- Uses the filled text field style as default for the ino-textarea (analogous to ino-input)
- Adds an option to style the ino-textarea as an outlined text input field via the inoOutlined property (analogous to ino-input)