### PR TITLE
fix: fix canary-releases

### DIFF
--- a/.github/workflows/release-canary.yml
+++ b/.github/workflows/release-canary.yml
@@ -30,18 +30,21 @@ jobs:
           restore-keys: |
             ${{ runner.OS }}-lerna-
       - name: Download elements artifact
-        uses: actions/download-artifact@v2
+        uses: dawidd6/action-download-artifact@v2
         with:
+          workflow: ${{ github.event.workflow_run.workflow_id }}
           name: elements
           path: packages/elements/dist/
       - name: Download elements-react artifact
-        uses: actions/download-artifact@v2
+        uses: dawidd6/action-download-artifact@v2
         with:
+          workflow: ${{ github.event.workflow_run.workflow_id }}
           name: elements-react
           path: packages/elements-react/dist/
       - name: Download elements-angular artifact
-        uses: actions/download-artifact@v2
+        uses: dawidd6/action-download-artifact@v2
         with:
+          workflow: ${{ github.event.workflow_run.workflow_id }}
           name: elements-angular
           path: packages/elements-angular/dist/
       - run: yarn install --frozen-lockfile


### PR DESCRIPTION
Closes #358 

## Proposed Changes

- Replace github action `actions/download-artifact@v2` with `dawidd6/action-download-artifact@v2` to download artifact from the same workflow run
