### PR TITLE
feat(elements|ino-datepicker): validate if first < second date

### DIFF
--- a/packages/elements/src/components/ino-datepicker/validator.spec.ts
+++ b/packages/elements/src/components/ino-datepicker/validator.spec.ts
@@ -24,27 +24,7 @@ describe('DateValidator', () => {
     expect(dateValidator.validate('01-01-2020')).toBe(false);
   });
 
-  it('should be valid if range in correct format', () => {
-    dateValidator.isRanged = true;
-    expect(dateValidator.validate('01.01.2020 to 02.01.2020')).toBe(true);
-  });
-
-  it('should be invalid if range in incorrect format', () => {
-    dateValidator.isRanged = true;
-    expect(dateValidator.validate('01-01-2020 to 02-01-2020')).toBe(false);
-  });
-
-  it('should be invalid if first date in range is in wrong format', () => {
-    dateValidator.isRanged = true;
-    expect(dateValidator.validate('01-01-2020 to 02.01.2020')).toBe(false);
-  });
-
-  it('should be invalid if second date in range is in wrong format', () => {
-    dateValidator.isRanged = true;
-    expect(dateValidator.validate('01.01.2020 to 02-01-2020')).toBe(false);
-  });
-
-  it('should be valid if value is equal to min date', () => {
+  it('should be valid if value is equal - min date', () => {
     dateValidator.minDate = '01.01.2020';
     expect(dateValidator.validate('01.01.2020')).toBe(true);
   });
@@ -59,7 +39,7 @@ describe('DateValidator', () => {
     expect(dateValidator.validate('31.12.2019')).toBe(false);
   });
 
-  it('should be valid if value is equal to max date', () => {
+  it('should be valid if value is equal - max date', () => {
     dateValidator.maxDate = '01.01.2020';
     expect(dateValidator.validate('01.01.2020')).toBe(true);
   });
@@ -86,9 +66,60 @@ describe('DateValidator', () => {
     }).toThrow();
   });
 
-  it('should throw error if value cannot be parsed', () => {
-    expect(() => {
-      dateValidator.validate('ABC');
-    }).toThrow();
+  it('should return false if value cannot be parsed', () => {
+    expect(dateValidator.validate('ABC')).toBeFalsy();
+  });
+
+  describe('Range', () => {
+    beforeEach(() => {
+      dateValidator.isRanged = true;
+    });
+
+    it('should be valid if range in correct format', () => {
+      dateValidator.isRanged = true;
+      expect(dateValidator.validate('01.01.2020 to 02.01.2020')).toBe(true);
+    });
+
+    it('should be invalid if range in incorrect format', () => {
+      dateValidator.isRanged = true;
+      expect(dateValidator.validate('01-01-2020 to 02-01-2020')).toBe(false);
+    });
+
+    it('should be invalid if first date in range is in wrong format', () => {
+      dateValidator.isRanged = true;
+      expect(dateValidator.validate('01-01-2020 to 02.01.2020')).toBe(false);
+    });
+
+    it('should be invalid if second date in range is in wrong format', () => {
+      dateValidator.isRanged = true;
+      expect(dateValidator.validate('01.01.2020 to 02-01-2020')).toBe(false);
+    });
+
+    it('should be invalid if date is less than min date', () => {
+      dateValidator.isRanged = true;
+      dateValidator.minDate = '02.01.2020';
+      expect(dateValidator.validate('01.01.2020 to 02.10.2020')).toBe(false);
+    });
+
+    it('should be invalid if date is greater than max date', () => {
+      dateValidator.isRanged = true;
+      dateValidator.maxDate = '01.10.2020';
+      expect(dateValidator.validate('01.01.2020 to 02.10.2020')).toBe(false);
+    });
+
+    it('should be invalid if second date is less than first date', () => {
+      dateValidator.isRanged = true;
+      expect(dateValidator.validate('01.01.2020 to 01.01.2019')).toBe(false);
+    });
+
+    it('should be invalid if second date is less than first date', () => {
+      dateValidator.isRanged = true;
+      expect(dateValidator.validate('01.01.2020 to 01.01.2019')).toBe(false);
+    });
+
+    it('should be invalid if second date is less than first date', () => {
+      dateValidator.isRanged = true;
+      expect(dateValidator.validate('01.01.2020 to 01.01.2019')).toBe(false);
+    });
   });
 });

--- a/packages/elements/src/components/ino-datepicker/validator.ts
+++ b/packages/elements/src/components/ino-datepicker/validator.ts
@@ -52,6 +52,10 @@ export class Validator {
       return false;
     }
 
+    if (this._isRanged && !this.validateRange(value)) {
+      return false;
+    }
+
     return true;
   };
 
@@ -105,9 +109,7 @@ export class Validator {
       );
       return formattedDate == value;
     } catch (_) {
-      throw new Error(
-        `Value (${value}) could not be parsed. Make sure to provide a date in the following format: ${this._dateFormat}`
-      );
+      // Silence the expection. This may not be a problem if the user is typing.
     }
   };
 
@@ -125,6 +127,16 @@ export class Validator {
     }
 
     return parsedDate;
+  };
+
+  private validateRange = (value: string): boolean => {
+    const dates = Validator.convertToRangeArray(value).map((date) =>
+      this.parseDate(date)
+    );
+    if (dates.length <= 1) {
+      return true;
+    }
+    return dates[1] >= dates[0];
   };
 
   set isDisabled(value: boolean) {


### PR DESCRIPTION
* Add validation for range dates such that the second one is large than the first one
* Restructure tests
* Ignore errors on wrong dateformats if the user ist still typing