### PR TITLE
feat(elements|ino-menu): emit new closeMenu event on click

### DIFF
--- a/packages/elements-angular/elements/src/directives/proxies.ts
+++ b/packages/elements-angular/elements/src/directives/proxies.ts
@@ -519,7 +519,7 @@ Contains the element itself in `event.detail` */
   }
 }
 
-
+import { Menu as IMenu } from '@inovex.de/elements/dist/types/components/ino-menu/ino-menu';
 export declare interface InoMenu extends Components.InoMenu {}
 @ProxyCmp({
   inputs: ['inoFor', 'inoOpen']
@@ -528,13 +528,17 @@ export declare interface InoMenu extends Components.InoMenu {}
   selector: 'ino-menu',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
-  inputs: ['inoFor', 'inoOpen']
+  inputs: ['inoFor', 'inoOpen'],
+  outputs: ['menuClose']
 })
 export class InoMenu {
+  /** Emits on any click. */
+  menuClose!: IMenu['menuClose'];
   protected el: HTMLElement;
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
     this.el = r.nativeElement;
+    proxyOutputs(this, this.el, ['menuClose']);
   }
 }
 

--- a/packages/elements-angular/elements/src/directives/proxies.ts
+++ b/packages/elements-angular/elements/src/directives/proxies.ts
@@ -532,7 +532,7 @@ export declare interface InoMenu extends Components.InoMenu {}
   outputs: ['menuClose']
 })
 export class InoMenu {
-  /** Emits on any click. */
+  /** Emits on outside menu click and escape press. */
   menuClose!: IMenu['menuClose'];
   protected el: HTMLElement;
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {

--- a/packages/elements/src/components.d.ts
+++ b/packages/elements/src/components.d.ts
@@ -2325,6 +2325,10 @@ declare namespace LocalJSX {
           * Set this option to show the menu.
          */
         "inoOpen"?: boolean;
+        /**
+          * Emits on any click.
+         */
+        "onMenuClose"?: (event: CustomEvent<void>) => void;
     }
     interface InoNavDrawer {
         /**

--- a/packages/elements/src/components.d.ts
+++ b/packages/elements/src/components.d.ts
@@ -2326,7 +2326,7 @@ declare namespace LocalJSX {
          */
         "inoOpen"?: boolean;
         /**
-          * Emits on any click.
+          * Emits on outside menu click and escape press.
          */
         "onMenuClose"?: (event: CustomEvent<void>) => void;
     }

--- a/packages/elements/src/components/ino-menu/MDCCustomMenu.js
+++ b/packages/elements/src/components/ino-menu/MDCCustomMenu.js
@@ -2,12 +2,19 @@ import { MDCMenu } from '@material/menu';
 
 export class MDCCustomMenu extends MDCMenu {
   // Really hacky
-  // TODO: Test if basic onclick and keydown events still come trough
   constructor(mdcMenu) {
     super(mdcMenu);
-    this.foundation.handleKeydown = (evt) => {};
-    this.foundation.handleClick = (evt) => {};
-    this.menuSurface_.handleBodyClick = (evt) => {};
-    this.menuSurface_.handleKeydown = (evt) => {};
+
+    // Prevent menu from closing
+    this.foundation.handleKeydown = _ => {};
+    this.foundation.handleClick = _ => {};
+    this.menuSurface_.handleKeydown = _ => {};
+    this.foundation.handleMenuSurfaceOpened = _ => {};
+    this.foundation.handleItemAction = _ => {};
+
+    this.menuSurface_.handleBodyClick = _ =>  this.root.dispatchEvent(
+        new CustomEvent('menu:close', {  bubbles: true, }
+      )
+    );
   }
 }

--- a/packages/elements/src/components/ino-menu/MDCCustomMenu.js
+++ b/packages/elements/src/components/ino-menu/MDCCustomMenu.js
@@ -5,16 +5,18 @@ export class MDCCustomMenu extends MDCMenu {
   constructor(mdcMenu) {
     super(mdcMenu);
 
-    // Prevent menu from closing
+    // TODO: wait for https://github.com/material-components/material-components-web/issues/4357 to be resolved
     this.foundation.handleKeydown = _ => {};
     this.foundation.handleClick = _ => {};
     this.menuSurface_.handleKeydown = _ => {};
     this.foundation.handleMenuSurfaceOpened = _ => {};
     this.foundation.handleItemAction = _ => {};
 
-    this.menuSurface_.handleBodyClick = _ =>  this.root.dispatchEvent(
-        new CustomEvent('menu:close', {  bubbles: true, }
-      )
-    );
+    this.menuSurface_.handleBodyClick = (e) =>  {
+
+      if(this.root.contains(e.target)) return;
+
+      this.root.dispatchEvent(new CustomEvent('menu:outside-click', {  bubbles: true, }));
+    }
   }
 }

--- a/packages/elements/src/components/ino-menu/MDCCustomMenu.js
+++ b/packages/elements/src/components/ino-menu/MDCCustomMenu.js
@@ -6,17 +6,18 @@ export class MDCCustomMenu extends MDCMenu {
     super(mdcMenu);
 
     // TODO: wait for https://github.com/material-components/material-components-web/issues/4357 to be resolved
-    this.foundation.handleKeydown = _ => {};
-    this.foundation.handleClick = _ => {};
-    this.menuSurface_.handleKeydown = _ => {};
-    this.foundation.handleMenuSurfaceOpened = _ => {};
-    this.foundation.handleItemAction = _ => {};
+    this.foundation.handleKeydown = (_) => {};
+    this.foundation.handleClick = (_) => {};
+    this.menuSurface_.handleKeydown = (_) => {};
+    this.foundation.handleMenuSurfaceOpened = (_) => {};
+    this.foundation.handleItemAction = (_) => {};
 
-    this.menuSurface_.handleBodyClick = (e) =>  {
+    this.menuSurface_.handleBodyClick = (e) => {
+      if (this.root.contains(e.target)) return;
 
-      if(this.root.contains(e.target)) return;
-
-      this.root.dispatchEvent(new CustomEvent('menu:outside-click', {  bubbles: true, }));
-    }
+      this.root.dispatchEvent(
+        new CustomEvent('menu:outside-click', { bubbles: true })
+      );
+    };
   }
 }

--- a/packages/elements/src/components/ino-menu/ino-menu.e2e.ts
+++ b/packages/elements/src/components/ino-menu/ino-menu.e2e.ts
@@ -23,4 +23,72 @@ describe('InoMenu', () => {
       expect(innerDiv).not.toHaveClass('mdc-menu-surface--open');
     });
   });
