### PR TITLE
fix(storybook|ino-snackbar): avoid multiple snackbar instances

### DIFF
--- a/packages/storybook/src/stories/ino-snackbar/ino-snackbar.stories.js
+++ b/packages/storybook/src/stories/ino-snackbar/ino-snackbar.stories.js
@@ -14,18 +14,28 @@ function subscribeToComponentEvents() {
 
     const templates = Array.from(document.getElementsByTagName('template'));
     const templateWithId = templates.find(
-      (template) => template.id === target.id
+      (template) => template.id === `${target.id}-tmpl`
     );
-
-    document.body.appendChild(templateWithId.content.cloneNode(true));
+    const snackbarInstanceWithId = document.querySelector(
+      `ino-snackbar#${target.id}-instance`
+    );
+    if (!snackbarInstanceWithId) {
+      document.body.appendChild(templateWithId.content.cloneNode(true));
+    }
   };
 
   document.addEventListener('click', eventHandler);
+  document.addEventListener('hideEl', (e) => {
+    e.target.remove();
+  });
   // == event block
 
   // unsubscribe function will be called by Storybook
   return () => {
     document.removeEventListener('click', eventHandler);
+    document.removeEventListener('hideEl', (e) => {
+      e.target.remove();
+    });
   };
 }
 
@@ -62,11 +72,10 @@ export const DefaultUsage = () => /*html*/ `
             )};
           }
         </style>
-        <ino-button id="snackbar-temp">Show Snackbar</ino-button>
-        <template id="snackbar-temp">
+        <ino-button id="customizable-snackbar">Show Snackbar</ino-button>
+        <template id="customizable-snackbar-tmpl">
           <ino-snackbar
-              class="customizable-snackbar"
-              id="custom-snackbar"
+              id="customizable-snackbar-instance"
               ino-message="${text('ino-message', sampleText)}"
               ino-action-text="${text('ino-action-text', 'Anlegen')}"
               ino-timeout="${number('ino-timeout', 5000)}"
@@ -84,32 +93,37 @@ export const DefaultUsage = () => /*html*/ `
 
         <h4>Variants</h4>
         <div class="snackbar-variants">
-          <ino-button id="snackbar-with-action-temp">Show Snackbar (With Action)</ino-button>
-          <template id="snackbar-with-action-temp">
+          <ino-button id="snackbar-with-action">Show Snackbar (With Action)</ino-button>
+          <template id="snackbar-with-action-tmpl">
               <ino-snackbar
+                  id="snackbar-with-action-instance"
                   ino-message="${sampleText}"
                   ino-action-text="Action"
                   ino-alignment="left" />
             </template>
-          <ino-button id="snackbar-no-action-temp">Show Snackbar (No Action)</ino-button>
-          <template id="snackbar-no-action-temp">
+          <ino-button id="snackbar-no-action">Show Snackbar (No Action)</ino-button>
+          <template id="snackbar-no-action-tmpl">
             <ino-snackbar
+                id="snackbar-no-action-instance"
+                class="snackbar-no-action-instance"
                 ino-message="${sampleText}"
                 ino-alignment="right" />
           </template>
         </div>
         <h4>Snackbar Types</h4>
         <div class="snackbar-variants">
-          <ino-button id="snackbar--warning">Show Snackbar (warning)</ino-button>
-          <template id="snackbar--warning">
+          <ino-button id="snackbar-warning">Show Snackbar (warning)</ino-button>
+          <template id="snackbar-warning-tmpl">
             <ino-snackbar
+                id="snackbar-warning-instance"
                 ino-message="${sampleText}"
                 ino-action-text="Action"
                 ino-type="warning"/>
           </template>
-          <ino-button id="snackbar--error">Show Snackbar (error)</ino-button>
-          <template id="snackbar--error">
+          <ino-button id="snackbar-error">Show Snackbar (error)</ino-button>
+          <template id="snackbar-error-tmpl">
             <ino-snackbar
+                id="snackbar-error-instance"
                 ino-message="${sampleText}"
                 ino-action-text="Action"
                 ino-type="error" />
@@ -118,8 +132,9 @@ export const DefaultUsage = () => /*html*/ `
         <h4>Alignments</h4>
         <div class="snackbar-variants">
             <ino-button id="left-align">Left</ino-button>
-            <template id="left-align">
+            <template id="left-align-tmpl">
               <ino-snackbar
+                  id="left-align-instance"
                   ino-message="${sampleText}"
                   ino-action-text="Anlegen"
                   ino-alignment="left"
@@ -127,16 +142,18 @@ export const DefaultUsage = () => /*html*/ `
               </ino-snackbar>
             </template>
             <ino-button id="center-align">Center</ino-button>
-            <template id="center-align">
+            <template id="center-align-tmpl">
               <ino-snackbar
+                  id="center-align-instance"
                   ino-message="${sampleText}"
                   ino-action-text="Anlegen"
                   >
               </ino-snackbar>
             </template>
             <ino-button id="right-align">Right</ino-button>
-            <template id="right-align">
+            <template id="right-align-tmpl">
               <ino-snackbar
+                  id="right-align-instance"
                   ino-message="${sampleText}"
                   ino-action-text="Anlegen"
                   ino-alignment="right"


### PR DESCRIPTION
Closes #81 

## Proposed Changes

- check if corresponding snackbar already exists before appending it to the DOM on ino-button click
