### PR TITLE
feat(elements|ino-popover): add property to manually show/hide

### DIFF
--- a/packages/elements-angular/elements/src/directives/proxies.ts
+++ b/packages/elements-angular/elements/src/directives/proxies.ts
@@ -633,16 +633,17 @@ export declare interface InoPopover extends Components.InoPopover {}
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
   inputs: ['inoColorScheme', 'inoFor', 'inoInteractive', 'inoPlacement', 'inoShow', 'inoTrigger'],
-  outputs: ['visibilityChanged']
+  outputs: ['clickOutside']
 })
 export class InoPopover {
-  /** Emits the visibility of the popover on change (true if shown, false if hidden). */
-  visibilityChanged!: IPopover['visibilityChanged'];
+  /** Emits when an element which is not part of the popover is clicked.
+Should be used if you control the state of the popover. */
+  clickOutside!: IPopover['clickOutside'];
   protected el: HTMLElement;
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
     this.el = r.nativeElement;
-    proxyOutputs(this, this.el, ['visibilityChanged']);
+    proxyOutputs(this, this.el, ['clickOutside']);
   }
 }
 

--- a/packages/elements-angular/elements/src/directives/proxies.ts
+++ b/packages/elements-angular/elements/src/directives/proxies.ts
@@ -622,23 +622,27 @@ export class InoOptionGroup {
   }
 }
 
-
+import { Popover as IPopover } from '@inovex.de/elements/dist/types/components/ino-popover/ino-popover';
 export declare interface InoPopover extends Components.InoPopover {}
 @ProxyCmp({
-  inputs: ['inoColorScheme', 'inoFor', 'inoInteractive', 'inoPlacement', 'inoTrigger'],
+  inputs: ['inoColorScheme', 'inoFor', 'inoInteractive', 'inoPlacement', 'inoShow', 'inoTrigger'],
   methods: ['getTippyInstance']
 })
 @Component({
   selector: 'ino-popover',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
-  inputs: ['inoColorScheme', 'inoFor', 'inoInteractive', 'inoPlacement', 'inoTrigger']
+  inputs: ['inoColorScheme', 'inoFor', 'inoInteractive', 'inoPlacement', 'inoShow', 'inoTrigger'],
+  outputs: ['visibilityChanged']
 })
 export class InoPopover {
+  /** Emits the visibility of the popover on change (true if shown, false if hidden). */
+  visibilityChanged!: IPopover['visibilityChanged'];
   protected el: HTMLElement;
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
     this.el = r.nativeElement;
+    proxyOutputs(this, this.el, ['visibilityChanged']);
   }
 }
 

