### PR TITLE
fix(elements-angular|ino-button): fix invisible loading spinner

### DIFF
--- a/packages/elements/src/components/ino-button/ino-button.tsx
+++ b/packages/elements/src/components/ino-button/ino-button.tsx
@@ -54,7 +54,7 @@ export class Button implements ComponentInterface {
   /**
    * Styles the button to have the edge on the top-right instead of the top-left
    */
-  @Prop() inoEdgeMirrored? = false;
+  @Prop() inoEdgeMirrored?= false;
 
   /**
    * The fill type of this element.
@@ -65,7 +65,7 @@ export class Button implements ComponentInterface {
   /**
    * Styles the button in 100% width.
    */
-  @Prop() inoFullWidth? = false;
+  @Prop() inoFullWidth?= false;
 
   /**
    * If enabled, prepends the slotted icon to the button label
@@ -85,7 +85,7 @@ export class Button implements ComponentInterface {
   /**
    * Shows an infinite loading spinner and prevents further clicks.
    */
-  @Prop() inoLoading?: boolean;
+  @Prop({ reflect: true }) inoLoading?: boolean;
 
   private buttonSizeBeforeLoad: string;
 
@@ -161,7 +161,7 @@ export class Button implements ComponentInterface {
         >
           {this.inoIconLeading && (
             <span class="mdc-button__icon">
-              <slot name="ino-icon-leading"/>
+              <slot name="ino-icon-leading" />
             </span>
           )}
           <div class="mdc-button__label">
@@ -173,7 +173,7 @@ export class Button implements ComponentInterface {
           </div>
           {this.inoIconTrailing && (
             <span class="mdc-button__icon">
-              <slot name="ino-icon-trailing"/>
+              <slot name="ino-icon-trailing" />
             </span>
           )}
         </button>


### PR DESCRIPTION
Closes #195

## Proposed Changes

- The styling of the spinner is bound to the ino-loading attribute somehow. If the property is set using e.g. Angular property binding (<ino-button [inoLoading]="true">...) it results in a modified attribute (ng-reflect-ino-loading) in the DOM, which breaks the styling
- By reflecting the inoLoading property value back to the DOM as HTML attribute (ino-loading), the correct spinner styling can be restored in the Angular use case
- I assume there is a better way to achieve this via the Angular adapter, but I don't really know how the adapter works