+
+  describe('Events', () => {
+    it('should emit \'menuClose\' event on outside click while menu open', async () => {
+
+      const btnId = 'id-btn';
+
+      const page = await setupPageWithContent(`
+        <div id="container">
+            <button id="${btnId}">Open menu</button>
+            <ino-menu ino-for="id-btn" ino-open="true">
+                <ino-list-item id="item-1" ino-text="item-1"></ino-list-item>
+                <ino-list-item id="item-1" ino-text="item-2"></ino-list-item>
+            </ino-menu>
+        </div>
+      `);
+
+      const menuCloseSpy = await page.spyOnEvent('menuClose');
+
+      await page.click(`#${btnId}`);
+      await page.waitForChanges();
+
+      expect(menuCloseSpy).toHaveReceivedEvent();
+    });
+
+    it('should not emit \'menuClose\' event on outside click while menu closed', async () => {
+
+      const btnId = 'id-btn';
+
+      const page = await setupPageWithContent(`
+        <div id="container">
+            <button id="${btnId}">Open menu</button>
+            <ino-menu ino-for="id-btn" ino-open="false">
+                <ino-list-item id="item-1" ino-text="item-1"></ino-list-item>
+                <ino-list-item id="item-1" ino-text="item-2"></ino-list-item>
+            </ino-menu>
+        </div>
+      `);
+
+      const menuCloseSpy = await page.spyOnEvent('menuClose');
+
+      await page.click(`#${btnId}`);
+      await page.waitForChanges();
+
+      expect(menuCloseSpy).not.toHaveReceivedEvent();
+    });
+
+    it('should emit \'menuClose\' event on inside item click', async () => {
+
+      const listItemId = 'item-1';
+
+      const page = await setupPageWithContent(`
+        <div id="container">
+            <button>Open menu</button>
+            <ino-menu ino-for="id-btn" ino-open="true">
+                <ino-list-item id="${listItemId}" ino-text="item-1"></ino-list-item>
+                <ino-list-item id="item-1" ino-text="item-2"></ino-list-item>
+            </ino-menu>
+        </div>
+      `);
+
+      const menuCloseSpy = await page.spyOnEvent('menuClose');
+
+      await page.click(`#${listItemId}`);
+      await page.waitForChanges();
+
+      expect(menuCloseSpy).toHaveReceivedEvent();
+    });
+  });
 });