--- a/packages/elements/src/components.d.ts
+++ b/packages/elements/src/components.d.ts
@@ -2374,9 +2374,9 @@ declare namespace LocalJSX {
          */
         "inoTrigger"?: Exclude<TooltipTrigger, 'manual'>;
         /**
-          * Emits the visibility of the popover on change (true if shown, false if hidden).
+          * Emits when an element which is not part of the popover is clicked. Should be used if you control the state of the popover.
          */
-        "onVisibilityChanged"?: (event: CustomEvent<boolean>) => void;
+        "onClickOutside"?: (event: CustomEvent<void>) => void;
     }
     interface InoProgressBar {
         /**

--- a/packages/elements/src/components.d.ts
+++ b/packages/elements/src/components.d.ts
@@ -810,9 +810,13 @@ export namespace Components {
          */
         "inoPlacement": Placement;
         /**
+          * Programmatically show or hide the popover. Using this property disables the functionality of the `inoTrigger` prop.
+         */
+        "inoShow"?: boolean;
+        /**
           * The trigger to show the tooltip - either click, hover or focus. Multiple triggers are possible by separating them with a space.
          */
-        "inoTrigger": TooltipTrigger;
+        "inoTrigger": Exclude<TooltipTrigger, 'manual'>;
     }
     interface InoProgressBar {
         /**
@@ -2362,9 +2366,17 @@ declare namespace LocalJSX {
          */
         "inoPlacement"?: Placement;
         /**
+          * Programmatically show or hide the popover. Using this property disables the functionality of the `inoTrigger` prop.
+         */
+        "inoShow"?: boolean;
+        /**
           * The trigger to show the tooltip - either click, hover or focus. Multiple triggers are possible by separating them with a space.
          */
-        "inoTrigger"?: TooltipTrigger;
+        "inoTrigger"?: Exclude<TooltipTrigger, 'manual'>;
+        /**
+          * Emits the visibility of the popover on change (true if shown, false if hidden).
+         */
+        "onVisibilityChanged"?: (event: CustomEvent<boolean>) => void;
     }
     interface InoProgressBar {
         /**

--- a/packages/elements/src/components/ino-popover/ino-popover.scss
+++ b/packages/elements/src/components/ino-popover/ino-popover.scss
@@ -3,6 +3,8 @@
 @use 'base/theme';
 
 ino-popover {
+  display: none;
+
   //default color scheme
   @include tooltip-mixins.tooltip(
     theme.color(primary, light),

--- a/packages/elements/src/components/ino-popover/ino-popover.tsx
+++ b/packages/elements/src/components/ino-popover/ino-popover.tsx
@@ -117,7 +117,7 @@ export class Popover implements ComponentInterface {
 
     const options: Partial<Props> = {
       allowHTML: true,
-      appendTo: this.el.parentElement,
+      appendTo: 'parent',
       content: this.el,
       duration: 100,
       hideOnClick: !isControlled,

--- a/packages/elements/src/components/ino-popover/ino-popover.tsx
+++ b/packages/elements/src/components/ino-popover/ino-popover.tsx
@@ -103,6 +103,10 @@ export class Popover implements ComponentInterface {
   private create() {
     this.tippyInstance?.destroy();
 
+    // Add the display property on creation to avoid jumping content
+    // see https://atomiks.github.io/tippyjs/v6/html-content/#element
+    this.el.style.display = 'block';
+
     const target = this.inoFor
       ? document.getElementById(this.inoFor)
       : this.el.parentElement;

--- a/packages/elements/src/components/ino-popover/ino-popover.tsx
+++ b/packages/elements/src/components/ino-popover/ino-popover.tsx
@@ -61,7 +61,7 @@ export class Popover implements ComponentInterface {
    * The trigger to show the tooltip - either click, hover or focus.
    * Multiple triggers are possible by separating them with a space.
    */
-  @Prop() inoTrigger: TooltipTrigger = 'mouseenter focus';
+  @Prop() inoTrigger: Exclude<TooltipTrigger, 'manual'> = 'mouseenter focus';
 
   @Watch('inoTrigger')
   inoTriggerChanged() {
@@ -85,6 +85,7 @@ export class Popover implements ComponentInterface {
 
   @Watch('inoShow')
   inoShowChanged(show: boolean) {
+    console.log('Show: ', show);
     show ? this.tippyInstance.show() : this.tippyInstance.hide();
   }
 
@@ -124,7 +125,20 @@ export class Popover implements ComponentInterface {
       interactive: this.inoInteractive,
     };
 
+    if (this.inoShow !== undefined) {
+      console.log('adding handlers');
+      options.onShow = (_) => this.handleVisibility(true);
+      options.onHide = (_) => this.handleVisibility(false);
+      options.showOnCreate = this.inoShow;
+    }
+
     this.tippyInstance = TippyJS(target, options);
+  }
+
+  handleVisibility(show: boolean): false | void {
+    console.log('Visibility: ', show, this);
+    this.visibilityChanged.emit(show);
+    return false;
   }
 
   render() {

--- a/packages/elements/src/components/ino-popover/readme.md
+++ b/packages/elements/src/components/ino-popover/readme.md
@@ -46,8 +46,8 @@ class MyComponent extends Component {
 ```
 _Controlled_
 
-Or you use the `ino-open` property to show/hide the popover by yourself. 
-This is helpful if you want to implement custom logic when the popover should be shown or hid.
+Or you use the `ino-show` property to show/hide the popover by yourself. 
+This is helpful if you want to implement custom logic when the popover should be shown or hidden.
 
 ```jsx
 // ...
@@ -132,6 +132,7 @@ class MyComponent extends Component {
 
 <!-- Auto Generated Below -->
 
+
 ## Properties
 
 | Property         | Attribute          | Description                                                                                                                              | Type                                                                                                                                                                                                                                                                                                                                   | Default              |
@@ -143,17 +144,20 @@ class MyComponent extends Component {
 | `inoShow`        | `ino-show`         | Programmatically show or hide the popover. Using this property disables the functionality of the `inoTrigger` prop.                      | `boolean`                                                                                                                                                                                                                                                                                                                              | `undefined`          |
 | `inoTrigger`     | `ino-trigger`      | The trigger to show the tooltip - either click, hover or focus. Multiple triggers are possible by separating them with a space.          | `"click focus mouseenter" \| "click focus" \| "click mouseenter focus" \| "click mouseenter" \| "click" \| "focus click mouseenter" \| "focus click" \| "focus mouseenter click" \| "focus mouseenter" \| "focus" \| "mouseenter click focus" \| "mouseenter click" \| "mouseenter focus click" \| "mouseenter focus" \| "mouseenter"` | `'mouseenter focus'` |
 
+
 ## Events
 
-| Event          | Description                                                                                                           | Type                |
-| -------------- | --------------------------------------------------------------------------------------------------------------------- | ------------------- |
-| `clickOutside` | Emits when an element which is not part of the popover is clicked. Should be used if you use the `ino-show` property. | `CustomEvent<void>` |
+| Event          | Description                                                                                                                | Type                |
+| -------------- | -------------------------------------------------------------------------------------------------------------------------- | ------------------- |
+| `clickOutside` | Emits when an element which is not part of the popover is clicked. Should be used if you control the state of the popover. | `CustomEvent<void>` |
+
 
 ## Methods
 
 ### `getTippyInstance() => Promise<any>`
 
-Returns the internally used tippy.js instance For more informations see: https://atomiks.github.io/tippyjs/
+Returns the internally used tippy.js instance
+For more informations see: https://atomiks.github.io/tippyjs/
 
 #### Returns
 

--- a/packages/elements/src/components/ino-popover/readme.md
+++ b/packages/elements/src/components/ino-popover/readme.md
@@ -1,18 +1,82 @@
 # ino-popover
 
-A Popover is a dialog which is bound to a specific element and appears on top of the current page. It uses [tippy.js](https://atomiks.github.io/tippyjs/) to position the popover correctly.
+A Popover is a dialog which is bound to a specific element and appears next to it. Under the
+hood, [tippy.js](https://atomiks.github.io/tippyjs/) is used.
 
-The Popover and [Tooltip](https://elements.inovex.de/dist/latest/storybook/?path=/story/notification-ino-tooltip--default-usage) components are very similar.
-However, popovers are complex dialogs consisting of several HTML elements, while tooltips can only display plain text.
+The Popover
+and [Tooltip](https://elements.inovex.de/dist/latest/storybook/?path=/story/notification-ino-tooltip--default-usage)
+components are very similar. However, popovers are complex dialogs consisting of several HTML elements, while tooltips
+can only display plain text.
 
 ### Usage
 
 The component can be used as follows:
 
 ```html
-<ino-popover ino-for="<string>" ino-placement="<string" ino-trigger="<string>">
+
+<ino-popover ino-for="<string>" ino-placement="<string>" ino-trigger="<string>">
   Any desired HTML
 </ino-popover>
+```
+
+#### Controlled vs. Uncontrolled
+
+There are currently two ways you can manage the state of the popover.
+
+_Uncontrolled_
+
+Either you use the `ino-trigger` property to define the method when the popover should be opened or closed (e.g. hovering in opens and hovering out closes the popover). 
+This is the easiest way as you don't have to worry about managing this state yourself.
+
+```jsx
+// ...
+
+class MyComponent extends Component {
+  render() {
+    return (
+      <div>
+        <InoButton id="my-target">Open Popover</InoButton>
+        <InoPopover inoFor="my-target" inoTrigger="mouseenter">
+          This popover will show as soon as the user hovers the button above
+        </InoPopover>
+      </div>
+    );
+  }
+}
+```
+_Controlled_
+
+Or you use the `ino-open` property to show/hide the popover by yourself. 
+This is helpful if you want to implement custom logic when the popover should be shown or hid.
+
+```jsx
+// ...
+
+class MyComponent extends Component {
+
+  state = {
+    showPopover: false
+  };
+
+  togglePopover = () => {
+    if (this.props.someProp) return; // Some condition
+    
+    this.setState({ showPopover: !this.state.showPopover });
+  }
+
+  render() {
+    return (
+      <div>
+        <InoButton id="my-target" onClick={this.togglePopover}>
+          Open Popover
+        </InoButton>
+        <InoPopover inoFor="my-target" inoShow={this.state.showPopover}>
+          This popover will show as soon as the user hovers the button above
+        </InoPopover>
+      </div>
+    );
+  }
+}
 ```
 
 ### React
@@ -68,7 +132,6 @@ class MyComponent extends Component {
 
 <!-- Auto Generated Below -->
 
-
 ## Properties
 
 | Property         | Attribute          | Description                                                                                                                              | Type                                                                                                                                                                                                                                                                                                                                   | Default              |
@@ -80,20 +143,17 @@ class MyComponent extends Component {
 | `inoShow`        | `ino-show`         | Programmatically show or hide the popover. Using this property disables the functionality of the `inoTrigger` prop.                      | `boolean`                                                                                                                                                                                                                                                                                                                              | `undefined`          |
 | `inoTrigger`     | `ino-trigger`      | The trigger to show the tooltip - either click, hover or focus. Multiple triggers are possible by separating them with a space.          | `"click focus mouseenter" \| "click focus" \| "click mouseenter focus" \| "click mouseenter" \| "click" \| "focus click mouseenter" \| "focus click" \| "focus mouseenter click" \| "focus mouseenter" \| "focus" \| "mouseenter click focus" \| "mouseenter click" \| "mouseenter focus click" \| "mouseenter focus" \| "mouseenter"` | `'mouseenter focus'` |
 
-
 ## Events
 
-| Event               | Description                                                                     | Type                   |
-| ------------------- | ------------------------------------------------------------------------------- | ---------------------- |
-| `visibilityChanged` | Emits the visibility of the popover on change (true if shown, false if hidden). | `CustomEvent<boolean>` |
-
+| Event          | Description                                                                                                           | Type                |
+| -------------- | --------------------------------------------------------------------------------------------------------------------- | ------------------- |
+| `clickOutside` | Emits when an element which is not part of the popover is clicked. Should be used if you use the `ino-show` property. | `CustomEvent<void>` |
 
 ## Methods
 
 ### `getTippyInstance() => Promise<any>`
 
-Returns the internally used tippy.js instance
-For more informations see: https://atomiks.github.io/tippyjs/
+Returns the internally used tippy.js instance For more informations see: https://atomiks.github.io/tippyjs/
 
 #### Returns
 

--- a/packages/elements/src/components/ino-popover/readme.md
+++ b/packages/elements/src/components/ino-popover/readme.md
@@ -77,7 +77,15 @@ class MyComponent extends Component {
 | `inoFor`         | `ino-for`          | The target id the tooltip belongs to. If not given, the tooltip is attached to the parent component.                                     | `string`                                                                                                                                                                                                                                                                                                                               | `undefined`          |
 | `inoInteractive` | `ino-interactive`  | Use this if you want to interact with the popover content (e.g. button clicks)                                                           | `boolean`                                                                                                                                                                                                                                                                                                                              | `false`              |
 | `inoPlacement`   | `ino-placement`    | The placement of this popover. Accepted values: `top(-start, -end)`, `right(-start, -end)`, `bottom(-start, -end)`, `left(-start, -end)` | `"auto" \| "auto-end" \| "auto-start" \| "bottom" \| "bottom-end" \| "bottom-start" \| "left" \| "left-end" \| "left-start" \| "right" \| "right-end" \| "right-start" \| "top" \| "top-end" \| "top-start"`                                                                                                                           | `'auto'`             |
+| `inoShow`        | `ino-show`         | Programmatically show or hide the popover. Using this property disables the functionality of the `inoTrigger` prop.                      | `boolean`                                                                                                                                                                                                                                                                                                                              | `undefined`          |
 | `inoTrigger`     | `ino-trigger`      | The trigger to show the tooltip - either click, hover or focus. Multiple triggers are possible by separating them with a space.          | `"click focus mouseenter" \| "click focus" \| "click mouseenter focus" \| "click mouseenter" \| "click" \| "focus click mouseenter" \| "focus click" \| "focus mouseenter click" \| "focus mouseenter" \| "focus" \| "mouseenter click focus" \| "mouseenter click" \| "mouseenter focus click" \| "mouseenter focus" \| "mouseenter"` | `'mouseenter focus'` |
+
+
+## Events
+
+| Event               | Description                                                                     | Type                   |
+| ------------------- | ------------------------------------------------------------------------------- | ---------------------- |
+| `visibilityChanged` | Emits the visibility of the popover on change (true if shown, false if hidden). | `CustomEvent<boolean>` |
 
 
 ## Methods

--- a/packages/storybook/src/stories/ino-popover/ino-popover.scss
+++ b/packages/storybook/src/stories/ino-popover/ino-popover.scss
@@ -1,5 +1,12 @@
 .story-popover {
-  padding-left: 20%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+
+  .row {
+    display: flex;
+    justify-content: space-between;
+  }
 
   ino-button {
     margin: 0 12px 12px 0;

--- a/packages/storybook/src/stories/ino-popover/ino-popover.stories.js
+++ b/packages/storybook/src/stories/ino-popover/ino-popover.stories.js
@@ -1,20 +1,50 @@
-import { boolean, select, text } from '@storybook/addon-knobs';
+import { boolean, select } from '@storybook/addon-knobs';
 
 import withStencilReadme from '_local-storybookcore/with-stencil-readme';
 
 import componentReadme from '_local-elements/src/components/ino-popover/readme.md';
 import './ino-popover.scss';
 
+function subscribeToComponentEvents() {
+  let popoverRef;
+
+  const eventHandler = function (e) {
+    if (e.target) {
+      const checkState = e.detail;
+
+      e.target.setAttribute('checked', checkState);
+
+      if (!popoverRef) {
+        popoverRef = document.getElementById('controlled-popover');
+      }
+
+      popoverRef.setAttribute('ino-show', checkState);
+    }
+  };
+
+  document.addEventListener('checkedChange', eventHandler);
+
+  return () => {
+    document.removeEventListener('checkedChange', eventHandler);
+  };
+}
+
 export default {
   title: 'Notification/<ino-popover>',
-  decorators: [withStencilReadme(componentReadme)],
+  decorators: [
+    withStencilReadme(componentReadme),
+    (story) => {
+      subscribeToComponentEvents();
+      return story();
+    },
+  ],
 };
 
 export const DefaultUsage = () => /*html*/ `
     <div class="story-popover">
       <ino-button id="popover-target">Popover</ino-button>
       <ino-popover
-        ino-for="${text('ino-for', 'popover-target')}"
+        ino-for="popover-target"
         ino-interactive="${boolean('ino-interactive', false)}"
         ino-placement="${select(
           'ino-placement',
@@ -50,13 +80,18 @@ export const DefaultUsage = () => /*html*/ `
       <ino-button class="placement-button" id="popover-positions-target">Popover</ino-button>
 
       <h4>Triggers</h4>
-      <ino-button id="popover-hover-focus">Hover & focus</ino-button>
-      <ino-popover ino-for="popover-hover-focus">This popover occurs on hover and focus.</ino-popover>
+      <div class="row">
+      <ino-button id="popover-hover">Mouseenter</ino-button>
+      <ino-popover ino-placement="left" ino-for="popover-hover" ino-trigger="mouseenter">This popover occurs on mouseenter</ino-popover>
+
+      <ino-button id="popover-focus">Focus</ino-button>
+      <ino-popover ino-placement="top" ino-for="popover-focus" ino-trigger="focus">This popover occurs on focus.</ino-popover>
 
       <ino-button id="popover-click">Click</ino-button>
-      <ino-popover ino-for="popover-click" ino-trigger="click">This popover occurs on click.</ino-popover>
-
+      <ino-popover ino-placement="right" ino-for="popover-click" ino-trigger="click">This popover occurs on click.</ino-popover>
+</div>
       <h4>Interactions</h4>
+            <div class="row">
       <ino-button id="popover-non-interactive">Non-Interactive content</ino-button>
       <ino-popover ino-interactive="false" ino-for="popover-non-interactive" ino-trigger="click" ino-color-scheme="transparent">
         <div id="interactive-demo-container">
@@ -69,6 +104,12 @@ export const DefaultUsage = () => /*html*/ `
         <div id="interactive-demo-container">
             <ino-button>You can click me without closing this popover!</ino-button>
         </div>
+      </ino-popover>
+      </div>
+      <h4>Controlled Popover</h4>
+      <ino-checkbox id="controlled-checkbox" checked="true">Uncheck to hide / check to show</ino-checkbox>
+      <ino-popover id="controlled-popover" ino-placement="bottom" ino-for="controlled-checkbox" ino-show="true">
+        I'm a controlled popover
       </ino-popover>
     </div>
   `;


### PR DESCRIPTION
Relates to #288 

In order to implement a better menu, it should be based on the popover and not on the MDC-Menu.
This PR provides functionalities to manage the state of the popover.

## Proposed Changes

- Add new `ino-show` property which controls the state of the popover
- Add `clickOutside` event to simplify the state management
- Update Storybook entry of the `ino-popover`
