### PR TITLE
fix(elements|ino-select): hide input used for form validation

### DIFF
--- a/packages/elements/src/components/ino-select/ino-select.e2e.ts
+++ b/packages/elements/src/components/ino-select/ino-select.e2e.ts
@@ -82,7 +82,9 @@ describe('InoSelect', () => {
       `);
 
       const submitEventSpy = await page.spyOnEvent('submit');
-      await page.$eval(`#${formId}`, (form: HTMLFormElement) => form.submit());
+      await page.$eval(`#${formId}`, (form: HTMLFormElement) =>
+        form.requestSubmit()
+      );
       expect(submitEventSpy).not.toHaveReceivedEvent();
     });
   });

--- a/packages/elements/src/components/ino-select/ino-select.e2e.ts
+++ b/packages/elements/src/components/ino-select/ino-select.e2e.ts
@@ -54,5 +54,36 @@ describe('InoSelect', () => {
 
       expect(valueChangeEvent).toHaveReceivedEvent();
     });
+
+    it('should receive submit event if select is required and value is set', async () => {
+      const formId = 'my-submit-form';
+      page = await setupPageWithContent(`
+        <form id="${formId}">
+           <ino-select required value="1">
+               <ino-option value="1" id="opt1">1</ino-option>
+            </ino-select>
+        </form>
+      `);
+      const submitEventSpy = await page.spyOnEvent('submit');
+      await page.$eval(`#${formId}`, (form: HTMLFormElement) =>
+        form.requestSubmit()
+      );
+      expect(submitEventSpy).toHaveReceivedEvent();
+    });
+
+    it('should not receive submit event if select is required and no value is set', async () => {
+      const formId = 'my-submit-form';
+      page = await setupPageWithContent(`
+        <form id="${formId}">
+           <ino-select required>
+               <ino-option value="1" id="opt1">1</ino-option>
+            </ino-select>
+        </form>
+      `);
+
+      const submitEventSpy = await page.spyOnEvent('submit');
+      await page.$eval(`#${formId}`, (form: HTMLFormElement) => form.submit());
+      expect(submitEventSpy).not.toHaveReceivedEvent();
+    });
   });
 });

