### PR TITLE
style(elements|ino-button): inherit width

### DIFF
--- a/packages/elements-angular/elements/src/directives/proxies.ts
+++ b/packages/elements-angular/elements/src/directives/proxies.ts
@@ -8,13 +8,13 @@ import { Components } from '@inovex.de/elements';
 
 export declare interface InoButton extends Components.InoButton {}
 @ProxyCmp({
-  inputs: ['autoFocus', 'disabled', 'form', 'inoColorScheme', 'inoDense', 'inoEdgeMirrored', 'inoFill', 'inoFullWidth', 'inoLoading', 'name', 'type']
+  inputs: ['autoFocus', 'disabled', 'form', 'inoColorScheme', 'inoDense', 'inoEdgeMirrored', 'inoFill', 'inoLoading', 'name', 'type']
 })
 @Component({
   selector: 'ino-button',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
-  inputs: ['autoFocus', 'disabled', 'form', 'inoColorScheme', 'inoDense', 'inoEdgeMirrored', 'inoFill', 'inoFullWidth', 'inoLoading', 'name', 'type']
+  inputs: ['autoFocus', 'disabled', 'form', 'inoColorScheme', 'inoDense', 'inoEdgeMirrored', 'inoFill', 'inoLoading', 'name', 'type']
 })
 export class InoButton {
   protected el: HTMLElement;

--- a/packages/elements/src/components.d.ts
+++ b/packages/elements/src/components.d.ts
@@ -38,10 +38,6 @@ export namespace Components {
          */
         "inoFill"?: SurfaceType;
         /**
-          * Styles the button in 100% width.
-         */
-        "inoFullWidth"?: boolean;
-        /**
           * Shows an infinite loading spinner and prevents further clicks.
          */
         "inoLoading"?: boolean;
@@ -1540,10 +1536,6 @@ declare namespace LocalJSX {
           * The fill type of this element. Possible values: `solid` (default), `outline`, `inverse`.
          */
         "inoFill"?: SurfaceType;
-        /**
-          * Styles the button in 100% width.
-         */
-        "inoFullWidth"?: boolean;
         /**
           * Shows an infinite loading spinner and prevents further clicks.
          */

--- a/packages/elements/src/components/ino-button/ino-button.scss
+++ b/packages/elements/src/components/ino-button/ino-button.scss
@@ -207,6 +207,8 @@ $color-states: (
 
 :host {
   .mdc-button {
+    width: inherit;
+
     // MDC mixins
     @include button.horizontal-padding(20px);
     @include button.outline-width(2px);
@@ -309,9 +311,4 @@ $color-states: (
     top: 2px;
     @include spinner.circle-color(var(--button-color));
   }
-}
-
-// Full Width Styles
-:host([ino-full-width]:not([ino-full-width='false'])) .mdc-button {
-  width: 100%;
 }

--- a/packages/elements/src/components/ino-button/ino-button.tsx
+++ b/packages/elements/src/components/ino-button/ino-button.tsx
@@ -76,11 +76,6 @@ export class Button implements ComponentInterface {
   @Prop() inoFill?: SurfaceType = 'solid';
 
   /**
-   * Styles the button in 100% width.
-   */
-  @Prop() inoFullWidth? = false;
-
-  /**
    * Makes the button text and container slightly smaller.
    */
   @Prop() inoDense?: boolean = false;

--- a/packages/elements/src/components/ino-button/readme.md
+++ b/packages/elements/src/components/ino-button/readme.md
@@ -23,8 +23,6 @@ document
   type="<string>"
   ino-color-scheme="<string>"
   ino-fill="<string>"
-  ino-icon-leading
-  ino-icon-trailing
   ino-dense
   onClick="handleClick()"
 >
@@ -105,7 +103,6 @@ class MyComponent extends Component {
 | `inoDense`        | `ino-dense`         | Makes the button text and container slightly smaller.                                                                                                                                                                                                     | `boolean`                                       | `false`     |
 | `inoEdgeMirrored` | `ino-edge-mirrored` | Styles the button to have the edge on the top-right instead of the top-left                                                                                                                                                                               | `boolean`                                       | `false`     |
 | `inoFill`         | `ino-fill`          | The fill type of this element. Possible values: `solid` (default), `outline`, `inverse`.                                                                                                                                                                  | `"inverse" \| "outline" \| "solid"`             | `'solid'`   |
-| `inoFullWidth`    | `ino-full-width`    | Styles the button in 100% width.                                                                                                                                                                                                                          | `boolean`                                       | `false`     |
 | `inoLoading`      | `ino-loading`       | Shows an infinite loading spinner and prevents further clicks.                                                                                                                                                                                            | `boolean`                                       | `undefined` |
 | `name`            | `name`              | The name of the element.                                                                                                                                                                                                                                  | `string`                                        | `undefined` |
 | `type`            | `type`              | The type of this form.  Can either be `button`, `submit` or `reset`.                                                                                                                                                                                      | `"button" \| "reset" \| "submit"`               | `'button'`  |

--- a/packages/storybook/src/stories/ino-button/ino-button.scss
+++ b/packages/storybook/src/stories/ino-button/ino-button.scss
@@ -1,6 +1,7 @@
 .story-button {
   ino-button {
     margin: 0 12px 12px 0;
+
     &.customizable-button {
       margin-bottom: 32px;
     }
@@ -20,5 +21,12 @@
       flex: 1;
       margin: 0 12px 12px 0;
     }
+  }
+
+  .white-button {
+    background-color: blue;
+    height: 100%;
+    width: min-content;
+    padding: 5px;
   }
 }

--- a/packages/storybook/src/stories/ino-button/ino-button.stories.js
+++ b/packages/storybook/src/stories/ino-button/ino-button.stories.js
@@ -100,7 +100,6 @@ export const DefaultUsage = () => /* html */ `
           'General'
         )}"
         ino-dense="${boolean('ino-dense', false, 'General')}"
-        ino-full-width="${boolean('ino-full-width', false, 'General')}"
         disabled="${boolean('disabled', false, 'General')}"
         ino-loading="${boolean('ino-loading', false, 'General')}"
         ino-edge-mirrored="${boolean('ino-edge-mirrored', false, 'General')}"
@@ -121,8 +120,8 @@ export const DefaultUsage = () => /* html */ `
       </div>
       <div class="button-row">
         <ino-button ino-fill="outline" ino-color-scheme="grey">Outline Grey</ino-button>
-        <div style="background-color: blue; height: 100%; padding: 5px;">
-            <ino-button style="width: 50%; margin: 0 auto;" ino-fill="outline" ino-color-scheme="white">Outline White</ino-button>
+        <div class="white-button">
+            <ino-button ino-fill="outline" ino-color-scheme="white">Outline White</ino-button>
         </div>
       </div>
 
@@ -145,7 +144,6 @@ export const DefaultUsage = () => /* html */ `
         <ino-button ino-loading="true">Loading button</ino-button>
         <ino-button ino-loading="true" ino-fill="outline">Loading button</ino-button>
        </div>
-       <ino-button ino-full-width>Full Width Button</ino-button>
     </div>
   `;
 


### PR DESCRIPTION
Closes #251 

## Proposed Changes

- Remove property `ino-full-width` of `<ino-button>`
- Inherit width on button element
