### PR TITLE
fix(elements|ino-tab-bar): prevent autofocus on creation

### DIFF
--- a/packages/elements/src/components/ino-tab-bar/ino-tab-bar.tsx
+++ b/packages/elements/src/components/ino-tab-bar/ino-tab-bar.tsx
@@ -45,6 +45,7 @@ export class TabBar implements ComponentInterface {
 
   componentDidLoad() {
     this.mdcInstance = new MDCTabBar(this.el.querySelector('.mdc-tab-bar'));
+    this.mdcInstance.focusOnActivate = false;
     this.mdcInstance.activateTab(this.activeTab);
   }
 


### PR DESCRIPTION
Closes #196 

## Proposed Changes

- `focusOnActivate` property is set to `false` on creation