### PR TITLE
fix(storybook|ino-icon): fix icon search

### DIFF
--- a/packages/storybook/src/stories/ino-icon/ino-icon.stories.js
+++ b/packages/storybook/src/stories/ino-icon/ino-icon.stories.js
@@ -23,11 +23,11 @@ function subscribeToComponentEvents() {
     const chips = Array.from(document.getElementsByTagName('ino-chip'));
 
     chips
-      .filter((chip) => !chip.getAttribute('ino-icon').includes(value))
+      .filter((chip) => !chip.getAttribute('id').includes(value))
       .forEach((chip) => (chip.style.display = 'none'));
 
     chips
-      .filter((chip) => chip.getAttribute('ino-icon').includes(value))
+      .filter((chip) => chip.getAttribute('id').includes(value))
       .forEach((chip) => (chip.style.display = 'block'));
 
     el.value = value;


### PR DESCRIPTION
Closes #235 

## Proposed Changes

- The chip attribute 'id' (which contains the icon name as 'icon-${name}) is used for the icon search instead of the 'ino-icon' attribute, because this property was removed from the chip component in an earlier PR