--- a/packages/elements/src/components/ino-menu/ino-menu.e2e.ts
+++ b/packages/elements/src/components/ino-menu/ino-menu.e2e.ts
@@ -69,7 +69,7 @@ describe('InoMenu', () => {
       expect(menuCloseSpy).not.toHaveReceivedEvent();
     });
 
-    it('should emit \'menuClose\' event on inside item click', async () => {
+    it('should not emit \'menuClose\' event on inside item click', async () => {
 
       const btnId = 'id-btn';
       const listItemId = 'item-1';
@@ -89,7 +89,7 @@ describe('InoMenu', () => {
       await page.click(`#${listItemId}`);
       await page.waitForChanges();
 
-      expect(menuCloseSpy).toHaveReceivedEvent();
+      expect(menuCloseSpy).not.toHaveReceivedEvent();
     });
   });
 });

--- a/packages/elements/src/components/ino-menu/ino-menu.e2e.ts
+++ b/packages/elements/src/components/ino-menu/ino-menu.e2e.ts
@@ -25,8 +25,7 @@ describe('InoMenu', () => {
   });
 
   describe('Events', () => {
-    it('should emit \'menuClose\' event on outside click while menu open', async () => {
-
+    it("should emit 'menuClose' event on outside click while menu open", async () => {
       const btnId = 'id-btn';
 
       const page = await setupPageWithContent(`
@@ -47,8 +46,7 @@ describe('InoMenu', () => {
       expect(menuCloseSpy).toHaveReceivedEvent();
     });
 
-    it('should not emit \'menuClose\' event on outside click while menu closed', async () => {
-
+    it("should not emit 'menuClose' event on outside click while menu closed", async () => {
       const btnId = 'id-btn';
 
       const page = await setupPageWithContent(`
@@ -69,8 +67,7 @@ describe('InoMenu', () => {
       expect(menuCloseSpy).not.toHaveReceivedEvent();
     });
 
-    it('should not emit \'menuClose\' event on inside item click', async () => {
-
+    it("should not emit 'menuClose' event on inside item click", async () => {
       const btnId = 'id-btn';
       const listItemId = 'item-1';
 

--- a/packages/elements/src/components/ino-menu/ino-menu.e2e.ts
+++ b/packages/elements/src/components/ino-menu/ino-menu.e2e.ts
@@ -32,7 +32,7 @@ describe('InoMenu', () => {
       const page = await setupPageWithContent(`
         <div id="container">
             <button id="${btnId}">Open menu</button>
-            <ino-menu ino-for="id-btn" ino-open="true">
+            <ino-menu ino-for="${btnId}" ino-open="true">
                 <ino-list-item id="item-1" ino-text="item-1"></ino-list-item>
                 <ino-list-item id="item-1" ino-text="item-2"></ino-list-item>
             </ino-menu>
@@ -54,7 +54,7 @@ describe('InoMenu', () => {
       const page = await setupPageWithContent(`
         <div id="container">
             <button id="${btnId}">Open menu</button>
-            <ino-menu ino-for="id-btn" ino-open="false">
+            <ino-menu ino-for="${btnId}" ino-open="false">
                 <ino-list-item id="item-1" ino-text="item-1"></ino-list-item>
                 <ino-list-item id="item-1" ino-text="item-2"></ino-list-item>
             </ino-menu>
@@ -71,12 +71,13 @@ describe('InoMenu', () => {
 
     it('should emit \'menuClose\' event on inside item click', async () => {
 
+      const btnId = 'id-btn';
       const listItemId = 'item-1';
 
       const page = await setupPageWithContent(`
         <div id="container">
-            <button>Open menu</button>
-            <ino-menu ino-for="id-btn" ino-open="true">
+            <button id="${btnId}">Open menu</button>
+            <ino-menu ino-for="${btnId}" ino-open="true">
                 <ino-list-item id="${listItemId}" ino-text="item-1"></ino-list-item>
                 <ino-list-item id="item-1" ino-text="item-2"></ino-list-item>
             </ino-menu>

--- a/packages/elements/src/components/ino-menu/ino-menu.tsx
+++ b/packages/elements/src/components/ino-menu/ino-menu.tsx
@@ -1,5 +1,16 @@
 import { MDCMenu } from '@material/menu';
-import { Component, ComponentInterface, Event, EventEmitter, Element, Host, Listen, Prop, Watch, h } from '@stencil/core';
+import {
+  Component,
+  ComponentInterface,
+  Event,
+  EventEmitter,
+  Element,
+  Host,
+  Listen,
+  Prop,
+  Watch,
+  h,
+} from '@stencil/core';
 
 import { MDCCustomMenu } from './MDCCustomMenu';
 
@@ -49,7 +60,7 @@ export class Menu implements ComponentInterface {
 
   @Listen('keydown')
   onKeydown({ key }: KeyboardEvent) {
-    if(key === 'Escape') {
+    if (key === 'Escape') {
       this.menuClose.emit();
     }
   }

--- a/packages/elements/src/components/ino-menu/ino-menu.tsx
+++ b/packages/elements/src/components/ino-menu/ino-menu.tsx
@@ -1,13 +1,5 @@
 import { MDCMenu } from '@material/menu';
-import {
-  Component,
-  ComponentInterface,
-  Element,
-  Host,
-  Prop,
-  Watch,
-  h,
-} from '@stencil/core';
+import { Component, ComponentInterface, Event, EventEmitter, Element, Host, Listen, Prop, Watch, h } from '@stencil/core';
 
 import { MDCCustomMenu } from './MDCCustomMenu';
 
@@ -23,6 +15,11 @@ export class Menu implements ComponentInterface {
    * An internal instance of the mdc menu.
    */
   private menu!: MDCMenu;
+
+  /**
+   * Emits on any click.
+   */
+  @Event() menuClose: EventEmitter<void>;
 
   /**
    * Anchor element for the menu
@@ -42,6 +39,12 @@ export class Menu implements ComponentInterface {
   @Watch('inoOpen')
   inoOpenChanged(open: boolean) {
     this.menu.open = open;
+  }
+
+  @Listen('menu:close')
+  onClose(ev: Event) {
+    ev.stopPropagation();
+    this.menuClose.emit();
   }
 
   componentDidLoad() {

--- a/packages/elements/src/components/ino-menu/ino-menu.tsx
+++ b/packages/elements/src/components/ino-menu/ino-menu.tsx
@@ -17,7 +17,7 @@ export class Menu implements ComponentInterface {
   private menu!: MDCMenu;
 
   /**
-   * Emits on any click.
+   * Emits on outside menu click and escape press.
    */
   @Event() menuClose: EventEmitter<void>;
 
@@ -45,6 +45,13 @@ export class Menu implements ComponentInterface {
   onClose(ev: Event) {
     ev.stopPropagation();
     this.menuClose.emit();
+  }
+
+  @Listen('keydown')
+  onKeydown({ key }: KeyboardEvent) {
+    if(key === 'Escape') {
+      this.menuClose.emit();
+    }
   }
 
   componentDidLoad() {

--- a/packages/elements/src/components/ino-menu/ino-menu.tsx
+++ b/packages/elements/src/components/ino-menu/ino-menu.tsx
@@ -41,7 +41,7 @@ export class Menu implements ComponentInterface {
     this.menu.open = open;
   }
 
-  @Listen('menu:close')
+  @Listen('menu:outside-click')
   onClose(ev: Event) {
     ev.stopPropagation();
     this.menuClose.emit();

--- a/packages/elements/src/components/ino-menu/readme.md
+++ b/packages/elements/src/components/ino-menu/readme.md
@@ -102,9 +102,9 @@ The menu creates a temporary surface with an empty list composer. The items of t
 
 ## Events
 
-| Event       | Description         | Type                |
-| ----------- | ------------------- | ------------------- |
-| `menuClose` | Emits on any click. | `CustomEvent<void>` |
+| Event       | Description                                   | Type                |
+| ----------- | --------------------------------------------- | ------------------- |
+| `menuClose` | Emits on outside menu click and escape press. | `CustomEvent<void>` |
 
 
 ## Dependencies

--- a/packages/elements/src/components/ino-menu/readme.md
+++ b/packages/elements/src/components/ino-menu/readme.md
@@ -1,7 +1,10 @@
 # ino-menu
 
 A menu component that displays a list of choices on a temporary surface. It functions as a wrapper around the material [menu](https://github.com/material-components/material-components-web/blob/master/packages/mdc-menu/) component.
-The anchor element is the parent element.
+
+The anchor element is the parent element or the element found via the selector of the `ino-for` property passed in.
+
+The `ino-list-item` (and `ino-list-divider`) component is used for the rendering of the menu items.
 
 ### Usage
 

--- a/packages/elements/src/components/ino-menu/readme.md
+++ b/packages/elements/src/components/ino-menu/readme.md
@@ -97,6 +97,13 @@ The menu creates a temporary surface with an empty list composer. The items of t
 | `inoOpen` | `ino-open` | Set this option to show the menu. | `boolean` | `false`     |
 
 
+## Events
+
+| Event       | Description         | Type                |
+| ----------- | ------------------- | ------------------- |
+| `menuClose` | Emits on any click. | `CustomEvent<void>` |
+
+
 ## Dependencies
 
 ### Depends on

--- a/packages/elements/src/util/e2etests-setup.ts
+++ b/packages/elements/src/util/e2etests-setup.ts
@@ -1,7 +1,14 @@
 import { newE2EPage } from '@stencil/core/testing';
 
+/**
+ * Helper function to create a new E2E page with the given content.
+ * Waits for the page to load before resolving.
+ * @param content HTML content to create the page from (e.g. `<ino-button>My Button</ino-button>`)
+ */
 export async function setupPageWithContent(content: string) {
   const page = await newE2EPage();
   await page.setContent(content);
+  await page.waitForChanges();
+
   return page;
 }

--- a/packages/storybook/src/stories/ino-menu/ino-menu.stories.js
+++ b/packages/storybook/src/stories/ino-menu/ino-menu.stories.js
@@ -5,32 +5,46 @@ import withStencilReadme from '_local-storybookcore/with-stencil-readme';
 import componentReadme from '_local-elements/src/components/ino-menu/readme.md';
 import './ino-menu.scss';
 
+const BTN_ID_CUSTOM_MENU = 'btn-custom-menu';
+const BTN_ID_DIVIDED_MENU = 'btn-divided-menu';
+
+const ID_CUSTOM_MENU = 'custom-menu';
+const ID_DIVIDED_MENU = 'divided-menu';
+
 function subscribeToComponentEvents() {
   // == event block
   const eventHandler = function (e) {
-    const innerText = e.target.innerText;
+    const targetId = e.target.id;
 
-    if (!innerText.startsWith('OPEN')) {
+    if (targetId !== BTN_ID_CUSTOM_MENU && targetId !== BTN_ID_DIVIDED_MENU) {
       return;
     }
 
-    const clickedMenuId =
-      innerText === 'OPEN MENU' ? 'custom-menu' : 'custom-menu-2';
-    const el = document.getElementById(clickedMenuId);
+    const menuEl = document.getElementById(
+      targetId === BTN_ID_CUSTOM_MENU ?
+        ID_CUSTOM_MENU : ID_DIVIDED_MENU
+    );
 
-    if (!el) {
-      return;
-    }
+    if (!menuEl) return;
 
-    const isMenuOpen = el.getAttribute('ino-open');
-    el.setAttribute('ino-open', isMenuOpen === 'false' ? 'true' : 'false');
+    const isMenuOpen = menuEl.getAttribute('ino-open');
+    menuEl.setAttribute(
+      'ino-open',
+      isMenuOpen === 'false' ? 'true' : 'false'
+    );
   };
 
+  function closeHandler(evt) {
+    evt.target.setAttribute('ino-open', 'false');
+  }
+
   document.addEventListener('click', eventHandler);
+  document.addEventListener('menuClose', closeHandler)
 
   // unsubscribe function will be called by Storybook
   return () => {
     document.removeEventListener('click', eventHandler);
+    document.removeEventListener('menuClose', closeHandler)
   };
 }
 
@@ -49,9 +63,9 @@ export default {
 export const DefaultUsage = () => /*html*/ `
     <div class="story-menu">
       <h4>Customizable Menu</h4>
-      <ino-button id="button-custom-menu">Open menu</ino-button>
+      <ino-button id="${BTN_ID_CUSTOM_MENU}">Open menu</ino-button>
       <ino-menu
-        id="custom-menu"
+        id="${ID_CUSTOM_MENU}"
         ino-for="button"
         ino-open="${boolean('ino-open', false)}"
       >
@@ -60,8 +74,8 @@ export const DefaultUsage = () => /*html*/ `
       </ino-menu>
 
       <h4>Variation with divider</h4>
-      <ino-button id="menu-2">Open divided menu</ino-button>
-      <ino-menu id="custom-menu-2" ino-for="menu-2" ino-open="${boolean(
+      <ino-button id="${BTN_ID_DIVIDED_MENU}">Open divided menu</ino-button>
+      <ino-menu id="${ID_DIVIDED_MENU}" ino-for="menu-2" ino-open="${boolean(
         'ino-open',
         false
       )}">

--- a/packages/storybook/src/stories/ino-menu/ino-menu.stories.js
+++ b/packages/storybook/src/stories/ino-menu/ino-menu.stories.js
@@ -69,8 +69,8 @@ export const DefaultUsage = () => /*html*/ `
         ino-for="button"
         ino-open="${boolean('ino-open', false)}"
       >
-        <ino-list-item ino-text="Item"></ino-list-item>
-        <ino-list-item ino-text="Item 2"></ino-list-item>
+        <ino-list-item tabindex="0" ino-text="Item"></ino-list-item>
+        <ino-list-item tabindex="0" ino-text="Item 2"></ino-list-item>
       </ino-menu>
 
       <h4>Variation with divider</h4>

--- a/packages/storybook/src/stories/ino-menu/ino-menu.stories.js
+++ b/packages/storybook/src/stories/ino-menu/ino-menu.stories.js
@@ -13,7 +13,7 @@ const ID_DIVIDED_MENU = 'divided-menu';
 
 function subscribeToComponentEvents() {
   // == event block
-  const eventHandler = function (e) {
+  const clickHandler = function (e) {
     const targetId = e.target.id;
 
     if (targetId !== BTN_ID_CUSTOM_MENU && targetId !== BTN_ID_DIVIDED_MENU) {
@@ -38,12 +38,12 @@ function subscribeToComponentEvents() {
     evt.target.setAttribute('ino-open', 'false');
   }
 
-  document.addEventListener('click', eventHandler);
+  document.addEventListener('click', clickHandler);
   document.addEventListener('menuClose', closeHandler)
 
   // unsubscribe function will be called by Storybook
   return () => {
-    document.removeEventListener('click', eventHandler);
+    document.removeEventListener('click', clickHandler);
     document.removeEventListener('menuClose', closeHandler)
   };
 }

--- a/packages/storybook/src/stories/ino-menu/ino-menu.stories.js
+++ b/packages/storybook/src/stories/ino-menu/ino-menu.stories.js
@@ -21,17 +21,13 @@ function subscribeToComponentEvents() {
     }
 
     const menuEl = document.getElementById(
-      targetId === BTN_ID_CUSTOM_MENU ?
-        ID_CUSTOM_MENU : ID_DIVIDED_MENU
+      targetId === BTN_ID_CUSTOM_MENU ? ID_CUSTOM_MENU : ID_DIVIDED_MENU
     );
 
     if (!menuEl) return;
 
     const isMenuOpen = menuEl.getAttribute('ino-open');
-    menuEl.setAttribute(
-      'ino-open',
-      isMenuOpen === 'false' ? 'true' : 'false'
-    );
+    menuEl.setAttribute('ino-open', isMenuOpen === 'false' ? 'true' : 'false');
   };
 
   function closeHandler(evt) {
@@ -39,12 +35,12 @@ function subscribeToComponentEvents() {
   }
 
   document.addEventListener('click', clickHandler);
-  document.addEventListener('menuClose', closeHandler)
+  document.addEventListener('menuClose', closeHandler);
 
   // unsubscribe function will be called by Storybook
   return () => {
     document.removeEventListener('click', clickHandler);
-    document.removeEventListener('menuClose', closeHandler)
+    document.removeEventListener('menuClose', closeHandler);
   };
 }
 
@@ -76,9 +72,9 @@ export const DefaultUsage = () => /*html*/ `
       <h4>Variation with divider</h4>
       <ino-button id="${BTN_ID_DIVIDED_MENU}">Open divided menu</ino-button>
       <ino-menu id="${ID_DIVIDED_MENU}" ino-for="menu-2" ino-open="${boolean(
-        'ino-open',
-        false
-      )}">
+  'ino-open',
+  false
+)}">
         <ino-list-item ino-text="Home"></ino-list-item>
         <ino-list-item ino-text="Projects"></ino-list-item>
         <ino-list-divider></ino-list-divider>


### PR DESCRIPTION
Closes #230 

## Proposed Changes

- Add new event `menuClose` which emits on any click
- Add tests for this new event
- Update wording in Storybook