### PR TITLE
docs(storybook|ino-progress-bar): add customization options and examples

### DIFF
--- a/packages/elements/src/components/ino-progress-bar/ino-progress-bar.scss
+++ b/packages/elements/src/components/ino-progress-bar/ino-progress-bar.scss
@@ -5,8 +5,8 @@
 
 :host {
   /**
-   * @Prop --progress-bar--bar-color: Color of the progress bar
-   * @Prop --progress-bar--buffer-color: Color of the buffer and buffering dots
+   * @prop --progress-bar--bar-color: Color of the progress bar
+   * @prop --progress-bar--buffer-color: Color of the buffer and buffering dots
    */
   --progress-bar--bar-color: #{theme.color(primary)};
   --progress-bar--buffer-color: #{theme.color(light, light)};

--- a/packages/elements/src/components/ino-progress-bar/ino-progress-bar.scss
+++ b/packages/elements/src/components/ino-progress-bar/ino-progress-bar.scss
@@ -6,10 +6,8 @@
 :host {
   /**
    * @prop --progress-bar--bar-color: Color of the progress bar
-   * @prop --progress-bar--buffer-color: Color of the buffer and buffering dots
    */
   --progress-bar--bar-color: #{theme.color(primary)};
-  --progress-bar--buffer-color: #{theme.color(light, light)};
 
   @include linear-progress.core-styles;
   @include linear-progress.bar-color(var(--progress-bar--bar-color));

--- a/packages/elements/src/components/ino-progress-bar/readme.md
+++ b/packages/elements/src/components/ino-progress-bar/readme.md
@@ -56,6 +56,14 @@ class MyComponent extends Component {
 | `inoReversed`      | `ino-reversed`      | Reverses the progress bar                                              | `boolean` | `false`     |
 
 
+## CSS Custom Properties
+
+| Name                           | Description                            |
+| ------------------------------ | -------------------------------------- |
+| `--progress-bar--bar-color`    | Color of the progress bar              |
+| `--progress-bar--buffer-color` | Color of the buffer and buffering dots |
+
+
 ----------------------------------------------
 
 *Built with [StencilJS](https://stenciljs.com/)*

--- a/packages/elements/src/components/ino-progress-bar/readme.md
+++ b/packages/elements/src/components/ino-progress-bar/readme.md
@@ -58,10 +58,9 @@ class MyComponent extends Component {
 
 ## CSS Custom Properties
 
-| Name                           | Description                            |
-| ------------------------------ | -------------------------------------- |
-| `--progress-bar--bar-color`    | Color of the progress bar              |
-| `--progress-bar--buffer-color` | Color of the buffer and buffering dots |
+| Name                        | Description               |
+| --------------------------- | ------------------------- |
+| `--progress-bar--bar-color` | Color of the progress bar |
 
 
 ----------------------------------------------

--- a/packages/storybook/src/stories/ino-progress-bar/ino-progress-bar.stories.js
+++ b/packages/storybook/src/stories/ino-progress-bar/ino-progress-bar.stories.js
@@ -60,7 +60,7 @@ export default {
 };
 
 export const DefaultUsage = () => /* html */ `
-    <h4>Customizable ino-progress-bar</h4>
+    <h3>Customizable ino-progress-bar</h3>
     <ino-progress-bar
       ino-progress="${number('ino-progress', 0, {min: 0, max: 1, step: 0.1})}"
       ino-buffer="${number('ino-buffer', 0, {min: 0, max: 1, step: 0.1})}"
@@ -69,6 +69,7 @@ export const DefaultUsage = () => /* html */ `
       ino-reversed="${boolean('ino-reversed', false)}"
     >
     </ino-progress-bar>
+
 
     <h3>Example</h3>
     <div class="progress-bar-example">

--- a/packages/storybook/src/stories/ino-progress-bar/ino-progress-bar.stories.js
+++ b/packages/storybook/src/stories/ino-progress-bar/ino-progress-bar.stories.js
@@ -1,7 +1,7 @@
 import componentReadme from '_local-elements/src/components/ino-progress-bar/readme.md';
 import withStencilReadme from '_local-storybookcore/with-stencil-readme';
 import './ino-progress-bar.scss';
-import { boolean, number, text } from '@storybook/addon-knobs';
+import { boolean, color, number, text } from '@storybook/addon-knobs';
 
 function subscribeToComponentEvents() {
   // == event block
@@ -60,10 +60,21 @@ export default {
 };
 
 export const DefaultUsage = () => /* html */ `
+
+    <style>
+      ino-progress-bar.customizable-progress-bar {
+        --progress-bar--bar-color: ${color(
+      '--progress-bar--bar-color',
+      '#3d40f5',
+        )};
+      }
+    </style>
+
     <h3>Customizable ino-progress-bar</h3>
     <ino-progress-bar
-      ino-progress="${number('ino-progress', 0, {min: 0, max: 1, step: 0.1})}"
-      ino-buffer="${number('ino-buffer', 0, {min: 0, max: 1, step: 0.1})}"
+      class="customizable-progress-bar"
+      ino-progress="${number('ino-progress', 0.5, {min: 0, max: 1, step: 0.1})}"
+      ino-buffer="${number('ino-buffer', 0.2, {min: 0, max: 1, step: 0.1})}"
       ino-label="${text('ino-label', 'My Label')}"
       ino-indeterminate="${boolean('ino-indeterminate', false)}"
       ino-reversed="${boolean('ino-reversed', false)}"

--- a/packages/storybook/src/stories/ino-progress-bar/ino-progress-bar.stories.js
+++ b/packages/storybook/src/stories/ino-progress-bar/ino-progress-bar.stories.js
@@ -1,6 +1,7 @@
 import componentReadme from '_local-elements/src/components/ino-progress-bar/readme.md';
 import withStencilReadme from '_local-storybookcore/with-stencil-readme';
 import './ino-progress-bar.scss';
+import { boolean, number, text } from '@storybook/addon-knobs';
 
 function subscribeToComponentEvents() {
   // == event block
@@ -59,14 +60,24 @@ export default {
 };
 
 export const DefaultUsage = () => /* html */ `
-
-    <h4>With custom max and min values</h4>
-    <ino-progress-bar ino-progress="9"></ino-progress-bar>
-
+    <h4>Customizable ino-progress-bar</h4>
+    <ino-progress-bar
+      ino-progress="${number('ino-progress', 0, {min: 0, max: 1, step: 0.1})}"
+      ino-buffer="${number('ino-buffer', 0, {min: 0, max: 1, step: 0.1})}"
+      ino-label="${text('ino-label', 'My Label')}"
+      ino-indeterminate="${boolean('ino-indeterminate', false)}"
+      ino-reversed="${boolean('ino-reversed', false)}"
+    >
+    </ino-progress-bar>
 
     <h3>Example</h3>
     <div class="progress-bar-example">
-        <ino-progress-bar ino-progress="0" ino-buffer="1" id="example"></ino-progress-bar>
+        <ino-progress-bar
+          id="example"
+          ino-progress="0"
+          ino-buffer="1"
+        >
+        </ino-progress-bar>
         <ino-input-file ino-label="Upload" multiple></ino-input-file>
     </div>
 


### PR DESCRIPTION
Closes #264 

## Proposed Changes

- Add knobs to test properties
- Restore CSS-Var Table
- Remove CSS-Var to color `buffer-dots` because CSS-Vars are not compatible with the mixin provided by MDC