--- a/packages/elements/src/components/ino-select/ino-select.e2e.ts
+++ b/packages/elements/src/components/ino-select/ino-select.e2e.ts
@@ -1,3 +1,4 @@
+import { E2EElement, E2EPage } from '@stencil/core/testing';
 import { setupPageWithContent } from '../../util/e2etests-setup';
 
 const INO_SELECT = `
@@ -9,53 +10,46 @@ const INO_SELECT_SELECTOR = 'ino-select';
 const INNER_DIV_SELECTOR = 'ino-select > div';
 
 describe('InoSelect', () => {
+  let page: E2EPage;
+  let inoSelectEl: E2EElement;
+  let mdcSelectEl: E2EElement;
+
+  beforeEach(async () => {
+    page = await setupPageWithContent(INO_SELECT);
+    inoSelectEl = await page.find(INO_SELECT_SELECTOR);
+    mdcSelectEl = await page.find(INNER_DIV_SELECTOR);
+  });
+
   describe('Properties', () => {
     it('should render with the disabled property set to true', async () => {
-      const page = await setupPageWithContent(INO_SELECT);
-      const inoSelect = await page.find(INO_SELECT_SELECTOR);
-      await inoSelect.setAttribute('disabled', true);
+      await inoSelectEl.setAttribute('disabled', true);
       await page.waitForChanges();
-
-      const innerDiv = await page.find(INNER_DIV_SELECTOR);
-      expect(innerDiv).toHaveClass('mdc-select--disabled');
+      expect(mdcSelectEl).toHaveClass('mdc-select--disabled');
     });
 
     it('should render with the required property set to true', async () => {
-      const page = await setupPageWithContent(INO_SELECT);
-      const inoSelect = await page.find(INO_SELECT_SELECTOR);
-      await inoSelect.setAttribute('required', true);
+      await inoSelectEl.setAttribute('required', true);
       await page.waitForChanges();
-
-      const innerDiv = await page.find(INNER_DIV_SELECTOR);
-      expect(innerDiv).toHaveClass('mdc-select--required');
+      expect(mdcSelectEl).toHaveClass('mdc-select--required');
     });
 
     it('should render as an outlined element if inoOutlined is true', async () => {
-      const page = await setupPageWithContent(INO_SELECT);
-      const inoSelect = await page.find(INO_SELECT_SELECTOR);
-      await inoSelect.setAttribute('outline', true);
+      await inoSelectEl.setAttribute('outline', true);
       await page.waitForChanges();
-
-      const innerDiv = await page.find(INNER_DIV_SELECTOR);
-      expect(innerDiv).toHaveClass('mdc-select--outlined');
+      expect(mdcSelectEl).toHaveClass('mdc-select--outlined');
     });
 
     it('should render as a filled element if inoOutlined is false', async () => {
-      const page = await setupPageWithContent(INO_SELECT);
-
-      const innerDiv = await page.find(INNER_DIV_SELECTOR);
-      expect(innerDiv).not.toHaveClass('mdc-select--outlined');
-      expect(innerDiv).toHaveClass('mdc-select--filled');
+      expect(mdcSelectEl).not.toHaveClass('mdc-select--outlined');
+      expect(mdcSelectEl).toHaveClass('mdc-select--filled');
     });
   });
 
   describe('Events', () => {
     it('should emit a valueChange event upon receiving a MDCSelect:change event', async () => {
-      const page = await setupPageWithContent(INO_SELECT);
-      const inoSelect = await page.find(INO_SELECT_SELECTOR);
       const valueChangeEvent = await page.spyOnEvent('valueChange');
 
-      await inoSelect.triggerEvent('MDCSelect:change');
+      await inoSelectEl.triggerEvent('MDCSelect:change');
       await page.waitForChanges();
 
       expect(valueChangeEvent).toHaveReceivedEvent();

--- a/packages/elements/src/components/ino-select/ino-select.scss
+++ b/packages/elements/src/components/ino-select/ino-select.scss
@@ -27,10 +27,12 @@ ino-select {
 
   display: block;
 
-  input {
-    opacity: 0;
-    width: 95%; // 100% shows ellipsis in Chrome
-    cursor: pointer;
+  .ino-hidden-input {
+    width: 0;
+    height: 0;
+    padding: 0;
+    margin: 0;
+    border: 0;
   }
 
   .mdc-select__menu {
@@ -51,25 +53,25 @@ ino-select {
 
   .mdc-select {
     @include select.label-color(
-        (
-          focus: theme.color(primary),
-        )
+      (
+        focus: theme.color(primary),
+      )
     );
     @include select.bottom-line-color(
-        (
-          focus: theme.color(primary),
-        )
+      (
+        focus: theme.color(primary),
+      )
     );
     @include select.outline-color(
-        (
-          focus: theme.color(primary),
-        )
+      (
+        focus: theme.color(primary),
+      )
     );
     @include select.container-fill-color(
-        (
-          default: transparent,
-          disabled: transparent,
-        )
+      (
+        default: transparent,
+        disabled: transparent,
+      )
     );
 
     &--focused .mdc-select__anchor {
@@ -80,13 +82,13 @@ ino-select {
       display: none;
     }
 
-    .mdc-select__icon {
-      width: 16px;
-      height: 16px;
+    .mdc-select__dropdown-icon {
+      width: 24px;
+      height: 24px;
 
       ino-icon {
-        --icon-width: 16px;
-        --icon-height: 16px;
+        --icon-width: 24px;
+        --icon-height: 24px;
       }
     }
   }
@@ -107,6 +109,10 @@ ino-select {
 
     .mdc-select__selected-text {
       margin-top: 24px;
+    }
+
+    .mdc-select__dropdown-icon {
+      margin-top: 18px;
     }
 
     .mdc-floating-label {

--- a/packages/elements/src/components/ino-select/ino-select.tsx
+++ b/packages/elements/src/components/ino-select/ino-select.tsx
@@ -144,6 +144,7 @@ export class Select implements ComponentInterface {
     const hiddenInput = this.required ? (
       <input
         class="ino-hidden-input"
+        aria-hidden
         ref={(el) => (this.nativeSelectElement = el)}
         required={this.required}
       ></input>

--- a/packages/elements/src/components/ino-select/ino-select.tsx
+++ b/packages/elements/src/components/ino-select/ino-select.tsx
@@ -155,13 +155,13 @@ export class Select implements ComponentInterface {
     return (
       <Host name={this.name}>
         <div class={classSelect}>
+          {hiddenInput}
           <div class="mdc-select__anchor">
             {leadingSlotHasContent && (
               <span class="mdc-select__icon">
                 <slot name="icon-leading"></slot>
               </span>
             )}
-            {hiddenInput}
             <div class="mdc-select__selected-text">{this.value}</div>
             {this.renderDropdownIcon()}
             <ino-label

--- a/packages/storybook/config/global.scss
+++ b/packages/storybook/config/global.scss
@@ -12,16 +12,3 @@ body {
 .ino-story-composer {
   margin: 16px;
 }
-
-.ino-visually-hidden {
-  border: 0px;
-  clip: rect(0px, 0px, 0px, 0px);
-  clip-path: inset(50%);
-  height: 1px;
-  margin: 0px -1px -1px 0px;
-  overflow: hidden;
-  padding: 0px;
-  position: absolute;
-  width: 1px;
-  white-space: nowrap;
-}

--- a/packages/storybook/src/stories/ino-select/ino-select.stories.ts
+++ b/packages/storybook/src/stories/ino-select/ino-select.stories.ts
@@ -134,7 +134,7 @@ export const Form = () => html`
   <form>
     <p>Form should not be submittable if no value is selected</p>
     <ino-select required> ${optionsTemplate}</ino-select>
