### PR TITLE
style(elements|ino-menu): inherit border-radius

### DIFF
--- a/packages/elements/src/components/ino-menu/ino-menu.scss
+++ b/packages/elements/src/components/ino-menu/ino-menu.scss
@@ -4,6 +4,7 @@
 
 ino-menu {
   display: block;
+  border-radius: 4px;
 
   .mdc-menu-surface--anchor {
     border-radius: inherit;

--- a/packages/elements/src/components/ino-menu/ino-menu.scss
+++ b/packages/elements/src/components/ino-menu/ino-menu.scss
@@ -4,7 +4,6 @@
 
 ino-menu {
   display: block;
-  border-radius: 4px;
 
   .mdc-menu-surface--anchor {
     border-radius: inherit;

--- a/packages/elements/src/components/ino-menu/ino-menu.scss
+++ b/packages/elements/src/components/ino-menu/ino-menu.scss
@@ -4,4 +4,13 @@
 
 ino-menu {
   display: block;
+  border-radius: 4px;
+
+  .mdc-menu-surface--anchor {
+    border-radius: inherit;
+
+    .mdc-menu.mdc-menu-surface {
+      border-radius: inherit;
+    }
+  }
 }

--- a/packages/storybook/src/stories/ino-menu/ino-menu.scss
+++ b/packages/storybook/src/stories/ino-menu/ino-menu.scss
@@ -2,4 +2,8 @@
   h4:not(:first-child) {
     margin-top: 48px;
   }
+
+  ino-menu {
+    border-radius: 4px;
+  }
 }

--- a/packages/storybook/src/stories/ino-menu/ino-menu.scss
+++ b/packages/storybook/src/stories/ino-menu/ino-menu.scss
@@ -2,8 +2,4 @@
   h4:not(:first-child) {
     margin-top: 48px;
   }
-
-  ino-menu {
-    border-radius: 4px;
-  }
 }


### PR DESCRIPTION
⚙️ **Changes:**
* adjusted the `border-radius` property of the `mdc-menu` class to inherit its value from `ino-menu`

🎟️ **Closes #231**