### PR TITLE
style(elements|ino-list): add css variable for border radius

### DIFF
--- a/packages/elements/src/components/ino-control-item/ino-control-item.scss
+++ b/packages/elements/src/components/ino-control-item/ino-control-item.scss
@@ -2,3 +2,7 @@
 @use '@material/list/mdc-list';
 @use '@material/form-field/mdc-form-field';
 @use '@material/checkbox/mdc-checkbox';
+
+ino-control-item > ino-list-item {
+  border-radius: inherit;
+}

--- a/packages/elements/src/components/ino-list/ino-list.scss
+++ b/packages/elements/src/components/ino-list/ino-list.scss
@@ -4,7 +4,7 @@
 @include list.core-styles;
 
 /**
-  * @prop --border-radius: Border radius
+  * @prop --border-radius: Border radius of the list container
  */
 ino-list {
   --border-radius: (var(--border-radius), 0);
@@ -15,18 +15,22 @@ ino-list {
 
   ino-list-item:first-child,
   ino-list-item:last-child,
+  ino-control-item:first-child,
+  ino-control-item:last-child,
   .mdc-list--avatar-list .mdc-list-item__graphic {
     overflow: hidden;
   }
 
   $half-border-radius: calc(var(--border-radius) * 0.5);
 
-  ino-list-item:first-child {
+  .mdc-list > ino-list-item:first-child,
+  .mdc-list > ino-control-item:first-child {
     border-top-left-radius: $half-border-radius;
     border-top-right-radius: $half-border-radius;
   }
 
-  ino-list-item:last-child {
+  .mdc-list > ino-list-item:last-child,
+  .mdc-list > ino-control-item:last-child {
     border-bottom-left-radius: $half-border-radius;
     border-bottom-right-radius: $half-border-radius;
   }

--- a/packages/elements/src/components/ino-list/ino-list.scss
+++ b/packages/elements/src/components/ino-list/ino-list.scss
@@ -1,11 +1,33 @@
 @use 'base/mdc-customize';
 @use '@material/list';
+
 @include list.core-styles;
 
+/**
+  * @prop --border-radius: Border radius
+ */
 ino-list {
+  --border-radius: (var(--border-radius), 0);
+
   display: block;
 
+  border-radius: var(--border-radius);
+
+  ino-list-item:first-child,
+  ino-list-item:last-child,
   .mdc-list--avatar-list .mdc-list-item__graphic {
     overflow: hidden;
+  }
+
+  $half-border-radius: calc(var(--border-radius) * 0.5);
+
+  ino-list-item:first-child {
+    border-top-left-radius: $half-border-radius;
+    border-top-right-radius: $half-border-radius;
+  }
+
+  ino-list-item:last-child {
+    border-bottom-left-radius: $half-border-radius;
+    border-bottom-right-radius: $half-border-radius;
   }
 }

--- a/packages/elements/src/components/ino-list/ino-list.scss
+++ b/packages/elements/src/components/ino-list/ino-list.scss
@@ -4,14 +4,14 @@
 @include list.core-styles;
 
 /**
-  * @prop --border-radius: Border radius of the list container
+  * @prop --ino-list-item-border-radius: Border radius of the list container, also effects the first and last list item
  */
 ino-list {
-  --border-radius: (var(--border-radius), 0);
+  --list-item-border-radius: (var(--ino-list-item-border-radius), 0);
 
   display: block;
 
-  border-radius: var(--border-radius);
+  border-radius: var(--list-item-border-radius);
 
   ino-list-item:first-child,
   ino-list-item:last-child,
@@ -21,7 +21,7 @@ ino-list {
     overflow: hidden;
   }
 
-  $half-border-radius: calc(var(--border-radius) * 0.5);
+  $half-border-radius: calc(var(--list-item-border-radius) * 0.5);
 
   .mdc-list > ino-list-item:first-child,
   .mdc-list > ino-control-item:first-child {

--- a/packages/elements/src/components/ino-list/readme.md
+++ b/packages/elements/src/components/ino-list/readme.md
@@ -115,9 +115,9 @@ Provide `two-lines` to set proper style attributes for list items having a prima
 
 ## CSS Custom Properties
 
-| Name              | Description   |
-| ----------------- | ------------- |
-| `--border-radius` | Border radius |
+| Name              | Description                         |
+| ----------------- | ----------------------------------- |
+| `--border-radius` | Border radius of the list container |
 
 
 ## Dependencies

--- a/packages/elements/src/components/ino-list/readme.md
+++ b/packages/elements/src/components/ino-list/readme.md
@@ -113,6 +113,13 @@ Provide `two-lines` to set proper style attributes for list items having a prima
 | `"default"` | One or more `ino-(control\|list\|nav)-item` and `ino-list-divider` |
 
 
+## CSS Custom Properties
+
+| Name              | Description   |
+| ----------------- | ------------- |
+| `--border-radius` | Border radius |
+
+
 ## Dependencies
 
 ### Used by

--- a/packages/elements/src/components/ino-list/readme.md
+++ b/packages/elements/src/components/ino-list/readme.md
@@ -115,9 +115,9 @@ Provide `two-lines` to set proper style attributes for list items having a prima
 
 ## CSS Custom Properties
 
-| Name              | Description                         |
-| ----------------- | ----------------------------------- |
-| `--border-radius` | Border radius of the list container |
+| Name                            | Description                                                                    |
+| ------------------------------- | ------------------------------------------------------------------------------ |
+| `--ino-list-item-border-radius` | Border radius of the list container, also effects the first and last list item |
 
 
 ## Dependencies

--- a/packages/storybook/custom-elements.json
+++ b/packages/storybook/custom-elements.json
@@ -2720,7 +2720,12 @@
           "description": "One or more `ino-(control|list|nav)-item` and `ino-list-divider`"
         }
       ],
-      "cssProperties": [],
+      "cssProperties": [
+        {
+          "name": "--ino-list-item-border-radius",
+          "description": "Border radius of the list container, also effects the first and last list item"
+        }
+      ],
       "cssParts": []
     },
     {


### PR DESCRIPTION
Closes #364 

## Proposed Changes

- Add CSS-Var `--border-radius` to give the container of the `ino-list` a border-radius
- Also affects the first and last `ino-(list|control)-item` in the list