-    <button disabled type="submit">Submit</button>
+    <button type="submit">Submit</button>
   </form>
 `;
 

--- a/packages/storybook/src/stories/ino-select/ino-select.stories.ts
+++ b/packages/storybook/src/stories/ino-select/ino-select.stories.ts
@@ -134,7 +134,7 @@ export const Form = () => html`
   <form>
     <p>Form should submit if no value is selected</p>
     <ino-select required> ${optionsTemplate}</ino-select>
-    <button type="submit">Submit</button>
+    <ino-button type="submit">Submit</ino-button>
   </form>
 `;
 

--- a/packages/storybook/src/stories/ino-select/ino-select.stories.ts
+++ b/packages/storybook/src/stories/ino-select/ino-select.stories.ts
@@ -2,8 +2,15 @@ import { Components } from '@inovex.de/elements';
 import { useEffect } from '@storybook/client-api';
 import { Story } from '@storybook/web-components';
 import { html } from 'lit-html';
-import { defaultDecorator } from '../utils';
+import { defaultDecorator, showSnackbar } from '../utils';
 import './ino-select.scss';
+
+const handleFormSubmission = (e) => {
+  e.preventDefault();
+  showSnackbar('Form submitted.');
+};
+
+const handleSelect = (e) => e.target.setAttribute('value', e.detail);
 
 export default {
   title: 'Input/ino-select',
@@ -17,14 +24,18 @@ export default {
     (story) => defaultDecorator(story, 'story-select'),
     (story) => {
       useEffect(() => {
-        const eventHandler = (e) => e.target.setAttribute('value', e.detail);
+        const formElement = document.querySelector('form');
+        formElement?.addEventListener('submit', handleFormSubmission);
+
         const selects = document.querySelectorAll('ino-select');
-        selects.forEach((s) => s.addEventListener('valueChange', eventHandler));
-        return () =>
+        selects.forEach((s) => s.addEventListener('valueChange', handleSelect));
+        return () => {
           selects.forEach((s) =>
-            s.removeEventListener('valueChange', eventHandler)
+            s.removeEventListener('valueChange', handleSelect)
           );
-      });
+          formElement?.removeEventListener('submit', handleFormSubmission);
+        };
+      }, []);
       return story();
     },
   ],
@@ -117,6 +128,14 @@ export const Required = () => html`
   <ino-select required label="Required select" show-label-hint>
     ${optionsTemplate}
   </ino-select>
+`;
+
+export const Form = () => html`
+  <form>
+    <p>Form should not be submittable if no value is selected</p>
+    <ino-select required> ${optionsTemplate}</ino-select>
+    <button disabled type="submit">Submit</button>
+  </form>
 `;
 
 export const Option = () => html`

--- a/packages/storybook/src/stories/ino-select/ino-select.stories.ts
+++ b/packages/storybook/src/stories/ino-select/ino-select.stories.ts
@@ -132,7 +132,7 @@ export const Required = () => html`
 
 export const Form = () => html`
   <form>
-    <p>Form should not be submittable if no value is selected</p>
+    <p>Form should submit if no value is selected</p>
     <ino-select required> ${optionsTemplate}</ino-select>
     <button type="submit">Submit</button>
   </form>


### PR DESCRIPTION
Closes #414. Basically reverts https://github.com/inovex/elements/pull/355 and fixes https://github.com/inovex/elements/issues/348 properly.

## Proposed Changes

- Revert to using a hidden input instead of select
- Move hidden input to prevent collision with mdc select internal logic
- Add tests to confirm correct form submission handling
- Add a story to test form submission