### PR TITLE
feat(elements|ino-popover): add functionality to control component

### DIFF
--- a/packages/elements-angular/elements/src/directives/proxies.ts
+++ b/packages/elements-angular/elements/src/directives/proxies.ts
@@ -625,15 +625,15 @@ export class InoOptionGroup {
 import { Popover as IPopover } from '@inovex.de/elements/dist/types/components/ino-popover/ino-popover';
 export declare interface InoPopover extends Components.InoPopover {}
 @ProxyCmp({
-  inputs: ['inoColorScheme', 'inoControlled', 'inoFor', 'inoInteractive', 'inoPlacement', 'inoShow', 'inoTrigger'],
+  inputs: ['inoColorScheme', 'inoControlled', 'inoFor', 'inoInteractive', 'inoPlacement', 'inoTrigger', 'inoVisible'],
   methods: ['getTippyInstance']
 })
 @Component({
   selector: 'ino-popover',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
-  inputs: ['inoColorScheme', 'inoControlled', 'inoFor', 'inoInteractive', 'inoPlacement', 'inoShow', 'inoTrigger'],
-  outputs: ['visibilityChanged']
+  inputs: ['inoColorScheme', 'inoControlled', 'inoFor', 'inoInteractive', 'inoPlacement', 'inoTrigger', 'inoVisible'],
+  outputs: ['inoVisibleChanged']
 })
 export class InoPopover {
   /** Emits when the popover wants to show (`true`) or hide (`false`) itself.
@@ -643,12 +643,12 @@ Use this event in controlled-mode (see `ino-controlled`).
 e.g.: `ino-trigger = 'click'` - This events emits with `true`
 when the user clicks on the target (slot/`ino-for`/parent-element)
 and emits with `false` when the target or the outside is clicked. */
-  visibilityChanged!: IPopover['visibilityChanged'];
+  inoVisibleChanged!: IPopover['inoVisibleChanged'];
   protected el: HTMLElement;
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
     this.el = r.nativeElement;
-    proxyOutputs(this, this.el, ['visibilityChanged']);
+    proxyOutputs(this, this.el, ['inoVisibleChanged']);
   }
 }
 

--- a/packages/elements-angular/elements/src/directives/proxies.ts
+++ b/packages/elements-angular/elements/src/directives/proxies.ts
@@ -633,16 +633,17 @@ export declare interface InoPopover extends Components.InoPopover {}
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
   inputs: ['inoColorScheme', 'inoFor', 'inoInteractive', 'inoPlacement', 'inoShow', 'inoTrigger'],
-  outputs: ['visibilityChanged']
+  outputs: ['clickOutside']
 })
 export class InoPopover {
-  /** Emits the visibility of the popover on change (true if shown, false if hidden). */
-  visibilityChanged!: IPopover['visibilityChanged'];
+  /** Emits when an element which is not part of the popover is clicked.
+Should be used if you control the state of the popover. */
+  clickOutside!: IPopover['clickOutside'];
   protected el: HTMLElement;
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
     this.el = r.nativeElement;
-    proxyOutputs(this, this.el, ['visibilityChanged']);
+    proxyOutputs(this, this.el, ['clickOutside']);
   }
 }
 

--- a/packages/elements-angular/elements/src/directives/proxies.ts
+++ b/packages/elements-angular/elements/src/directives/proxies.ts
@@ -625,27 +625,30 @@ export class InoOptionGroup {
 import { Popover as IPopover } from '@inovex.de/elements/dist/types/components/ino-popover/ino-popover';
 export declare interface InoPopover extends Components.InoPopover {}
 @ProxyCmp({
-  inputs: ['inoColorScheme', 'inoFor', 'inoInteractive', 'inoPlacement', 'inoShow', 'inoTrigger'],
+  inputs: ['inoColorScheme', 'inoControlled', 'inoFor', 'inoInteractive', 'inoPlacement', 'inoShow', 'inoTrigger'],
   methods: ['getTippyInstance']
 })
 @Component({
   selector: 'ino-popover',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
-  inputs: ['inoColorScheme', 'inoFor', 'inoInteractive', 'inoPlacement', 'inoShow', 'inoTrigger'],
-  outputs: ['visibilityChanged', 'clickOutside']
+  inputs: ['inoColorScheme', 'inoControlled', 'inoFor', 'inoInteractive', 'inoPlacement', 'inoShow', 'inoTrigger'],
+  outputs: ['visibilityChanged']
 })
 export class InoPopover {
-  /**  */
+  /** Emits when the popover wants to show (`true`) or hide (`false`) itself.
+This is depended on the `ino-trigger` property.
+Use this event in controlled-mode (see `ino-controlled`).
+
+e.g.: `ino-trigger = 'click'` - This events emits with `true`
+when the user clicks on the target (slot/`ino-for`/parent-element)
+and emits with `false` when the target or the outside is clicked. */
   visibilityChanged!: IPopover['visibilityChanged'];
-  /** Emits when an element which is not part of the popover is clicked.
-Should be used if you control the state of the popover. */
-  clickOutside!: IPopover['clickOutside'];
   protected el: HTMLElement;
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
     this.el = r.nativeElement;
-    proxyOutputs(this, this.el, ['visibilityChanged', 'clickOutside']);
+    proxyOutputs(this, this.el, ['visibilityChanged']);
   }
 }
 

--- a/packages/elements-angular/elements/src/directives/proxies.ts
+++ b/packages/elements-angular/elements/src/directives/proxies.ts
@@ -622,23 +622,27 @@ export class InoOptionGroup {
   }
 }
 
-
+import { Popover as IPopover } from '@inovex.de/elements/dist/types/components/ino-popover/ino-popover';
 export declare interface InoPopover extends Components.InoPopover {}
 @ProxyCmp({
-  inputs: ['inoColorScheme', 'inoFor', 'inoInteractive', 'inoPlacement', 'inoTrigger'],
+  inputs: ['inoColorScheme', 'inoFor', 'inoInteractive', 'inoPlacement', 'inoShow', 'inoTrigger'],
   methods: ['getTippyInstance']
 })
 @Component({
   selector: 'ino-popover',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
-  inputs: ['inoColorScheme', 'inoFor', 'inoInteractive', 'inoPlacement', 'inoTrigger']
+  inputs: ['inoColorScheme', 'inoFor', 'inoInteractive', 'inoPlacement', 'inoShow', 'inoTrigger'],
+  outputs: ['visibilityChanged']
 })
 export class InoPopover {
+  /** Emits the visibility of the popover on change (true if shown, false if hidden). */
+  visibilityChanged!: IPopover['visibilityChanged'];
   protected el: HTMLElement;
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
     this.el = r.nativeElement;
+    proxyOutputs(this, this.el, ['visibilityChanged']);
   }
 }
 

--- a/packages/elements-angular/elements/src/directives/proxies.ts
+++ b/packages/elements-angular/elements/src/directives/proxies.ts
@@ -633,9 +633,11 @@ export declare interface InoPopover extends Components.InoPopover {}
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
   inputs: ['inoColorScheme', 'inoFor', 'inoInteractive', 'inoPlacement', 'inoShow', 'inoTrigger'],
-  outputs: ['clickOutside']
+  outputs: ['visibilityChanged', 'clickOutside']
 })
 export class InoPopover {
+  /**  */
+  visibilityChanged!: IPopover['visibilityChanged'];
   /** Emits when an element which is not part of the popover is clicked.
 Should be used if you control the state of the popover. */
   clickOutside!: IPopover['clickOutside'];
@@ -643,7 +645,7 @@ Should be used if you control the state of the popover. */
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
     this.el = r.nativeElement;
-    proxyOutputs(this, this.el, ['clickOutside']);
+    proxyOutputs(this, this.el, ['visibilityChanged', 'clickOutside']);
   }
 }
 

