### PR TITLE
style(elements|ino-popover): use scale-animation as default

### DIFF
--- a/packages/elements/src/components/ino-popover/ino-popover.scss
+++ b/packages/elements/src/components/ino-popover/ino-popover.scss
@@ -1,6 +1,7 @@
 @use 'base/mdc-customize';
 @use 'ino-tooltip/mixins' as tooltip-mixins;
 @use 'base/theme';
+@import '~tippy.js/animations/scale.css';
 
 ino-popover .ino-popover {
   //default color scheme

--- a/packages/elements/src/components/ino-popover/ino-popover.tsx
+++ b/packages/elements/src/components/ino-popover/ino-popover.tsx
@@ -136,6 +136,7 @@ export class Popover implements ComponentInterface {
 
     const options: Partial<Props> = {
       allowHTML: true,
+      animation: 'scale',
       appendTo: this.inoPopoverContainer,
       content: this.inoPopoverContent,
       duration: 100,


### PR DESCRIPTION
## Proposed Changes

- Use a default `scale` animation provided by tippy
