### PR TITLE
fix(elements|ino-list-item): fix text alignment

### DIFF
--- a/packages/elements/src/components/ino-list-item/ino-list-item.tsx
+++ b/packages/elements/src/components/ino-list-item/ino-list-item.tsx
@@ -75,8 +75,10 @@ export class ListItem implements ComponentInterface {
       'mdc-list-item--disabled': this.inoDisabled
     });
 
+    const hasSecondarySlotContent = this.el.querySelectorAll("[slot=ino-secondary]").length > 0;
+
     const primaryContent = this.inoText || <slot name="ino-primary" />;
-    const secondaryContent = this.inoSecondaryText || <slot name="ino-secondary" />;
+    const secondaryContent = this.inoSecondaryText || (hasSecondarySlotContent ? <slot name="ino-secondary" /> : null);
 
     return (
       <Host>


### PR DESCRIPTION
Closes #229

## Proposed Changes

- The text alignment was broken, because the slot for the secondary text was rendered even if no content was provided for this slot (the secondary slot took up space although it was empty)
- This solution only renders the slot if content is provided for this specific slot