--- a/packages/elements/src/components.d.ts
+++ b/packages/elements/src/components.d.ts
@@ -2374,9 +2374,9 @@ declare namespace LocalJSX {
          */
         "inoTrigger"?: Exclude<TooltipTrigger, 'manual'>;
         /**
-          * Emits the visibility of the popover on change (true if shown, false if hidden).
+          * Emits when an element which is not part of the popover is clicked. Should be used if you control the state of the popover.
          */
-        "onVisibilityChanged"?: (event: CustomEvent<boolean>) => void;
+        "onClickOutside"?: (event: CustomEvent<void>) => void;
     }
     interface InoProgressBar {
         /**

--- a/packages/elements/src/components.d.ts
+++ b/packages/elements/src/components.d.ts
@@ -798,7 +798,7 @@ export namespace Components {
          */
         "inoColorScheme"?: string;
         /**
-          * Used to indicate if the popover should be controlled by itself (`false`) or manually by the `ino-show` property (`true`)
+          * Used to indicate if the popover should be controlled by itself (`false`) or manually by the `ino-visible` property (`true`)
          */
         "inoControlled": boolean;
         /**
@@ -814,13 +814,13 @@ export namespace Components {
          */
         "inoPlacement": Placement;
         /**
-          * Programmatically show or hide the popover. Can only be used in controlled mode (see property `ino-controlled`). Use the `visibilityChanged` to sync the popovers' visibility state with yours.
-         */
-        "inoShow"?: boolean;
-        /**
           * The trigger to show the tooltip - either click, hover or focus. Multiple triggers are possible by separating them with a space.
          */
         "inoTrigger": Exclude<TooltipTrigger, 'manual'>;
+        /**
+          * Programmatically show or hide the popover. Can only be used in controlled mode (see property `ino-controlled`). Use the `inoVisibleChanged` to sync the popovers' visibility state with yours.
+         */
+        "inoVisible"?: boolean;
     }
     interface InoProgressBar {
         /**
@@ -2358,7 +2358,7 @@ declare namespace LocalJSX {
          */
         "inoColorScheme"?: string;
         /**
-          * Used to indicate if the popover should be controlled by itself (`false`) or manually by the `ino-show` property (`true`)
+          * Used to indicate if the popover should be controlled by itself (`false`) or manually by the `ino-visible` property (`true`)
          */
         "inoControlled"?: boolean;
         /**
@@ -2374,17 +2374,17 @@ declare namespace LocalJSX {
          */
         "inoPlacement"?: Placement;
         /**
-          * Programmatically show or hide the popover. Can only be used in controlled mode (see property `ino-controlled`). Use the `visibilityChanged` to sync the popovers' visibility state with yours.
-         */
-        "inoShow"?: boolean;
-        /**
           * The trigger to show the tooltip - either click, hover or focus. Multiple triggers are possible by separating them with a space.
          */
         "inoTrigger"?: Exclude<TooltipTrigger, 'manual'>;
         /**
+          * Programmatically show or hide the popover. Can only be used in controlled mode (see property `ino-controlled`). Use the `inoVisibleChanged` to sync the popovers' visibility state with yours.
+         */
+        "inoVisible"?: boolean;
+        /**
           * Emits when the popover wants to show (`true`) or hide (`false`) itself. This is depended on the `ino-trigger` property. Use this event in controlled-mode (see `ino-controlled`).  e.g.: `ino-trigger = 'click'` - This events emits with `true` when the user clicks on the target (slot/`ino-for`/parent-element) and emits with `false` when the target or the outside is clicked.
          */
-        "onVisibilityChanged"?: (event: CustomEvent<boolean>) => void;
+        "onInoVisibleChanged"?: (event: CustomEvent<boolean>) => void;
     }
     interface InoProgressBar {
         /**

--- a/packages/elements/src/components.d.ts
+++ b/packages/elements/src/components.d.ts
@@ -798,7 +798,11 @@ export namespace Components {
          */
         "inoColorScheme"?: string;
         /**
-          * The target id the tooltip belongs to. If not given, the tooltip is attached to the parent component.
+          * Used to indicate if the popover should be controlled by itself (`false`) or manually by the `ino-show` property (`true`)
+         */
+        "inoControlled": boolean;
+        /**
+          * The target id the popover belongs to. If not given, the popover is attached to the element provided in the named slot (`ino-popover-trigger`) or the parent component if a slot element does not exist.
          */
         "inoFor"?: string;
         /**
@@ -810,7 +814,7 @@ export namespace Components {
          */
         "inoPlacement": Placement;
         /**
-          * Programmatically show or hide the popover. Using this property disables the functionality of the `inoTrigger` prop.
+          * Programmatically show or hide the popover. Can only be used in controlled mode (see property `ino-controlled`). Use the `visibilityChanged` to sync the popovers' visibility state with yours.
          */
         "inoShow"?: boolean;
         /**
@@ -2354,7 +2358,11 @@ declare namespace LocalJSX {
          */
         "inoColorScheme"?: string;
         /**
-          * The target id the tooltip belongs to. If not given, the tooltip is attached to the parent component.
+          * Used to indicate if the popover should be controlled by itself (`false`) or manually by the `ino-show` property (`true`)
+         */
+        "inoControlled"?: boolean;
+        /**
+          * The target id the popover belongs to. If not given, the popover is attached to the element provided in the named slot (`ino-popover-trigger`) or the parent component if a slot element does not exist.
          */
         "inoFor"?: string;
         /**
@@ -2366,7 +2374,7 @@ declare namespace LocalJSX {
          */
         "inoPlacement"?: Placement;
         /**
-          * Programmatically show or hide the popover. Using this property disables the functionality of the `inoTrigger` prop.
+          * Programmatically show or hide the popover. Can only be used in controlled mode (see property `ino-controlled`). Use the `visibilityChanged` to sync the popovers' visibility state with yours.
          */
         "inoShow"?: boolean;
         /**
@@ -2374,9 +2382,8 @@ declare namespace LocalJSX {
          */
         "inoTrigger"?: Exclude<TooltipTrigger, 'manual'>;
         /**
-          * Emits when an element which is not part of the popover is clicked. Should be used if you control the state of the popover.
+          * Emits when the popover wants to show (`true`) or hide (`false`) itself. This is depended on the `ino-trigger` property. Use this event in controlled-mode (see `ino-controlled`).  e.g.: `ino-trigger = 'click'` - This events emits with `true` when the user clicks on the target (slot/`ino-for`/parent-element) and emits with `false` when the target or the outside is clicked.
          */
-        "onClickOutside"?: (event: CustomEvent<void>) => void;
         "onVisibilityChanged"?: (event: CustomEvent<boolean>) => void;
     }
     interface InoProgressBar {

--- a/packages/elements/src/components.d.ts
+++ b/packages/elements/src/components.d.ts
@@ -2377,6 +2377,7 @@ declare namespace LocalJSX {
           * Emits when an element which is not part of the popover is clicked. Should be used if you control the state of the popover.
          */
         "onClickOutside"?: (event: CustomEvent<void>) => void;
+        "onVisibilityChanged"?: (event: CustomEvent<boolean>) => void;
     }
     interface InoProgressBar {
         /**

--- a/packages/elements/src/components.d.ts
+++ b/packages/elements/src/components.d.ts
@@ -810,9 +810,13 @@ export namespace Components {
          */
         "inoPlacement": Placement;
         /**
+          * Programmatically show or hide the popover. Using this property disables the functionality of the `inoTrigger` prop.
+         */
+        "inoShow"?: boolean;
+        /**
           * The trigger to show the tooltip - either click, hover or focus. Multiple triggers are possible by separating them with a space.
          */
-        "inoTrigger": TooltipTrigger;
+        "inoTrigger": Exclude<TooltipTrigger, 'manual'>;
     }
     interface InoProgressBar {
         /**
@@ -2362,9 +2366,17 @@ declare namespace LocalJSX {
          */
         "inoPlacement"?: Placement;
         /**
+          * Programmatically show or hide the popover. Using this property disables the functionality of the `inoTrigger` prop.
+         */
+        "inoShow"?: boolean;
+        /**
           * The trigger to show the tooltip - either click, hover or focus. Multiple triggers are possible by separating them with a space.
          */
-        "inoTrigger"?: TooltipTrigger;
+        "inoTrigger"?: Exclude<TooltipTrigger, 'manual'>;
+        /**
+          * Emits the visibility of the popover on change (true if shown, false if hidden).
+         */
+        "onVisibilityChanged"?: (event: CustomEvent<boolean>) => void;
     }
     interface InoProgressBar {
         /**

--- a/packages/elements/src/components/ino-popover/ino-popover.scss
+++ b/packages/elements/src/components/ino-popover/ino-popover.scss
@@ -2,7 +2,7 @@
 @use 'ino-tooltip/mixins' as tooltip-mixins;
 @use 'base/theme';
 
-ino-popover {
+ino-popover .ino-popover {
   //default color scheme
   @include tooltip-mixins.tooltip(
     theme.color(primary, light),

--- a/packages/elements/src/components/ino-popover/ino-popover.scss
+++ b/packages/elements/src/components/ino-popover/ino-popover.scss
@@ -9,33 +9,35 @@ ino-popover .ino-popover {
     theme.color(primary, contrast)
   );
 
-  &[ino-color-scheme='primary'] {
+  .ino-popover__content {
+    padding-right: 5px;
+    padding-left: 5px;
+  }
+}
+
+ino-popover {
+  &[ino-color-scheme='primary'] .ino-popover {
     @include tooltip-mixins.tooltip(
       theme.color(primary, light),
       theme.color(primary, contrast)
     );
   }
 
-  &[ino-color-scheme='secondary'] {
+  &[ino-color-scheme='secondary'] .ino-popover {
     @include tooltip-mixins.tooltip(
       theme.color(secondary, light),
       theme.color(secondary, contrast)
     );
   }
 
-  &[ino-color-scheme='light'] {
+  &[ino-color-scheme='light'] .ino-popover {
     @include tooltip-mixins.tooltip(
       theme.color(light),
       theme.color(light, contrast)
     );
   }
 
-  &[ino-color-scheme='transparent'] {
+  &[ino-color-scheme='transparent'] .ino-popover {
     @include tooltip-mixins.tooltip(#fff, theme.color(dark));
-  }
-
-  .ino-popover__content {
-    padding-right: 5px;
-    padding-left: 5px;
   }
 }

--- a/packages/elements/src/components/ino-popover/ino-popover.tsx
+++ b/packages/elements/src/components/ino-popover/ino-popover.tsx
@@ -159,7 +159,7 @@ export class Popover implements ComponentInterface {
     this.tippyInstance = TippyJS(this.target, options);
   }
 
-  get target(): HTMLElement | null {
+  private get target(): HTMLElement | null {
     const slotContent = getSlotContent(this.el, 'ino-popover-trigger');
 
     if (slotContent) return slotContent;

--- a/packages/elements/src/components/ino-popover/ino-popover.tsx
+++ b/packages/elements/src/components/ino-popover/ino-popover.tsx
@@ -85,7 +85,7 @@ export class Popover implements ComponentInterface {
   }
 
   /**
-   * Used to indicate if the popover should be controlled by itself (`false`) or manually by the `ino-show` property (`true`)
+   * Used to indicate if the popover should be controlled by itself (`false`) or manually by the `ino-visible` property (`true`)
    */
   @Prop() inoControlled: boolean = false;
 
@@ -97,12 +97,12 @@ export class Popover implements ComponentInterface {
   /**
    * Programmatically show or hide the popover.
    * Can only be used in controlled mode (see property `ino-controlled`).
-   * Use the `visibilityChanged` to sync the popovers' visibility state with yours.
+   * Use the `inoVisibleChanged` to sync the popovers' visibility state with yours.
    */
-  @Prop() inoShow?: boolean = false;
+  @Prop() inoVisible?: boolean = false;
 
-  @Watch('inoShow')
-  inoShowChanged(show: boolean) {
+  @Watch('inoVisible')
+  inoVisibleChangeHandler(show: boolean) {
     if (!this.inoControlled) {
       return;
     }
@@ -119,7 +119,7 @@ export class Popover implements ComponentInterface {
    * when the user clicks on the target (slot/`ino-for`/parent-element)
    * and emits with `false` when the target or the outside is clicked.
    */
-  @Event() visibilityChanged: EventEmitter<boolean>;
+  @Event() inoVisibleChanged: EventEmitter<boolean>;
 
   componentDidLoad() {
     this.create();
@@ -143,14 +143,14 @@ export class Popover implements ComponentInterface {
       trigger: this.inoTrigger,
       interactive: this.inoInteractive,
       onShow: () => {
-        if (this.inoControlled && !this.inoShow) {
-          this.visibilityChanged.emit(true);
+        if (this.inoControlled && !this.inoVisible) {
+          this.inoVisibleChanged.emit(true);
           return false;
         }
       },
       onHide: () => {
-        if (this.inoControlled && this.inoShow) {
-          this.visibilityChanged.emit(false);
+        if (this.inoControlled && this.inoVisible) {
+          this.inoVisibleChanged.emit(false);
           return false;
         }
       },

--- a/packages/elements/src/components/ino-popover/ino-popover.tsx
+++ b/packages/elements/src/components/ino-popover/ino-popover.tsx
@@ -1,8 +1,8 @@
 import {
   Component,
   ComponentInterface,
-  Event,
   Element,
+  Event,
   EventEmitter,
   h,
   Host,
@@ -85,8 +85,11 @@ export class Popover implements ComponentInterface {
 
   @Watch('inoShow')
   inoShowChanged(show: boolean) {
+    console.log('SHOW CHANGED TO', show);
     show ? this.tippyInstance.show() : this.tippyInstance.hide();
   }
+
+  @Event() visibilityChanged: EventEmitter<boolean>;
 
   // Lifecycle
 
@@ -113,22 +116,41 @@ export class Popover implements ComponentInterface {
       );
     }
 
-    const isControlled = this.inoShow !== undefined;
-
     const options: Partial<Props> = {
       allowHTML: true,
       appendTo: this.el.parentElement,
       content: this.el,
       duration: 100,
-      hideOnClick: !isControlled,
       placement: this.inoPlacement,
-      trigger: isControlled ? 'manual' : this.inoTrigger,
-      interactive: isControlled || this.inoInteractive,
-      showOnCreate: isControlled && this.inoShow,
-      onClickOutside: () => this.clickOutside.emit(),
+      trigger: this.inoTrigger,
+      interactive: this.inoInteractive,
+      onShow: () => this.onShow(),
+      onHide: () => this.onHide(),
     };
 
     this.tippyInstance = TippyJS(target, options);
+  }
+
+  internalVisibility: boolean = false;
+
+  onShow(): false | void {
+    console.log('SHOWING');
+
+    if (this.internalVisibility) return;
+
+    console.log('NOT VISIBLE YET');
+    this.visibilityChanged.emit(true);
+    this.internalVisibility = true;
+    return false;
+  }
+
+  onHide(): false | void {
+    if (this.internalVisibility) {
+      this.visibilityChanged.emit(false);
+      return false;
+    } else {
+      this.internalVisibility = false;
+    }
   }
 
   render() {

--- a/packages/elements/src/components/ino-popover/ino-popover.tsx
+++ b/packages/elements/src/components/ino-popover/ino-popover.tsx
@@ -118,48 +118,43 @@ export class Popover implements ComponentInterface {
 
     const options: Partial<Props> = {
       allowHTML: true,
-      appendTo: this.el.parentElement,
-      content: this.el,
+      appendTo: this.el.querySelector('.ino-popover'),
+      content: this.el.querySelector('.ino-popover__content'),
       duration: 100,
       placement: this.inoPlacement,
       trigger: this.inoTrigger,
       interactive: this.inoInteractive,
-      onShow: () => this.onShow(),
-      onHide: () => this.onHide(),
+      onShow: () => {
+        if (this.isControlled && !this.inoShow) {
+          this.visibilityChanged.emit(true);
+          return false;
+        }
+      },
+      onHide: () => {
+        if (this.isControlled && this.inoShow) {
+          this.visibilityChanged.emit(false);
+          return false;
+        }
+      } 
     };
 
     this.tippyInstance = TippyJS(target, options);
   }
 
-  internalVisibility: boolean = false;
-
-  onShow(): false | void {
-    console.log('SHOWING');
-
-    if (this.internalVisibility) return;
-
-    console.log('NOT VISIBLE YET');
-    this.visibilityChanged.emit(true);
-    this.internalVisibility = true;
-    return false;
-  }
-
-  onHide(): false | void {
-    if (this.internalVisibility) {
-      this.visibilityChanged.emit(false);
-      return false;
-    } else {
-      this.internalVisibility = false;
-    }
+  get isControlled() {
+    return this.inoShow !== undefined || this.inoShow !== null;
   }
 
   render() {
     return (
       <Host>
-        <div class="ino-tooltip__composer ino-popover__content" role="tooltip">
-          <div class="ino-tooltip__inner">
-            <div class="ino-popover__content">
-              <slot></slot>
+        <slot name="ino-popover-trigger"></slot>
+        <div class="ino-popover">
+          <div class="ino-tooltip__composer ino-popover__content" role="tooltip">
+            <div class="ino-tooltip__inner">
+              <div class="ino-popover__content">
+                <slot></slot>
+              </div>
             </div>
           </div>
         </div>

--- a/packages/elements/src/components/ino-popover/ino-popover.tsx
+++ b/packages/elements/src/components/ino-popover/ino-popover.tsx
@@ -61,7 +61,7 @@ export class Popover implements ComponentInterface {
    * The trigger to show the tooltip - either click, hover or focus.
    * Multiple triggers are possible by separating them with a space.
    */
-  @Prop() inoTrigger: TooltipTrigger = 'mouseenter focus';
+  @Prop() inoTrigger: Exclude<TooltipTrigger, 'manual'> = 'mouseenter focus';
 
   @Watch('inoTrigger')
   inoTriggerChanged() {
@@ -85,6 +85,7 @@ export class Popover implements ComponentInterface {
 
   @Watch('inoShow')
   inoShowChanged(show: boolean) {
+    console.log('Show: ', show);
     show ? this.tippyInstance.show() : this.tippyInstance.hide();
   }
 
@@ -124,7 +125,20 @@ export class Popover implements ComponentInterface {
       interactive: this.inoInteractive,
     };
 
+    if (this.inoShow !== undefined) {
+      console.log('adding handlers');
+      options.onShow = (_) => this.handleVisibility(true);
+      options.onHide = (_) => this.handleVisibility(false);
+      options.showOnCreate = this.inoShow;
+    }
+
     this.tippyInstance = TippyJS(target, options);
+  }
+
+  handleVisibility(show: boolean): false | void {
+    console.log('Visibility: ', show, this);
+    this.visibilityChanged.emit(show);
+    return false;
   }
 
   render() {

--- a/packages/elements/src/components/ino-popover/ino-popover.tsx
+++ b/packages/elements/src/components/ino-popover/ino-popover.tsx
@@ -107,7 +107,7 @@ export class Popover implements ComponentInterface {
       return;
     }
 
-    show ? this.tippyInstance.show() : this.tippyInstance.hide();
+    show ? this.tippyInstance?.show() : this.tippyInstance?.hide();
   }
 
   /**

--- a/packages/elements/src/components/ino-popover/readme.md
+++ b/packages/elements/src/components/ino-popover/readme.md
@@ -1,18 +1,82 @@
 # ino-popover
 
-A Popover is a dialog which is bound to a specific element and appears on top of the current page. It uses [tippy.js](https://atomiks.github.io/tippyjs/) to position the popover correctly.
+A Popover is a dialog which is bound to a specific element and appears next to it. Under the
+hood, [tippy.js](https://atomiks.github.io/tippyjs/) is used.
 
-The Popover and [Tooltip](https://elements.inovex.de/dist/latest/storybook/?path=/story/notification-ino-tooltip--default-usage) components are very similar.
-However, popovers are complex dialogs consisting of several HTML elements, while tooltips can only display plain text.
+The Popover
+and [Tooltip](https://elements.inovex.de/dist/latest/storybook/?path=/story/notification-ino-tooltip--default-usage)
+components are very similar. However, popovers are complex dialogs consisting of several HTML elements, while tooltips
+can only display plain text.
 
 ### Usage
 
 The component can be used as follows:
 
 ```html
-<ino-popover ino-for="<string>" ino-placement="<string" ino-trigger="<string>">
+
+<ino-popover ino-for="<string>" ino-placement="<string>" ino-trigger="<string>">
   Any desired HTML
 </ino-popover>
+```
+
+#### Controlled vs. Uncontrolled
+
+There are currently two ways you can manage the state of the popover.
+
+_Uncontrolled_
+
+Either you use the `ino-trigger` property to define the method when the popover should be opened or closed (e.g. hovering in opens and hovering out closes the popover). 
+This is the easiest way as you don't have to worry about managing this state yourself.
+
+```jsx
+// ...
+
+class MyComponent extends Component {
+  render() {
+    return (
+      <div>
+        <InoButton id="my-target">Open Popover</InoButton>
+        <InoPopover inoFor="my-target" inoTrigger="mouseenter">
+          This popover will show as soon as the user hovers the button above
+        </InoPopover>
+      </div>
+    );
+  }
+}
+```
+_Controlled_
+
+Or you use the `ino-open` property to show/hide the popover by yourself. 
+This is helpful if you want to implement custom logic when the popover should be shown or hid.
+
+```jsx
+// ...
+
+class MyComponent extends Component {
+
+  state = {
+    showPopover: false
+  };
+
+  togglePopover = () => {
+    if (this.props.someProp) return; // Some condition
+    
+    this.setState({ showPopover: !this.state.showPopover });
+  }
+
+  render() {
+    return (
+      <div>
+        <InoButton id="my-target" onClick={this.togglePopover}>
+          Open Popover
+        </InoButton>
+        <InoPopover inoFor="my-target" inoShow={this.state.showPopover}>
+          This popover will show as soon as the user hovers the button above
+        </InoPopover>
+      </div>
+    );
+  }
+}
 ```
 
 ### React
@@ -68,7 +132,6 @@ class MyComponent extends Component {
 
 <!-- Auto Generated Below -->
 
-
 ## Properties
 
 | Property         | Attribute          | Description                                                                                                                              | Type                                                                                                                                                                                                                                                                                                                                   | Default              |
@@ -80,20 +143,17 @@ class MyComponent extends Component {
 | `inoShow`        | `ino-show`         | Programmatically show or hide the popover. Using this property disables the functionality of the `inoTrigger` prop.                      | `boolean`                                                                                                                                                                                                                                                                                                                              | `undefined`          |
 | `inoTrigger`     | `ino-trigger`      | The trigger to show the tooltip - either click, hover or focus. Multiple triggers are possible by separating them with a space.          | `"click focus mouseenter" \| "click focus" \| "click mouseenter focus" \| "click mouseenter" \| "click" \| "focus click mouseenter" \| "focus click" \| "focus mouseenter click" \| "focus mouseenter" \| "focus" \| "mouseenter click focus" \| "mouseenter click" \| "mouseenter focus click" \| "mouseenter focus" \| "mouseenter"` | `'mouseenter focus'` |
 
-
 ## Events
 
-| Event               | Description                                                                     | Type                   |
-| ------------------- | ------------------------------------------------------------------------------- | ---------------------- |
-| `visibilityChanged` | Emits the visibility of the popover on change (true if shown, false if hidden). | `CustomEvent<boolean>` |
-
+| Event          | Description                                                                                                           | Type                |
+| -------------- | --------------------------------------------------------------------------------------------------------------------- | ------------------- |
+| `clickOutside` | Emits when an element which is not part of the popover is clicked. Should be used if you use the `ino-show` property. | `CustomEvent<void>` |
 
 ## Methods
 
 ### `getTippyInstance() => Promise<any>`
 
-Returns the internally used tippy.js instance
-For more informations see: https://atomiks.github.io/tippyjs/
+Returns the internally used tippy.js instance For more informations see: https://atomiks.github.io/tippyjs/
 
 #### Returns
 

--- a/packages/elements/src/components/ino-popover/readme.md
+++ b/packages/elements/src/components/ino-popover/readme.md
@@ -14,7 +14,15 @@ The component can be used as follows:
 
 ```html
 
-<ino-popover ino-for="<string>" ino-placement="<string>" ino-trigger="<string>">
+<ino-popover
+  ino-color-scheme="<string>"
+  ino-controlled="<boolean>"
+  ino-for="<string>"
+  ino-interactive="<boolean>"
+  ino-placement="<string>" 
+  ino-show="<boolean>"
+  ino-trigger="<string>"
+>
   Any desired HTML
 </ino-popover>
 ```
@@ -22,7 +30,7 @@ The component can be used as follows:
 #### Targets
 There are currently three ways to attach your popover to a component:
 
-1. Using the slot _(preferred)_:
+1. Using the `ino-popover-trigger` slot _(preferred)_:
 ```html
 <ino-popover ino-trigger="click">
     <ino-button slot="ino-popover-trigger">Click to show/hide</ino-button>
@@ -78,7 +86,7 @@ _Controlled_
 Or you use the `ino-controlled` and `ino-show` property to show/hide the popover by yourself. 
 This is helpful if you want to implement custom logic when the popover should be shown or hidden.
 
-```tsx
+```typescript jsx
 // ...
 
 class MyComponent extends Component {
@@ -116,7 +124,7 @@ class MyComponent extends Component {
 
 #### Example #1 - Basic
 
-```js
+```jsx
 import { Component } from 'react';
 import { InoPopover } from '@inovex.de/elements/dist/react';
 
@@ -133,7 +141,7 @@ class MyComponent extends Component {
 
 #### Example #2 - With Types
 
-```js
+```typescript jsx
 import React, { Component } from 'react';
 import { InoPopover } from '@inovex.de/elements/dist/react';
 import { Components } from '@inovex.de/elements/dist/types/components';

--- a/packages/elements/src/components/ino-popover/readme.md
+++ b/packages/elements/src/components/ino-popover/readme.md
@@ -77,7 +77,15 @@ class MyComponent extends Component {
 | `inoFor`         | `ino-for`          | The target id the tooltip belongs to. If not given, the tooltip is attached to the parent component.                                     | `string`                                                                                                                                                                                                                                                                                                                               | `undefined`          |
 | `inoInteractive` | `ino-interactive`  | Use this if you want to interact with the popover content (e.g. button clicks)                                                           | `boolean`                                                                                                                                                                                                                                                                                                                              | `false`              |
 | `inoPlacement`   | `ino-placement`    | The placement of this popover. Accepted values: `top(-start, -end)`, `right(-start, -end)`, `bottom(-start, -end)`, `left(-start, -end)` | `"auto" \| "auto-end" \| "auto-start" \| "bottom" \| "bottom-end" \| "bottom-start" \| "left" \| "left-end" \| "left-start" \| "right" \| "right-end" \| "right-start" \| "top" \| "top-end" \| "top-start"`                                                                                                                           | `'auto'`             |
+| `inoShow`        | `ino-show`         | Programmatically show or hide the popover. Using this property disables the functionality of the `inoTrigger` prop.                      | `boolean`                                                                                                                                                                                                                                                                                                                              | `undefined`          |
 | `inoTrigger`     | `ino-trigger`      | The trigger to show the tooltip - either click, hover or focus. Multiple triggers are possible by separating them with a space.          | `"click focus mouseenter" \| "click focus" \| "click mouseenter focus" \| "click mouseenter" \| "click" \| "focus click mouseenter" \| "focus click" \| "focus mouseenter click" \| "focus mouseenter" \| "focus" \| "mouseenter click focus" \| "mouseenter click" \| "mouseenter focus click" \| "mouseenter focus" \| "mouseenter"` | `'mouseenter focus'` |
+
+
+## Events
+
+| Event               | Description                                                                     | Type                   |
+| ------------------- | ------------------------------------------------------------------------------- | ---------------------- |
+| `visibilityChanged` | Emits the visibility of the popover on change (true if shown, false if hidden). | `CustomEvent<boolean>` |
 
 
 ## Methods

--- a/packages/elements/src/components/ino-popover/readme.md
+++ b/packages/elements/src/components/ino-popover/readme.md
@@ -19,6 +19,35 @@ The component can be used as follows:
 </ino-popover>
 ```
 
+#### Targets
+There are currently three ways to attach your popover to a component:
+
+1. Using the slot _(preferred)_:
+```html
+<ino-popover ino-trigger="click">
+    <ino-button slot="ino-popover-trigger">Click to show/hide</ino-button>
+    I'm the content of the popover
+</ino-popover>
+```
+
+2. Using the `ino-for` property:
+```html
+<ino-button id="my-target" slot="ino-popover-trigger">Click to show/hide</ino-button>
+<ino-popover ino-for="my-target" ino-trigger="click">
+    I'm the content of the popover
+</ino-popover>
+```
+
+3. Using the parent element:
+```html
+<ino-button>
+  Click to show/hide
+  <ino-popover ino-trigger="click">
+      I'm the content of the popover
+  </ino-popover>
+</ino-button>
+```
+
 #### Controlled vs. Uncontrolled
 
 There are currently two ways you can manage the state of the popover.
@@ -35,8 +64,8 @@ class MyComponent extends Component {
   render() {
     return (
       <div>
-        <InoButton id="my-target">Open Popover</InoButton>
-        <InoPopover inoFor="my-target" inoTrigger="mouseenter">
+        <InoPopover inoTrigger="mouseenter">
+          <InoButton slot="ino-popover-trigger">Open Popover</InoButton>
           This popover will show as soon as the user hovers the button above
         </InoPopover>
       </div>
@@ -46,10 +75,10 @@ class MyComponent extends Component {
 ```
 _Controlled_
 
-Or you use the `ino-open` property to show/hide the popover by yourself. 
-This is helpful if you want to implement custom logic when the popover should be shown or hid.
+Or you use the `ino-controlled` and `ino-show` property to show/hide the popover by yourself. 
+This is helpful if you want to implement custom logic when the popover should be shown or hidden.
 
-```jsx
+```tsx
 // ...
 
 class MyComponent extends Component {
@@ -58,20 +87,24 @@ class MyComponent extends Component {
     showPopover: false
   };
 
-  togglePopover = () => {
+  setPopoverState = (show: boolean) => {
     if (this.props.someProp) return; // Some condition
     
-    this.setState({ showPopover: !this.state.showPopover });
+    this.setState({ showPopover: show });
   }
 
   render() {
     return (
       <div>
-        <InoButton id="my-target" onClick={this.togglePopover}>
-          Open Popover
-        </InoButton>
-        <InoPopover inoFor="my-target" inoShow={this.state.showPopover}>
-          This popover will show as soon as the user hovers the button above
+        <InoPopover 
+          inoControlled 
+          inoShow={this.state.showPopover}
+          onVisibilityChanged={(e) => setPopoverState(e.detail)}
+        >
+          <InoButton slot="ino-popover-trigger">
+            Open Popover
+          </InoButton>
+          This popover will show as soon as the user clicks the button above
         </InoPopover>
       </div>
     );
@@ -135,22 +168,22 @@ class MyComponent extends Component {
 
 ## Properties
 
-| Property         | Attribute          | Description                                                                                                                              | Type                                                                                                                                                                                                                                                                                                                                   | Default              |
-| ---------------- | ------------------ | ---------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------- |
-| `inoColorScheme` | `ino-color-scheme` | Sets the color scheme of the popup Valid options include: 'primary', 'secondary', 'light', 'transparent'                                 | `string`                                                                                                                                                                                                                                                                                                                               | `'primary'`          |
-| `inoFor`         | `ino-for`          | The target id the tooltip belongs to. If not given, the tooltip is attached to the parent component.                                     | `string`                                                                                                                                                                                                                                                                                                                               | `undefined`          |
-| `inoInteractive` | `ino-interactive`  | Use this if you want to interact with the popover content (e.g. button clicks)                                                           | `boolean`                                                                                                                                                                                                                                                                                                                              | `false`              |
-| `inoPlacement`   | `ino-placement`    | The placement of this popover. Accepted values: `top(-start, -end)`, `right(-start, -end)`, `bottom(-start, -end)`, `left(-start, -end)` | `"auto" \| "auto-end" \| "auto-start" \| "bottom" \| "bottom-end" \| "bottom-start" \| "left" \| "left-end" \| "left-start" \| "right" \| "right-end" \| "right-start" \| "top" \| "top-end" \| "top-start"`                                                                                                                           | `'auto'`             |
-| `inoShow`        | `ino-show`         | Programmatically show or hide the popover. Using this property disables the functionality of the `inoTrigger` prop.                      | `boolean`                                                                                                                                                                                                                                                                                                                              | `undefined`          |
-| `inoTrigger`     | `ino-trigger`      | The trigger to show the tooltip - either click, hover or focus. Multiple triggers are possible by separating them with a space.          | `"click focus mouseenter" \| "click focus" \| "click mouseenter focus" \| "click mouseenter" \| "click" \| "focus click mouseenter" \| "focus click" \| "focus mouseenter click" \| "focus mouseenter" \| "focus" \| "mouseenter click focus" \| "mouseenter click" \| "mouseenter focus click" \| "mouseenter focus" \| "mouseenter"` | `'mouseenter focus'` |
+| Property         | Attribute          | Description                                                                                                                                                                                             | Type                                                                                                                                                                                                                                                                                                                                   | Default              |
+| ---------------- | ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------- |
+| `inoColorScheme` | `ino-color-scheme` | Sets the color scheme of the popup Valid options include: 'primary', 'secondary', 'light', 'transparent'                                                                                                | `string`                                                                                                                                                                                                                                                                                                                               | `'primary'`          |
+| `inoControlled`  | `ino-controlled`   | Used to indicate if the popover should be controlled by itself (`false`) or manually by the `ino-show` property (`true`)                                                                                | `boolean`                                                                                                                                                                                                                                                                                                                              | `false`              |
+| `inoFor`         | `ino-for`          | The target id the popover belongs to. If not given, the popover is attached to the element provided in the named slot (`ino-popover-trigger`) or the parent component if a slot element does not exist. | `string`                                                                                                                                                                                                                                                                                                                               | `undefined`          |
+| `inoInteractive` | `ino-interactive`  | Use this if you want to interact with the popover content (e.g. button clicks)                                                                                                                          | `boolean`                                                                                                                                                                                                                                                                                                                              | `false`              |
+| `inoPlacement`   | `ino-placement`    | The placement of this popover. Accepted values: `top(-start, -end)`, `right(-start, -end)`, `bottom(-start, -end)`, `left(-start, -end)`                                                                | `"auto" \| "auto-end" \| "auto-start" \| "bottom" \| "bottom-end" \| "bottom-start" \| "left" \| "left-end" \| "left-start" \| "right" \| "right-end" \| "right-start" \| "top" \| "top-end" \| "top-start"`                                                                                                                           | `'auto'`             |
+| `inoShow`        | `ino-show`         | Programmatically show or hide the popover. Can only be used in controlled mode (see property `ino-controlled`). Use the `visibilityChanged` to sync the popovers' visibility state with yours.          | `boolean`                                                                                                                                                                                                                                                                                                                              | `false`              |
+| `inoTrigger`     | `ino-trigger`      | The trigger to show the tooltip - either click, hover or focus. Multiple triggers are possible by separating them with a space.                                                                         | `"click focus mouseenter" \| "click focus" \| "click mouseenter focus" \| "click mouseenter" \| "click" \| "focus click mouseenter" \| "focus click" \| "focus mouseenter click" \| "focus mouseenter" \| "focus" \| "mouseenter click focus" \| "mouseenter click" \| "mouseenter focus click" \| "mouseenter focus" \| "mouseenter"` | `'mouseenter focus'` |
 
 
 ## Events
 
-| Event               | Description                                                                                                                | Type                   |
-| ------------------- | -------------------------------------------------------------------------------------------------------------------------- | ---------------------- |
-| `clickOutside`      | Emits when an element which is not part of the popover is clicked. Should be used if you control the state of the popover. | `CustomEvent<void>`    |
-| `visibilityChanged` |                                                                                                                            | `CustomEvent<boolean>` |
+| Event               | Description                                                                                                                                                                                                                                                                                                                                                                           | Type                   |
+| ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------- |
+| `visibilityChanged` | Emits when the popover wants to show (`true`) or hide (`false`) itself. This is depended on the `ino-trigger` property. Use this event in controlled-mode (see `ino-controlled`).  e.g.: `ino-trigger = 'click'` - This events emits with `true` when the user clicks on the target (slot/`ino-for`/parent-element) and emits with `false` when the target or the outside is clicked. | `CustomEvent<boolean>` |
 
 
 ## Methods
@@ -165,6 +198,13 @@ For more informations see: https://atomiks.github.io/tippyjs/
 Type: `Promise<any>`
 
 
+
+
+## Slots
+
+| Slot                    | Description                                  |
+| ----------------------- | -------------------------------------------- |
+| `"ino-popover-trigger"` | The target element to attach the triggers to |
 
 
 ----------------------------------------------

--- a/packages/elements/src/components/ino-popover/readme.md
+++ b/packages/elements/src/components/ino-popover/readme.md
@@ -132,6 +132,7 @@ class MyComponent extends Component {
 
 <!-- Auto Generated Below -->
 
+
 ## Properties
 
 | Property         | Attribute          | Description                                                                                                                              | Type                                                                                                                                                                                                                                                                                                                                   | Default              |
@@ -143,17 +144,21 @@ class MyComponent extends Component {
 | `inoShow`        | `ino-show`         | Programmatically show or hide the popover. Using this property disables the functionality of the `inoTrigger` prop.                      | `boolean`                                                                                                                                                                                                                                                                                                                              | `undefined`          |
 | `inoTrigger`     | `ino-trigger`      | The trigger to show the tooltip - either click, hover or focus. Multiple triggers are possible by separating them with a space.          | `"click focus mouseenter" \| "click focus" \| "click mouseenter focus" \| "click mouseenter" \| "click" \| "focus click mouseenter" \| "focus click" \| "focus mouseenter click" \| "focus mouseenter" \| "focus" \| "mouseenter click focus" \| "mouseenter click" \| "mouseenter focus click" \| "mouseenter focus" \| "mouseenter"` | `'mouseenter focus'` |
 
+
 ## Events
 
-| Event          | Description                                                                                                           | Type                |
-| -------------- | --------------------------------------------------------------------------------------------------------------------- | ------------------- |
-| `clickOutside` | Emits when an element which is not part of the popover is clicked. Should be used if you use the `ino-show` property. | `CustomEvent<void>` |
+| Event               | Description                                                                                                                | Type                   |
+| ------------------- | -------------------------------------------------------------------------------------------------------------------------- | ---------------------- |
+| `clickOutside`      | Emits when an element which is not part of the popover is clicked. Should be used if you control the state of the popover. | `CustomEvent<void>`    |
+| `visibilityChanged` |                                                                                                                            | `CustomEvent<boolean>` |
+
 
 ## Methods
 
 ### `getTippyInstance() => Promise<any>`
 
-Returns the internally used tippy.js instance For more informations see: https://atomiks.github.io/tippyjs/
+Returns the internally used tippy.js instance
+For more informations see: https://atomiks.github.io/tippyjs/
 
 #### Returns
 

--- a/packages/elements/src/components/ino-popover/readme.md
+++ b/packages/elements/src/components/ino-popover/readme.md
@@ -20,8 +20,8 @@ The component can be used as follows:
   ino-for="<string>"
   ino-interactive="<boolean>"
   ino-placement="<string>" 
-  ino-show="<boolean>"
   ino-trigger="<string>"
+  ino-visible="<boolean>"
 >
   Any desired HTML
 </ino-popover>
@@ -49,10 +49,10 @@ There are currently three ways to attach your popover to a component:
 3. Using the parent element:
 ```html
 <ino-button>
-  Click to show/hide
-  <ino-popover ino-trigger="click">
-      I'm the content of the popover
-  </ino-popover>
+    Click to show/hide
+    <ino-popover ino-trigger="click">
+        I'm the content of the popover
+    </ino-popover>
 </ino-button>
 ```
 
@@ -83,7 +83,7 @@ class MyComponent extends Component {
 ```
 _Controlled_
 
-Or you use the `ino-controlled` and `ino-show` property to show/hide the popover by yourself. 
+Or you use the `ino-controlled` and `ino-visible` property to show/hide the popover by yourself. 
 This is helpful if you want to implement custom logic when the popover should be shown or hidden.
 
 ```typescript jsx
@@ -106,8 +106,8 @@ class MyComponent extends Component {
       <div>
         <InoPopover 
           inoControlled 
-          inoShow={this.state.showPopover}
-          onVisibilityChanged={(e) => setPopoverState(e.detail)}
+          inoVisible={this.state.showPopover}
+          onInoVisibleChanged={(e) => setPopoverState(e.detail)}
         >
           <InoButton slot="ino-popover-trigger">
             Open Popover
@@ -179,19 +179,19 @@ class MyComponent extends Component {
 | Property         | Attribute          | Description                                                                                                                                                                                             | Type                                                                                                                                                                                                                                                                                                                                   | Default              |
 | ---------------- | ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------- |
 | `inoColorScheme` | `ino-color-scheme` | Sets the color scheme of the popup Valid options include: 'primary', 'secondary', 'light', 'transparent'                                                                                                | `string`                                                                                                                                                                                                                                                                                                                               | `'primary'`          |
-| `inoControlled`  | `ino-controlled`   | Used to indicate if the popover should be controlled by itself (`false`) or manually by the `ino-show` property (`true`)                                                                                | `boolean`                                                                                                                                                                                                                                                                                                                              | `false`              |
+| `inoControlled`  | `ino-controlled`   | Used to indicate if the popover should be controlled by itself (`false`) or manually by the `ino-visible` property (`true`)                                                                             | `boolean`                                                                                                                                                                                                                                                                                                                              | `false`              |
 | `inoFor`         | `ino-for`          | The target id the popover belongs to. If not given, the popover is attached to the element provided in the named slot (`ino-popover-trigger`) or the parent component if a slot element does not exist. | `string`                                                                                                                                                                                                                                                                                                                               | `undefined`          |
 | `inoInteractive` | `ino-interactive`  | Use this if you want to interact with the popover content (e.g. button clicks)                                                                                                                          | `boolean`                                                                                                                                                                                                                                                                                                                              | `false`              |
 | `inoPlacement`   | `ino-placement`    | The placement of this popover. Accepted values: `top(-start, -end)`, `right(-start, -end)`, `bottom(-start, -end)`, `left(-start, -end)`                                                                | `"auto" \| "auto-end" \| "auto-start" \| "bottom" \| "bottom-end" \| "bottom-start" \| "left" \| "left-end" \| "left-start" \| "right" \| "right-end" \| "right-start" \| "top" \| "top-end" \| "top-start"`                                                                                                                           | `'auto'`             |
-| `inoShow`        | `ino-show`         | Programmatically show or hide the popover. Can only be used in controlled mode (see property `ino-controlled`). Use the `visibilityChanged` to sync the popovers' visibility state with yours.          | `boolean`                                                                                                                                                                                                                                                                                                                              | `false`              |
 | `inoTrigger`     | `ino-trigger`      | The trigger to show the tooltip - either click, hover or focus. Multiple triggers are possible by separating them with a space.                                                                         | `"click focus mouseenter" \| "click focus" \| "click mouseenter focus" \| "click mouseenter" \| "click" \| "focus click mouseenter" \| "focus click" \| "focus mouseenter click" \| "focus mouseenter" \| "focus" \| "mouseenter click focus" \| "mouseenter click" \| "mouseenter focus click" \| "mouseenter focus" \| "mouseenter"` | `'mouseenter focus'` |
+| `inoVisible`     | `ino-visible`      | Programmatically show or hide the popover. Can only be used in controlled mode (see property `ino-controlled`). Use the `inoVisibleChanged` to sync the popovers' visibility state with yours.          | `boolean`                                                                                                                                                                                                                                                                                                                              | `false`              |
 
 
 ## Events
 
 | Event               | Description                                                                                                                                                                                                                                                                                                                                                                           | Type                   |
 | ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------- |
-| `visibilityChanged` | Emits when the popover wants to show (`true`) or hide (`false`) itself. This is depended on the `ino-trigger` property. Use this event in controlled-mode (see `ino-controlled`).  e.g.: `ino-trigger = 'click'` - This events emits with `true` when the user clicks on the target (slot/`ino-for`/parent-element) and emits with `false` when the target or the outside is clicked. | `CustomEvent<boolean>` |
+| `inoVisibleChanged` | Emits when the popover wants to show (`true`) or hide (`false`) itself. This is depended on the `ino-trigger` property. Use this event in controlled-mode (see `ino-controlled`).  e.g.: `ino-trigger = 'click'` - This events emits with `true` when the user clicks on the target (slot/`ino-for`/parent-element) and emits with `false` when the target or the outside is clicked. | `CustomEvent<boolean>` |
 
 
 ## Methods

--- a/packages/elements/src/components/ino-popover/readme.md
+++ b/packages/elements/src/components/ino-popover/readme.md
@@ -28,22 +28,32 @@ The component can be used as follows:
 ```
 
 #### Targets
-There are currently three ways to attach your popover to a component:
+There are currently three ways to attach your popover to a component, which results in a slightly different structure:
 
 1. Using the `ino-popover-trigger` slot _(preferred)_:
 ```html
 <ino-popover ino-trigger="click">
     <ino-button slot="ino-popover-trigger">Click to show/hide</ino-button>
-    I'm the content of the popover
+    <custom-html-content></custom-html-content>
 </ino-popover>
+```
+```html
+<ino-popover>
+├── <ino-button>
+└── <custom-html-content>
 ```
 
 2. Using the `ino-for` property:
 ```html
 <ino-button id="my-target" slot="ino-popover-trigger">Click to show/hide</ino-button>
 <ino-popover ino-for="my-target" ino-trigger="click">
-    I'm the content of the popover
+  <custom-html-content></custom-html-content>
 </ino-popover>
+```
+```html
+<ino-button>
+<ino-popover>
+└── <custom-html-content>
 ```
 
 3. Using the parent element:
@@ -51,11 +61,15 @@ There are currently three ways to attach your popover to a component:
 <ino-button>
     Click to show/hide
     <ino-popover ino-trigger="click">
-        I'm the content of the popover
+      <custom-html-content></custom-html-content>
     </ino-popover>
 </ino-button>
 ```
-
+```html
+<ino-button>
+└── <ino-popover>
+    └── <custom-html-content>
+```
 #### Controlled vs. Uncontrolled
 
 There are currently two ways you can manage the state of the popover.

--- a/packages/elements/src/util/component-utils.ts
+++ b/packages/elements/src/util/component-utils.ts
@@ -5,6 +5,13 @@ export function generateUniqueId() {
   return '_' + Math.random().toString(36).substr(2, 9);
 }
 
+export function getSlotContent(
+  el: HTMLElement,
+  slotName: string
+): HTMLElement | null {
+  return el.querySelector(`[slot="${slotName}"]`);
+}
+
 /**
  * Checks if the given element has at least one child node at the given slot
  * @param el The element which has a named slot inside

--- a/packages/storybook/src/stories/ino-popover/ino-popover.scss
+++ b/packages/storybook/src/stories/ino-popover/ino-popover.scss
@@ -1,5 +1,12 @@
 .story-popover {
-  padding-left: 20%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+
+  .row {
+    display: flex;
+    justify-content: space-between;
+  }
 
   ino-button {
     margin: 0 12px 12px 0;

--- a/packages/storybook/src/stories/ino-popover/ino-popover.scss
+++ b/packages/storybook/src/stories/ino-popover/ino-popover.scss
@@ -17,7 +17,6 @@
     padding: 24px;
     display: flex;
     justify-content: space-between;
-    --ino-icon-color-primary: white;
   }
 
   #interactive-demo-container {

--- a/packages/storybook/src/stories/ino-popover/ino-popover.scss
+++ b/packages/storybook/src/stories/ino-popover/ino-popover.scss
@@ -13,9 +13,11 @@
   }
 
   .styled-popover {
+    width: 200px;
     padding: 24px;
     display: flex;
     justify-content: space-between;
+    --ino-icon-color-primary: white;
   }
 
   #interactive-demo-container {

--- a/packages/storybook/src/stories/ino-popover/ino-popover.stories.js
+++ b/packages/storybook/src/stories/ino-popover/ino-popover.stories.js
@@ -6,16 +6,15 @@ import componentReadme from '_local-elements/src/components/ino-popover/readme.m
 import './ino-popover.scss';
 
 function subscribeToComponentEvents() {
-  let popoverRef;
-
   const eventHandler = function (e) {
-    e.target?.setAttribute('ino-show', e.detail);
+    console.log(e);
+    e.target?.setAttribute('ino-visible', e.detail);
     document.querySelector('#controlled-checkbox').checked = e.detail;
   };
-  document.addEventListener('visibilityChanged', eventHandler);
+  document.addEventListener('inoVisibleChanged', eventHandler);
 
   return () => {
-    document.addEventListener('visibilityChanged', eventHandler);
+    document.addEventListener('inoVisibleChanged', eventHandler);
   };
 }
 
@@ -98,7 +97,7 @@ export const DefaultUsage = () => /*html*/ `
       </ino-popover>
       </div>
       <h4>Controlled Popover</h4>
-      <ino-popover id="controlled-popover" ino-placement="left" ino-controlled ino-show="false" ino-trigger="click">
+      <ino-popover id="controlled-popover" ino-placement="left" ino-controlled ino-visible="false" ino-trigger="click">
         <ino-checkbox id="controlled-checkbox" slot="ino-popover-trigger">Uncheck to hide / check to show</ino-checkbox>
         I'm a controlled popover
       </ino-popover>

--- a/packages/storybook/src/stories/ino-popover/ino-popover.stories.js
+++ b/packages/storybook/src/stories/ino-popover/ino-popover.stories.js
@@ -91,14 +91,14 @@ export const DefaultUsage = () => /*html*/ `
       </ino-popover>
 
       <ino-button id="popover-interactive">Interactive content</ino-button>
-      <ino-popover ino-interactive="true" ino-for="popover-interactive" ino-trigger="click" ino-color-scheme="transparent">
+      <ino-popover ino-interactive="true" ino-for="popover-interactive" ino-trigger="click">
         <div id="interactive-demo-container">
-            <ino-button>You can click me without closing this popover!</ino-button>
+            <ino-button ino-fill="outline" ino-color-scheme="white">You can click me without closing this popover!</ino-button>
         </div>
       </ino-popover>
       </div>
       <h4>Controlled Popover</h4>
-      <ino-popover id="controlled-popover" ino-placement="left" ino-for="controlled-checkbox" ino-show="false" ino-trigger="click">
+      <ino-popover id="controlled-popover" ino-placement="left" ino-controlled ino-show="false" ino-trigger="click">
         <ino-checkbox id="controlled-checkbox" slot="ino-popover-trigger">Uncheck to hide / check to show</ino-checkbox>
         I'm a controlled popover
       </ino-popover>

--- a/packages/storybook/src/stories/ino-popover/ino-popover.stories.js
+++ b/packages/storybook/src/stories/ino-popover/ino-popover.stories.js
@@ -9,20 +9,15 @@ function subscribeToComponentEvents() {
   let popoverRef;
 
   const eventHandler = function (e) {
+    console.log('EVENT: ', e);
     if (e.target) {
       const checkState = e.detail;
 
-      e.target.setAttribute('checked', checkState);
-
-      if (!popoverRef) {
-        popoverRef = document.getElementById('controlled-popover');
-      }
-
-      popoverRef.setAttribute('ino-show', checkState);
+      e.target.setAttribute('ino-show', checkState);
     }
   };
 
-  document.addEventListener('checkedChange', eventHandler);
+  document.addEventListener('visibilityChanged', eventHandler);
 
   return () => {
     document.removeEventListener('checkedChange', eventHandler);
@@ -42,8 +37,10 @@ export default {
 
 export const DefaultUsage = () => /*html*/ `
     <div class="story-popover">
+
       <ino-button id="popover-target">Popover</ino-button>
       <ino-popover
+        ino-show="false"
         ino-for="popover-target"
         ino-interactive="${boolean('ino-interactive', false)}"
         ino-placement="${select(

--- a/packages/storybook/src/stories/ino-popover/ino-popover.stories.js
+++ b/packages/storybook/src/stories/ino-popover/ino-popover.stories.js
@@ -1,20 +1,50 @@
-import { boolean, select, text } from '@storybook/addon-knobs';
+import { boolean, select } from '@storybook/addon-knobs';
 
 import withStencilReadme from '_local-storybookcore/with-stencil-readme';
 
 import componentReadme from '_local-elements/src/components/ino-popover/readme.md';
 import './ino-popover.scss';
 
+function subscribeToComponentEvents() {
+  let popoverRef;
+
+  const eventHandler = function (e) {
+    if (e.target) {
+      const checkState = e.detail;
+
+      e.target.setAttribute('checked', checkState);
+
+      if (!popoverRef) {
+        popoverRef = document.getElementById('controlled-popover');
+      }
+
+      popoverRef.setAttribute('ino-show', checkState);
+    }
+  };
+
+  document.addEventListener('checkedChange', eventHandler);
+
+  return () => {
+    document.removeEventListener('checkedChange', eventHandler);
+  };
+}
+
 export default {
   title: 'Notification/<ino-popover>',
-  decorators: [withStencilReadme(componentReadme)],
+  decorators: [
+    withStencilReadme(componentReadme),
+    (story) => {
+      subscribeToComponentEvents();
+      return story();
+    },
+  ],
 };
 
 export const DefaultUsage = () => /*html*/ `
     <div class="story-popover">
       <ino-button id="popover-target">Popover</ino-button>
       <ino-popover
-        ino-for="${text('ino-for', 'popover-target')}"
+        ino-for="popover-target"
         ino-interactive="${boolean('ino-interactive', false)}"
         ino-placement="${select(
           'ino-placement',
@@ -50,13 +80,18 @@ export const DefaultUsage = () => /*html*/ `
       <ino-button class="placement-button" id="popover-positions-target">Popover</ino-button>
 
       <h4>Triggers</h4>
-      <ino-button id="popover-hover-focus">Hover & focus</ino-button>
-      <ino-popover ino-for="popover-hover-focus">This popover occurs on hover and focus.</ino-popover>
+      <div class="row">
+      <ino-button id="popover-hover">Mouseenter</ino-button>
+      <ino-popover ino-placement="left" ino-for="popover-hover" ino-trigger="mouseenter">This popover occurs on mouseenter</ino-popover>
+
+      <ino-button id="popover-focus">Focus</ino-button>
+      <ino-popover ino-placement="top" ino-for="popover-focus" ino-trigger="focus">This popover occurs on focus.</ino-popover>
 
       <ino-button id="popover-click">Click</ino-button>
-      <ino-popover ino-for="popover-click" ino-trigger="click">This popover occurs on click.</ino-popover>
-
+      <ino-popover ino-placement="right" ino-for="popover-click" ino-trigger="click">This popover occurs on click.</ino-popover>
+</div>
       <h4>Interactions</h4>
+            <div class="row">
       <ino-button id="popover-non-interactive">Non-Interactive content</ino-button>
       <ino-popover ino-interactive="false" ino-for="popover-non-interactive" ino-trigger="click" ino-color-scheme="transparent">
         <div id="interactive-demo-container">
@@ -69,6 +104,12 @@ export const DefaultUsage = () => /*html*/ `
         <div id="interactive-demo-container">
             <ino-button>You can click me without closing this popover!</ino-button>
         </div>
+      </ino-popover>
+      </div>
+      <h4>Controlled Popover</h4>
+      <ino-checkbox id="controlled-checkbox" checked="true">Uncheck to hide / check to show</ino-checkbox>
+      <ino-popover id="controlled-popover" ino-placement="bottom" ino-for="controlled-checkbox" ino-show="true">
+        I'm a controlled popover
       </ino-popover>
     </div>
   `;

--- a/packages/storybook/src/stories/ino-popover/ino-popover.stories.js
+++ b/packages/storybook/src/stories/ino-popover/ino-popover.stories.js
@@ -9,18 +9,13 @@ function subscribeToComponentEvents() {
   let popoverRef;
 
   const eventHandler = function (e) {
-    console.log('EVENT: ', e);
-    if (e.target) {
-      const checkState = e.detail;
-
-      e.target.setAttribute('ino-show', checkState);
-    }
+    e.target?.setAttribute('ino-show', e.detail);
+    document.querySelector('#controlled-checkbox').checked = e.detail;
   };
-
   document.addEventListener('visibilityChanged', eventHandler);
 
   return () => {
-    document.removeEventListener('checkedChange', eventHandler);
+    document.addEventListener('visibilityChanged', eventHandler);
   };
 }
 
@@ -40,7 +35,6 @@ export const DefaultUsage = () => /*html*/ `
 
       <ino-button id="popover-target">Popover</ino-button>
       <ino-popover
-        ino-show="false"
         ino-for="popover-target"
         ino-interactive="${boolean('ino-interactive', false)}"
         ino-placement="${select(
@@ -104,8 +98,8 @@ export const DefaultUsage = () => /*html*/ `
       </ino-popover>
       </div>
       <h4>Controlled Popover</h4>
-      <ino-checkbox id="controlled-checkbox" checked="true">Uncheck to hide / check to show</ino-checkbox>
-      <ino-popover id="controlled-popover" ino-placement="bottom" ino-for="controlled-checkbox" ino-show="true">
+      <ino-popover id="controlled-popover" ino-placement="left" ino-for="controlled-checkbox" ino-show="false" ino-trigger="click">
+        <ino-checkbox id="controlled-checkbox" slot="ino-popover-trigger">Uncheck to hide / check to show</ino-checkbox>
         I'm a controlled popover
       </ino-popover>
     </div>


### PR DESCRIPTION
Relates to #288 

In order to implement a better menu, it should be based on the popover and not on the MDC-Menu.
This PR provides functionalities to manage the state of the popover.

## Proposed Changes

- Add new `ino-controlled` and `ino-show` property which can be used to control the state of the popover
- Add `visibilityChanged` event
- Add slot `ino-popover-trigger`
- Update ReadMe
- Update Storybook entry of the `ino-popover`