### PR TITLE
feat(elements|ino-nav-item): add prop for sub text

### DIFF
--- a/packages/elements-angular/elements/src/directives/proxies.ts
+++ b/packages/elements-angular/elements/src/directives/proxies.ts
@@ -564,13 +564,13 @@ export class InoNavDrawer {
 
 export declare interface InoNavItem extends Components.InoNavItem {}
 @ProxyCmp({
-  inputs: ['inoActivated', 'inoDisabled', 'inoText']
+  inputs: ['inoActivated', 'inoDisabled', 'inoSecondaryText', 'inoText']
 })
 @Component({
   selector: 'ino-nav-item',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
-  inputs: ['inoActivated', 'inoDisabled', 'inoText']
+  inputs: ['inoActivated', 'inoDisabled', 'inoSecondaryText', 'inoText']
 })
 export class InoNavItem {
   protected el: HTMLElement;

--- a/packages/elements-angular/elements/src/directives/proxies.ts
+++ b/packages/elements-angular/elements/src/directives/proxies.ts
@@ -564,13 +564,13 @@ export class InoNavDrawer {
 
 export declare interface InoNavItem extends Components.InoNavItem {}
 @ProxyCmp({
-  inputs: ['inoActivated', 'inoDisabled', 'inoSecondaryText', 'inoText']
+  inputs: ['inoActivated', 'inoDisabled', 'inoSubText', 'inoText']
 })
 @Component({
   selector: 'ino-nav-item',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
-  inputs: ['inoActivated', 'inoDisabled', 'inoSecondaryText', 'inoText']
+  inputs: ['inoActivated', 'inoDisabled', 'inoSubText', 'inoText']
 })
 export class InoNavItem {
   protected el: HTMLElement;

--- a/packages/elements/src/components.d.ts
+++ b/packages/elements/src/components.d.ts
@@ -775,13 +775,17 @@ export namespace Components {
     }
     interface InoNavItem {
         /**
-          * Styles the row in an activated style.  Use this for only one item and to mark it as permantently activated.
+          * Styles the row in an activated style.  Use this for only one item and to mark it as permanently activated.
          */
         "inoActivated"?: boolean;
         /**
           * Styles the row in a disabled style.
          */
         "inoDisabled"?: boolean;
+        /**
+          * The secondary text of this list item used in a two-lined list.
+         */
+        "inoSecondaryText"?: string;
         /**
           * The text of this list item.
          */
@@ -2346,13 +2350,17 @@ declare namespace LocalJSX {
     }
     interface InoNavItem {
         /**
-          * Styles the row in an activated style.  Use this for only one item and to mark it as permantently activated.
+          * Styles the row in an activated style.  Use this for only one item and to mark it as permanently activated.
          */
         "inoActivated"?: boolean;
         /**
           * Styles the row in a disabled style.
          */
         "inoDisabled"?: boolean;
+        /**
+          * The secondary text of this list item used in a two-lined list.
+         */
+        "inoSecondaryText"?: string;
         /**
           * The text of this list item.
          */

--- a/packages/elements/src/components.d.ts
+++ b/packages/elements/src/components.d.ts
@@ -785,7 +785,7 @@ export namespace Components {
         /**
           * The secondary text of this list item used in a two-lined list.
          */
-        "inoSecondaryText"?: string;
+        "inoSubText"?: string;
         /**
           * The text of this list item.
          */
@@ -2360,7 +2360,7 @@ declare namespace LocalJSX {
         /**
           * The secondary text of this list item used in a two-lined list.
          */
-        "inoSecondaryText"?: string;
+        "inoSubText"?: string;
         /**
           * The text of this list item.
          */

--- a/packages/elements/src/components/ino-nav-item/ino-nav-item.scss
+++ b/packages/elements/src/components/ino-nav-item/ino-nav-item.scss
@@ -23,6 +23,10 @@ ino-nav-item  {
     color: var(--nav-item-color);
     font-size: 14px;
 
+    .mdc-list-item__secondary-text {
+      font-size: 12px;
+    }
+
     // icon
     ::slotted(ino-icon), ino-icon, .ino-list-item__icon {
       --icon-width: 24px;

--- a/packages/elements/src/components/ino-nav-item/ino-nav-item.scss
+++ b/packages/elements/src/components/ino-nav-item/ino-nav-item.scss
@@ -18,7 +18,6 @@ ino-nav-item  {
   .mdc-list-item, ino-list-item .mdc-list-item {
 
     padding: 0px 24px;
-    height: 60px;
     background-color: var(--nav-item-background-color);
     color: var(--nav-item-color);
     font-size: 14px;

--- a/packages/elements/src/components/ino-nav-item/ino-nav-item.scss
+++ b/packages/elements/src/components/ino-nav-item/ino-nav-item.scss
@@ -18,6 +18,7 @@ ino-nav-item  {
   .mdc-list-item, ino-list-item .mdc-list-item {
 
     padding: 0px 24px;
+    height: 60px;
     background-color: var(--nav-item-background-color);
     color: var(--nav-item-color);
     font-size: 14px;

--- a/packages/elements/src/components/ino-nav-item/ino-nav-item.tsx
+++ b/packages/elements/src/components/ino-nav-item/ino-nav-item.tsx
@@ -21,10 +21,15 @@ export class NavItem implements ComponentInterface {
   @Prop() inoText?: string;
 
   /**
+   * The secondary text of this list item used in a two-lined list.
+   */
+  @Prop() inoSecondaryText?: string;
+
+  /**
    * Styles the row in an activated style.
    *
    * Use this for only one item
-   * and to mark it as permantently activated.
+   * and to mark it as permanently activated.
    */
   @Prop() inoActivated?: boolean = false;
 
@@ -33,10 +38,6 @@ export class NavItem implements ComponentInterface {
    */
   @Prop() inoDisabled?: boolean = false;
 
-  disconnectedCallback() {
-    this.el.remove();
-  }
-
   render() {
     const slotPosition = this.el.children.length > 0 ? 'ino-leading' : '';
 
@@ -44,6 +45,7 @@ export class NavItem implements ComponentInterface {
       <Host>
         <ino-list-item
           inoText={this.inoText}
+          inoSecondaryText={this.inoSecondaryText}
           inoActivated={this.inoActivated}
           inoDisabled={this.inoDisabled}
         >

--- a/packages/elements/src/components/ino-nav-item/ino-nav-item.tsx
+++ b/packages/elements/src/components/ino-nav-item/ino-nav-item.tsx
@@ -4,13 +4,13 @@ import {
   Element,
   Prop,
   Host,
-  h
+  h,
 } from '@stencil/core';
 
 @Component({
   tag: 'ino-nav-item',
   styleUrl: 'ino-nav-item.scss',
-  shadow: false
+  shadow: false,
 })
 export class NavItem implements ComponentInterface {
   @Element() el!: HTMLElement;
@@ -23,7 +23,7 @@ export class NavItem implements ComponentInterface {
   /**
    * The secondary text of this list item used in a two-lined list.
    */
-  @Prop() inoSecondaryText?: string;
+  @Prop() inoSubText?: string;
 
   /**
    * Styles the row in an activated style.
@@ -45,7 +45,7 @@ export class NavItem implements ComponentInterface {
       <Host>
         <ino-list-item
           inoText={this.inoText}
-          inoSecondaryText={this.inoSecondaryText}
+          inoSecondaryText={this.inoSubText}
           inoActivated={this.inoActivated}
           inoDisabled={this.inoDisabled}
         >

--- a/packages/elements/src/components/ino-nav-item/readme.md
+++ b/packages/elements/src/components/ino-nav-item/readme.md
@@ -38,12 +38,12 @@ document
 
 ## Properties
 
-| Property           | Attribute            | Description                                                                                                | Type      | Default     |
-| ------------------ | -------------------- | ---------------------------------------------------------------------------------------------------------- | --------- | ----------- |
-| `inoActivated`     | `ino-activated`      | Styles the row in an activated style.  Use this for only one item and to mark it as permanently activated. | `boolean` | `false`     |
-| `inoDisabled`      | `ino-disabled`       | Styles the row in a disabled style.                                                                        | `boolean` | `false`     |
-| `inoSecondaryText` | `ino-secondary-text` | The secondary text of this list item used in a two-lined list.                                             | `string`  | `undefined` |
-| `inoText`          | `ino-text`           | The text of this list item.                                                                                | `string`  | `undefined` |
+| Property       | Attribute       | Description                                                                                                | Type      | Default     |
+| -------------- | --------------- | ---------------------------------------------------------------------------------------------------------- | --------- | ----------- |
+| `inoActivated` | `ino-activated` | Styles the row in an activated style.  Use this for only one item and to mark it as permanently activated. | `boolean` | `false`     |
+| `inoDisabled`  | `ino-disabled`  | Styles the row in a disabled style.                                                                        | `boolean` | `false`     |
+| `inoSubText`   | `ino-sub-text`  | The secondary text of this list item used in a two-lined list.                                             | `string`  | `undefined` |
+| `inoText`      | `ino-text`      | The text of this list item.                                                                                | `string`  | `undefined` |
 
 
 ## CSS Custom Properties

--- a/packages/elements/src/components/ino-nav-item/readme.md
+++ b/packages/elements/src/components/ino-nav-item/readme.md
@@ -38,11 +38,12 @@ document
 
 ## Properties
 
-| Property       | Attribute       | Description                                                                                                 | Type      | Default     |
-| -------------- | --------------- | ----------------------------------------------------------------------------------------------------------- | --------- | ----------- |
-| `inoActivated` | `ino-activated` | Styles the row in an activated style.  Use this for only one item and to mark it as permantently activated. | `boolean` | `false`     |
-| `inoDisabled`  | `ino-disabled`  | Styles the row in a disabled style.                                                                         | `boolean` | `false`     |
-| `inoText`      | `ino-text`      | The text of this list item.                                                                                 | `string`  | `undefined` |
+| Property           | Attribute            | Description                                                                                                | Type      | Default     |
+| ------------------ | -------------------- | ---------------------------------------------------------------------------------------------------------- | --------- | ----------- |
+| `inoActivated`     | `ino-activated`      | Styles the row in an activated style.  Use this for only one item and to mark it as permanently activated. | `boolean` | `false`     |
+| `inoDisabled`      | `ino-disabled`       | Styles the row in a disabled style.                                                                        | `boolean` | `false`     |
+| `inoSecondaryText` | `ino-secondary-text` | The secondary text of this list item used in a two-lined list.                                             | `string`  | `undefined` |
+| `inoText`          | `ino-text`           | The text of this list item.                                                                                | `string`  | `undefined` |
 
 
 ## CSS Custom Properties

--- a/packages/storybook/src/stories/ino-list/ino-list.stories.js
+++ b/packages/storybook/src/stories/ino-list/ino-list.stories.js
@@ -613,8 +613,8 @@ export const NavItem = () => /*html*/ `
 
   <h4>Two Lines</h4>
   <ino-list ino-two-lines="true">
-    <ino-nav-item ino-text="Simple item" ino-secondary-text="Secondary Text"></ino-nav-item>
-    <ino-nav-item ino-text="Simple item 2" ino-secondary-text="Secondary Text 2"></ino-nav-item>
+    <ino-nav-item ino-text="Simple item" ino-sub-text="Secondary Text"></ino-nav-item>
+    <ino-nav-item ino-text="Simple item 2" ino-sub-text="Secondary Text 2"></ino-nav-item>
   </ino-list>
 
   <h4>Graphic</h4>

--- a/packages/storybook/src/stories/ino-list/ino-list.stories.js
+++ b/packages/storybook/src/stories/ino-list/ino-list.stories.js
@@ -611,6 +611,12 @@ export const NavItem = () => /*html*/ `
     <ino-nav-item ino-disabled ino-text="Disabled item"></ino-nav-item>
   </ino-list>
 
+  <h4>Two Lines</h4>
+  <ino-list ino-two-lines="true">
+    <ino-nav-item ino-text="Simple item" ino-secondary-text="Secondary Text"></ino-nav-item>
+    <ino-nav-item ino-text="Simple item 2" ino-secondary-text="Secondary Text 2"></ino-nav-item>
+  </ino-list>
+
   <h4>Graphic</h4>
   <ino-list>
     <ino-nav-item ino-text="Lorem ipsum dolor sit">


### PR DESCRIPTION
Adds a secondary text prop analogous to the ino-list-item