### PR TITLE
refactor(elements): use listen decorator

### DIFF
--- a/packages/elements/src/components/ino-dialog/ino-dialog.e2e.ts
+++ b/packages/elements/src/components/ino-dialog/ino-dialog.e2e.ts
@@ -46,13 +46,13 @@ describe('InoDialog', () => {
       const inoDialog = await page.find(INO_DIALOG_SELECTOR);
       const inoChangedEvent = await page.spyOnEvent('openChange');
 
-      await inoDialog.triggerEvent('MDCDialog:opened');
+      await inoDialog.setAttribute('ino-open', true);
       await page.waitForChanges();
 
       expect(inoChangedEvent).toHaveReceivedEvent();
       expect(inoChangedEvent).toHaveReceivedEventDetail(true);
 
-      await inoDialog.triggerEvent('MDCDialog:closed');
+      await inoDialog.setAttribute('ino-open', false);
       await page.waitForChanges();
 
       expect(inoChangedEvent).toHaveReceivedEvent();

--- a/packages/elements/src/components/ino-dialog/ino-dialog.tsx
+++ b/packages/elements/src/components/ino-dialog/ino-dialog.tsx
@@ -29,8 +29,10 @@ export class Dialog implements ComponentInterface {
   inoOpenChange(newVal: boolean) {
     if (newVal) {
       this.mdcDialog.open();
+      this.openChange.emit(true);
     } else {
       this.mdcDialog.close();
+      this.openChange.emit(false);
     }
   }
 
@@ -43,16 +45,6 @@ export class Dialog implements ComponentInterface {
     this.mdcDialog = new MDCDialog(
       this.el.shadowRoot.querySelector('.mdc-dialog')
     );
-    this.el.addEventListener('MDCDialog:opened', (e) => {
-      e.preventDefault();
-      e.stopPropagation();
-      this.openChange.emit(true);
-    });
-    this.el.addEventListener('MDCDialog:closed', (e) => {
-      e.preventDefault();
-      e.stopPropagation();
-      this.openChange.emit(false);
-    });
     this.mdcDialog.scrimClickAction = '';
     this.mdcDialog.escapeKeyAction = '';
     if (this.inoOpen) {

--- a/packages/elements/src/components/ino-tab-bar/ino-tab-bar.tsx
+++ b/packages/elements/src/components/ino-tab-bar/ino-tab-bar.tsx
@@ -9,7 +9,7 @@ import {
   Prop,
   Watch,
   h, Listen
-} from "@stencil/core";
+} from '@stencil/core';
 
 @Component({
   tag: 'ino-tab-bar',

--- a/packages/elements/src/components/ino-tab-bar/ino-tab-bar.tsx
+++ b/packages/elements/src/components/ino-tab-bar/ino-tab-bar.tsx
@@ -8,8 +8,8 @@ import {
   Host,
   Prop,
   Watch,
-  h,
-} from '@stencil/core';
+  h, Listen
+} from "@stencil/core";
 
 @Component({
   tag: 'ino-tab-bar',
@@ -42,15 +42,14 @@ export class TabBar implements ComponentInterface {
   componentDidLoad() {
     this.mdcInstance = new MDCTabBar(this.el.querySelector('.mdc-tab-bar'));
     this.mdcInstance.activateTab(this.inoActiveTab);
-    this.el.addEventListener('inoInteracted', this.interactionHandler);
   }
 
   disconnectedCallback() {
     this.mdcInstance?.destroy();
-    this.el.removeEventListener('inoInteracted', this.interactionHandler);
   }
 
-  interactionHandler = async (e) => {
+  @Listen('inoInteracted')
+  async interactionHandler(e) {
     e.stopPropagation();
     const allTabs = await Promise.all(
       Array.from(this.el.querySelectorAll('ino-tab'))

--- a/packages/elements/src/components/ino-tab/ino-tab.tsx
+++ b/packages/elements/src/components/ino-tab/ino-tab.tsx
@@ -6,8 +6,8 @@ import {
   EventEmitter,
   Host,
   Prop,
-  h,
-} from '@stencil/core';
+  h, Listen
+} from "@stencil/core";
 import classNames from 'classnames';
 
 @Component({
@@ -44,15 +44,8 @@ export class Tab implements ComponentInterface {
    */
   @Event() inoInteracted!: EventEmitter;
 
-  componentDidLoad() {
-    this.el.addEventListener('MDCTab:interacted', this.interactionHandler);
-  }
-
-  componentDidUnLoad() {
-    this.el.removeEventListener('MDCTab:interacted', this.interactionHandler);
-  }
-
-  interactionHandler = (e) => {
+  @Listen('MDCTab:interacted')
+  interactionHandler(e) {
     e.stopPropagation();
     this.inoInteracted.emit(this.el);
   };


### PR DESCRIPTION
⚙️ **Changes:**
* Removed the event listeners from the `ino-dialog` component since the events were never dispatched due to the missing `data-mdc-dialog-action` attribute (see [mdc-dialog documentation](https://github.com/material-components/material-components-web/tree/master/packages/mdc-dialog#full-screen-dialog))
* Added stencil's `Listen()` decorator to the `ino-tab` and `ino-tab-bar` components

⚠️ **The `Listen()` decorator can not be used in the following components:**
| Component | Reason |
| ----------- | -------- |
| `ino-nav-drawer` | Event listener is attached to a specific target. The only targets supported by `Listen()` are `window`, `document`, and `body`. |
| `ino-chip-set` | Event listener is only attached in specific cases. |
| `ino-datepicker` | Event listener is attached to a specific target. |
| `ino-file-input` | Listens to multiple events at the same time. What is more, some events are only attached if they're supported by the browser. |
| `ino-radio-group` | Listeners are attached to specific targets. |
| `ino-segment-button` | Listeners are only attached if the segment button belongs to a group. |
| `ino-tooltip` | Listeners are attached to specific targets. |

🎟️ **Closes #249**