### PR TITLE
chore(storybook): bump marked from 1.2.0 to 2.0.1

### DIFF
--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -64,7 +64,7 @@
     "jest": "24.8.0",
     "jest-cli": "24.8.0",
     "jest-environment-node": "23.4.0",
-    "marked": "^1.2.0",
+    "marked": ">=2.0.0",
     "node-sass": "^4.12.0",
     "prettier": "^1.16.4",
     "react": "^16.8.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -14933,10 +14933,10 @@ markdown-to-jsx@^6.11.4:
     prop-types "^15.6.2"
     unquote "^1.1.0"
 
-marked@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.npmjs.org/marked/-/marked-1.2.0.tgz#7221ce2395fa6cf6d722e6f2871a32d3513c85ca"
-  integrity sha512-tiRxakgbNPBr301ihe/785NntvYyhxlqcL3YaC8CaxJQh7kiaEtrN9B/eK2I2943Yjkh5gw25chYFDQhOMCwMA==
+marked@>=2.0.0:
+  version "2.0.1"
+  resolved "https://registry.npmjs.org/marked/-/marked-2.0.1.tgz#5e7ed7009bfa5c95182e4eb696f85e948cefcee3"
+  integrity sha512-5+/fKgMv2hARmMW7DOpykr2iLhl0NgjyELk5yn92iE7z8Se1IS9n3UsFm86hFXIkvMBmVxki8+ckcpjBeyo/hw==
 
 material-colors@^1.2.1:
   version "1.2.6"


### PR DESCRIPTION
As suggested by the depandabot alert
https://github.com/inovex/elements/security/dependabot/packages/storybook/package.json/marked/open