### PR TITLE
fix(elements|ino-progress-bar): restore buffer dots

### DIFF
--- a/packages/elements/src/components/ino-progress-bar/ino-progress-bar.scss
+++ b/packages/elements/src/components/ino-progress-bar/ino-progress-bar.scss
@@ -10,17 +10,7 @@
    */
   --progress-bar--bar-color: #{colors.ino-color(primary)};
   --progress-bar--buffer-color: #{colors.ino-color(light, light)};
-}
 
-:host {
+  @include linear-progress.core-styles;
   @include linear-progress.bar-color(var(--progress-bar--bar-color));
-
-  .mdc-linear-progress {
-    .mdc-linear-progress__buffer {
-      background-color: var(--progress-bar--buffer-color);
-    }
-    .mdc-linear-progress__buffering-dots {
-      color: var(--progress-bar--buffer-color);
-    }
-  }
 }


### PR DESCRIPTION
Closes #177 

## Proposed Changes

- Fix progress bar styling and make use of provided mdc sass mixin 
- The styling of the buffer bar and dots should be configurable via the `buffer-color` mixin (`@include linear-progress.buffer-color((var(--progress-bar--buffer-color)));`), but it seems like this only styles the buffer bar correctly, but not the dots.