### PR TITLE
fix(elements|ino-tooltip): updating `ino-label` leads to non-styled text

### DIFF
--- a/packages/elements/src/components/ino-tooltip/ino-tooltip.tsx
+++ b/packages/elements/src/components/ino-tooltip/ino-tooltip.tsx
@@ -67,13 +67,6 @@ export class Tooltip implements ComponentInterface {
    */
   @Prop() inoLabel?: string;
 
-  @Watch('inoLabel')
-  inoLabelChanged() {
-    if (this.tooltipInstance) {
-      this.tooltipInstance.setContent(this.inoLabel);
-    }
-  }
-
   /**
    * Returns the internally used tippy.js instance
    * For more informations see: https://atomiks.github.io/tippyjs/


### PR DESCRIPTION
Closes #300 

## Proposed Changes

- Delete watcher that replaced the whole tooltip content including containers
