### PR TITLE
feat(elements-angular|ino-textarea): handle onTouched in TextValueAccessor

### DIFF
--- a/packages/elements-angular/elements/src/directives/control-value-accesors/text-value-accessor.directive.ts
+++ b/packages/elements-angular/elements/src/directives/control-value-accesors/text-value-accessor.directive.ts
@@ -23,4 +23,9 @@ export class TextValueAccessorDirective extends ValueAccessorDirective {
   _handleInputEvent(value: string) {
     this.handleChangeEvent(value);
   }
+
+  @HostListener('inoBlur')
+  _handleInoBlur() {
+    this.handleBlurEvent();
+  }
 }

--- a/packages/elements-angular/elements/src/directives/control-value-accesors/value-accessor.directive.ts
+++ b/packages/elements-angular/elements/src/directives/control-value-accesors/value-accessor.directive.ts
@@ -24,6 +24,10 @@ export class ValueAccessorDirective implements ControlValueAccessor {
     }
   }
 
+  handleBlurEvent() {
+    this.onTouched();
+  }
+
   registerOnChange(fn: (value: any) => void) {
     this.onChange = fn;
   }

--- a/packages/elements-angular/elements/src/directives/proxies.ts
+++ b/packages/elements-angular/elements/src/directives/proxies.ts
@@ -996,16 +996,18 @@ export declare interface InoTextarea extends Components.InoTextarea {}
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
   inputs: ['autoFocus', 'autogrow', 'cols', 'disabled', 'inoLabel', 'inoOutline', 'inoShowLabelHint', 'maxlength', 'minlength', 'name', 'placeholder', 'required', 'rows', 'showCharacterCounter', 'value'],
-  outputs: ['valueChange']
+  outputs: ['inoBlur', 'valueChange']
 })
 export class InoTextarea {
+  /** Emits when the textarea is blurred and validates email input */
+  inoBlur!: ITextarea['inoBlur'];
   /** Emits when the user types something in. Contains typed input in `event.detail` */
   valueChange!: ITextarea['valueChange'];
   protected el: HTMLElement;
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
     this.el = r.nativeElement;
-    proxyOutputs(this, this.el, ['valueChange']);
+    proxyOutputs(this, this.el, ['inoBlur', 'valueChange']);
   }
 }
 

--- a/packages/elements/src/components.d.ts
+++ b/packages/elements/src/components.d.ts
@@ -2710,6 +2710,10 @@ declare namespace LocalJSX {
          */
         "name"?: string;
         /**
+          * Emits when the textarea is blurred and validates email input
+         */
+        "onInoBlur"?: (event: CustomEvent<void>) => void;
+        /**
           * Emits when the user types something in. Contains typed input in `event.detail`
          */
         "onValueChange"?: (event: CustomEvent<string>) => void;

--- a/packages/elements/src/components/ino-textarea/ino-textarea.tsx
+++ b/packages/elements/src/components/ino-textarea/ino-textarea.tsx
@@ -118,6 +118,14 @@ export class Textarea implements ComponentInterface {
    */
   @Prop() inoLabel?: string;
 
+  /**
+   * Emits when the textarea is blurred and validates email input
+   */
+  @Event({ bubbles: false }) inoBlur!: EventEmitter<void>;
+  private handleBlur = (e) => {
+    this.inoBlur.emit(e);
+  };
+
   @Watch('value')
   handleChange(value: string) {
     if (this.nativeTextareaElement && this.textfield) {
@@ -224,6 +232,7 @@ export class Textarea implements ComponentInterface {
             rows={this.rows}
             value={this.value}
             onInput={this.handleNativeTextareaChange.bind(this)}
+            onBlur={this.handleBlur}
           />
           {this.maxlength && (
             <div class="mdc-text-field-character-counter">

--- a/packages/elements/src/components/ino-textarea/readme.md
+++ b/packages/elements/src/components/ino-textarea/readme.md
@@ -136,6 +136,15 @@ The component is based on a native input with additional features. Thus, the com
 | `valueChange` | Emits when the user types something in. Contains typed input in `event.detail` | `CustomEvent<string>` |
 
 
+## CSS Custom Properties
+
+| Name                           | Description                   |
+| ------------------------------ | ----------------------------- |
+| `--ino-textarea-caret-color`   | color of the caret            |
+| `--ino-textarea-label-color`   | color of the label            |
+| `--ino-textarea-outline-color` | outline color of the textarea |
+
+
 ## Dependencies
 
 ### Depends on

--- a/packages/elements/src/components/ino-textarea/readme.md
+++ b/packages/elements/src/components/ino-textarea/readme.md
@@ -132,16 +132,8 @@ The component is based on a native input with additional features. Thus, the com
 
 | Event         | Description                                                                    | Type                  |
 | ------------- | ------------------------------------------------------------------------------ | --------------------- |
+| `inoBlur`     | Emits when the textarea is blurred and validates email input                   | `CustomEvent<void>`   |
 | `valueChange` | Emits when the user types something in. Contains typed input in `event.detail` | `CustomEvent<string>` |
-
-
-## CSS Custom Properties
-
-| Name                           | Description                   |
-| ------------------------------ | ----------------------------- |
-| `--ino-textarea-caret-color`   | color of the caret            |
-| `--ino-textarea-label-color`   | color of the label            |
-| `--ino-textarea-outline-color` | outline color of the textarea |
 
 
 ## Dependencies


### PR DESCRIPTION
## Proposed Changes

- add `inoBlur` event to `ino-textarea`
- handle `inoBlur` event in `TextValueAccessorDirective` to mark form input and textarea fields as `touched` in combination with angular forms
