### PR TITLE
fix: run canary release action only in master branch

### DIFF
--- a/.github/workflows/release-canary.yml
+++ b/.github/workflows/release-canary.yml
@@ -9,7 +9,9 @@ on:
 jobs:
   canary-release:
     runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    if: |
+      github.ref == 'refs/heads/master' &&
+      github.event.workflow_run.conclusion == 'success'
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Closes #360 

## Proposed Changes

- Check if the current branch is the master branch
