### PR TITLE
fix(storybook): scope all story styles

### DIFF
--- a/packages/storybook/src/stories/ino-autocomplete/ino-autocomplete.stories.ts
+++ b/packages/storybook/src/stories/ino-autocomplete/ino-autocomplete.stories.ts
@@ -2,7 +2,7 @@ import { Components } from '@inovex.de/elements';
 import { useEffect } from '@storybook/client-api';
 import { Meta, Story } from '@storybook/web-components';
 import { html } from 'lit-html';
-import { defaultDecorator, showSnackbar } from '../utils';
+import { decorateStoryWithClass, showSnackbar } from '../utils';
 
 import './ino-autocomplete.scss';
 
@@ -15,7 +15,7 @@ export default {
     },
   },
   decorators: [
-    defaultDecorator,
+    (story) => decorateStoryWithClass(story),
     (story) => {
       useEffect(() => {
         const eventHandler = function (e: CustomEvent<string>) {

--- a/packages/storybook/src/stories/ino-button/ino-button.stories.ts
+++ b/packages/storybook/src/stories/ino-button/ino-button.stories.ts
@@ -1,14 +1,14 @@
 import { Components } from '@inovex.de/elements';
 import { Meta, Story } from '@storybook/web-components';
 import { html, TemplateResult } from 'lit-html';
-import { defaultDecorator } from '../utils';
+import { decorateStoryWithClass } from '../utils';
 
 import './ino-button.scss';
 
 export default {
   title: 'Buttons/<ino-button>',
   component: 'ino-button',
-  decorators: [defaultDecorator],
+  decorators: [(story) => decorateStoryWithClass(story, 'story-button')],
   parameters: {
     actions: {
       handles: [
@@ -68,21 +68,21 @@ export const Others = (): TemplateResult => html`
     </div>
     <div class="button-row">
       <ino-button fill="solid" color-scheme="secondary"
-        >Solid Secondary</ino-button
-      >
+        >Solid Secondary
+      </ino-button>
       <ino-button fill="outline" color-scheme="secondary"
-        >Outline Secondary</ino-button
-      >
+        >Outline Secondary
+      </ino-button>
       <ino-button fill="inverse" color-scheme="secondary"
-        >Inverse Secondary</ino-button
-      >
+        >Inverse Secondary
+      </ino-button>
     </div>
     <div class="button-row">
       <ino-button fill="outline" color-scheme="grey">Outline Grey</ino-button>
       <div class="white-button">
         <ino-button fill="outline" color-scheme="white"
-          >Outline White</ino-button
-        >
+          >Outline White
+        </ino-button>
       </div>
     </div>
 

--- a/packages/storybook/src/stories/ino-card/ino-card.stories.ts
+++ b/packages/storybook/src/stories/ino-card/ino-card.stories.ts
@@ -2,7 +2,7 @@ import { Components } from '@inovex.de/elements';
 import { useEffect } from '@storybook/client-api';
 import { Meta, Story } from '@storybook/web-components';
 import { html } from 'lit-html';
-import { defaultDecorator } from '../utils';
+import { decorateStoryWithClass } from '../utils';
 
 import './ino-card.scss';
 
@@ -10,7 +10,7 @@ export default {
   title: 'Structure/<ino-card>',
   component: 'ino-card',
   decorators: [
-    defaultDecorator,
+    (story) => decorateStoryWithClass(story, 'story-card'),
     (story) => {
       useEffect(() => {
         const handleClick = function (e) {

--- a/packages/storybook/src/stories/ino-carousel/ino-carousel.scss
+++ b/packages/storybook/src/stories/ino-carousel/ino-carousel.scss
@@ -1,5 +1,7 @@
-.ino-carousel-example {
-  display: flex;
-  flex-direction: row;
-  justify-content: center;
+.story-carousel {
+  .ino-carousel-example {
+    display: flex;
+    flex-direction: row;
+    justify-content: center;
+  }
 }

--- a/packages/storybook/src/stories/ino-carousel/ino-carousel.stories.ts
+++ b/packages/storybook/src/stories/ino-carousel/ino-carousel.stories.ts
@@ -10,7 +10,7 @@ import mountainsImg from '../../assets/images/mountains.jpg';
 // @ts-ignore
 import nidarosImg from '../../assets/images/nidaros.jpg';
 
-import { defaultDecorator } from '../utils';
+import { decorateStoryWithClass } from '../utils';
 
 import './ino-carousel.scss';
 
@@ -18,7 +18,7 @@ export default {
   title: 'Graphic/<ino-carousel>',
   component: 'ino-carousel',
   decorators: [
-    defaultDecorator,
+    (story) => decorateStoryWithClass(story, 'story-carousel'),
     (story) => {
       useEffect(() => {
         const eventHandler = function (e) {

--- a/packages/storybook/src/stories/ino-checkbox/ino-checkbox.scss
+++ b/packages/storybook/src/stories/ino-checkbox/ino-checkbox.scss
@@ -1,31 +1,33 @@
-ino-checkbox {
-  width: 33%;
-}
+.story-checkbox {
+  ino-checkbox {
+    width: 33%;
+  }
 
-.story-checkbox-states {
-  display: flex;
-  justify-content: space-around;
-  flex-wrap: wrap;
-  align-items: center;
-  margin: auto;
-  text-align: center;
-}
+  .story-checkbox-states {
+    display: flex;
+    justify-content: space-around;
+    flex-wrap: wrap;
+    align-items: center;
+    margin: auto;
+    text-align: center;
+  }
 
-.story-selection-states {
-  display: flex;
-  justify-content: space-around;
-  align-self: center;
-  text-align: center;
-}
+  .story-selection-states {
+    display: flex;
+    justify-content: space-around;
+    align-self: center;
+    text-align: center;
+  }
 
-.story-selection-states ino-checkbox {
-  width: 25%;
-}
+  .story-selection-states ino-checkbox {
+    width: 25%;
+  }
 
-.customizable-checkbox {
-  display: block;
-  margin-left: auto;
-  margin-right: auto;
-  margin-bottom: 40px;
-  align-self: center;
+  .customizable-checkbox {
+    display: block;
+    margin-left: auto;
+    margin-right: auto;
+    margin-bottom: 40px;
+    align-self: center;
+  }
 }

--- a/packages/storybook/src/stories/ino-checkbox/ino-checkbox.stories.ts
+++ b/packages/storybook/src/stories/ino-checkbox/ino-checkbox.stories.ts
@@ -3,14 +3,14 @@ import { useEffect } from '@storybook/client-api';
 import { Meta, Story } from '@storybook/web-components';
 import { html, TemplateResult } from 'lit-html';
 
-import { defaultDecorator } from '../utils';
+import { decorateStoryWithClass } from '../utils';
 import './ino-checkbox.scss';
 
 export default {
   title: 'Input/ino-checkbox',
   component: 'ino-checkbox',
   decorators: [
-    defaultDecorator,
+    (story) => decorateStoryWithClass(story, 'story-checkbox'),
     (story) => {
       useEffect(() => {
         const handleCheckedChange = (e) => {

--- a/packages/storybook/src/stories/ino-chip-set/ino-chip-set.stories.ts
+++ b/packages/storybook/src/stories/ino-chip-set/ino-chip-set.stories.ts
@@ -1,20 +1,20 @@
 import { Components } from '@inovex.de/elements';
-import { Story } from '@storybook/web-components';
+import { Meta, Story } from '@storybook/web-components';
 import { html, TemplateResult } from 'lit-html';
-import { defaultDecorator } from '../utils';
+import { decorateStoryWithClass } from '../utils';
 
 import './ino-chip-set.scss';
 
 export default {
   title: 'Buttons/<ino-chip-set>',
   component: 'ino-chip-set',
-  decorators: [defaultDecorator],
+  decorators: [(story) => decorateStoryWithClass(story)],
   parameters: {
     actions: {
       handles: ['removeChip'],
     },
   },
-};
+} as Meta;
 
 export const Playground: Story<Components.InoChipSet> = (args) => html`
   <ino-chip-set class="customizable-chip-set" type="${args.type}">

--- a/packages/storybook/src/stories/ino-chip/ino-chip.stories.ts
+++ b/packages/storybook/src/stories/ino-chip/ino-chip.stories.ts
@@ -1,14 +1,14 @@
 import { Components } from '@inovex.de/elements';
 import { Meta, Story } from '@storybook/web-components';
 import { html, TemplateResult } from 'lit-html';
-import { defaultDecorator, withColorScheme } from '../utils';
+import { decorateStoryWithClass, withColorScheme } from '../utils';
 
 import './ino-chip.scss';
 
 export default {
   title: 'Buttons/<ino-chip>',
   component: 'ino-chip',
-  decorators: [defaultDecorator],
+  decorators: [(story) => decorateStoryWithClass(story)],
   parameters: {
     actions: {
       handles: ['removeChip'],

--- a/packages/storybook/src/stories/ino-control-item/ino-control-item.stories.ts
+++ b/packages/storybook/src/stories/ino-control-item/ino-control-item.stories.ts
@@ -2,7 +2,7 @@ import { Components } from '@inovex.de/elements';
 import { useEffect } from '@storybook/client-api';
 import { Meta, Story } from '@storybook/web-components';
 import { html, TemplateResult } from 'lit-html';
-import { defaultDecorator } from '../utils';
+import { decorateStoryWithClass } from '../utils';
 
 import './ino-control-item.scss';
 
@@ -10,7 +10,7 @@ export default {
   title: 'Structure/ino-control-item',
   component: 'ino-control-item',
   decorators: [
-    defaultDecorator,
+    (story) => decorateStoryWithClass(story),
     (story) => {
       useEffect(() => {
         const checkedChangeHandler = (e: CustomEvent<boolean>) => {

--- a/packages/storybook/src/stories/ino-datepicker/ino-datepicker.stories.ts
+++ b/packages/storybook/src/stories/ino-datepicker/ino-datepicker.stories.ts
@@ -3,7 +3,7 @@ import { useEffect } from '@storybook/client-api';
 import { Meta, Story } from '@storybook/web-components';
 import { html } from 'lit-html';
 import * as moment from 'moment';
-import { defaultDecorator } from '../utils';
+import { decorateStoryWithClass } from '../utils';
 import './ino-datepicker.scss';
 
 const days = 5;
@@ -20,7 +20,7 @@ export default {
     },
   },
   decorators: [
-    defaultDecorator,
+    (story) => decorateStoryWithClass(story, 'story-datepicker'),
     (story) => {
       useEffect(() => {
         const eventHandler = (e) => e.target.setAttribute('value', e.detail);

--- a/packages/storybook/src/stories/ino-dialog/ino-dialog.scss
+++ b/packages/storybook/src/stories/ino-dialog/ino-dialog.scss
@@ -1,42 +1,44 @@
-ino-dialog {
-  --ino-dialog-width: 650px;
-  --ino-dialog-height: 250px;
-}
+.story-dialog {
+  ino-dialog {
+    --ino-dialog-width: 650px;
+    --ino-dialog-height: 250px;
+  }
 
-.ino-dialog-header {
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-  justify-content: flex-end;
-  height: 100%;
-
-  .ino-dialog-title {
+  .ino-dialog-header {
     display: flex;
     flex-direction: row;
-    width: 100%;
+    align-items: center;
+    justify-content: flex-end;
+    height: 100%;
 
-    h3 {
-      padding: 0 10px 0 10px;
+    .ino-dialog-title {
+      display: flex;
+      flex-direction: row;
+      width: 100%;
+
+      h3 {
+        padding: 0 10px 0 10px;
+      }
     }
   }
-}
 
-.ino-dialog-content {
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  align-items: center;
-  height: 100%;
-}
+  .ino-dialog-content {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    height: 100%;
+  }
 
-.ino-dialog-footer {
-  display: flex;
-  flex-direction: row;
-  justify-content: flex-end;
-  align-items: center;
-  height: 100%;
+  .ino-dialog-footer {
+    display: flex;
+    flex-direction: row;
+    justify-content: flex-end;
+    align-items: center;
+    height: 100%;
 
-  ino-button {
-    margin-right: 10px;
+    ino-button {
+      margin-right: 10px;
+    }
   }
 }

--- a/packages/storybook/src/stories/ino-dialog/ino-dialog.stories.ts
+++ b/packages/storybook/src/stories/ino-dialog/ino-dialog.stories.ts
@@ -1,8 +1,8 @@
 import { Components } from '@inovex.de/elements';
 import { useEffect } from '@storybook/client-api';
-import { Story } from '@storybook/web-components';
+import { Meta, Story } from '@storybook/web-components';
 import { html } from 'lit-html';
-import { defaultDecorator } from '../utils';
+import { decorateStoryWithClass } from '../utils';
 
 import './ino-dialog.scss';
 
@@ -10,7 +10,7 @@ export default {
   title: 'Structure/<ino-dialog>',
   component: 'ino-dialog',
   decorators: [
-    defaultDecorator,
+    (story) => decorateStoryWithClass(story, 'story-dialog'),
     (story) => {
       useEffect(() => {
         const openDialogHandler = function (e) {
@@ -56,7 +56,7 @@ export default {
       return story();
     },
   ],
-};
+} as Meta;
 
 export const Playground: Story<Components.InoDialog> = (args) => html`
   <ino-button id="open-dialog-btn">Open Dialog</ino-button>

--- a/packages/storybook/src/stories/ino-fab-set/ino-fab-set.stories.ts
+++ b/packages/storybook/src/stories/ino-fab-set/ino-fab-set.stories.ts
@@ -1,8 +1,8 @@
 import { Components } from '@inovex.de/elements';
 import { useEffect } from '@storybook/client-api';
-import { Story } from '@storybook/web-components';
+import { Meta, Story } from '@storybook/web-components';
 import { html } from 'lit-html';
-import { defaultDecorator } from '../utils';
+import { decorateStoryWithClass } from '../utils';
 
 import './ino-fab-set.scss';
 
@@ -15,7 +15,7 @@ export default {
     },
   },
   decorators: [
-    defaultDecorator,
+    (story) => decorateStoryWithClass(story),
     (story) => {
       useEffect(() => {
         const clickHandler = function (e) {
@@ -35,7 +35,7 @@ export default {
       return story();
     },
   ],
-};
+} as Meta;
 
 export const Playground: Story<Components.InoFabSet> = (args) => html`
   <ino-fab-set

--- a/packages/storybook/src/stories/ino-fab/ino-fab.scss
+++ b/packages/storybook/src/stories/ino-fab/ino-fab.scss
@@ -1,4 +1,6 @@
-.ino-fab-variants {
-  display: flex;
-  justify-content: space-around;
+.story-fab {
+  .ino-fab-variants {
+    display: flex;
+    justify-content: space-around;
+  }
 }

--- a/packages/storybook/src/stories/ino-fab/ino-fab.stories.ts
+++ b/packages/storybook/src/stories/ino-fab/ino-fab.stories.ts
@@ -1,15 +1,15 @@
 import { Components } from '@inovex.de/elements';
-import { Story } from '@storybook/web-components';
+import { Meta, Story } from '@storybook/web-components';
 import { html } from 'lit-html';
-import { defaultDecorator, withIconControl } from '../utils';
+import { decorateStoryWithClass, withIconControl } from '../utils';
 
 import './ino-fab.scss';
 
 export default {
   title: 'Buttons/<ino-fab>',
   component: 'ino-fab',
-  decorators: [defaultDecorator],
-};
+  decorators: [(story) => decorateStoryWithClass(story, 'story-fab')],
+} as Meta;
 
 export const Playground: Story<Components.InoFab> = (args) => html`
   <ino-fab

--- a/packages/storybook/src/stories/ino-form-row/ino-form-row.stories.ts
+++ b/packages/storybook/src/stories/ino-form-row/ino-form-row.stories.ts
@@ -1,8 +1,8 @@
 import { Components } from '@inovex.de/elements';
 import { useEffect } from '@storybook/client-api';
-import { Story } from '@storybook/web-components';
+import { Meta, Story } from '@storybook/web-components';
 import { html } from 'lit-html';
-import { defaultDecorator } from '../utils';
+import { decorateStoryWithClass } from '../utils';
 
 import './ino-form-row.scss';
 
@@ -15,7 +15,7 @@ export default {
     },
   },
   decorators: [
-    defaultDecorator,
+    (story) => decorateStoryWithClass(story),
     (story) => {
       useEffect(() => {
         const valueChangeHandler = function (e) {
@@ -38,7 +38,7 @@ export default {
       return story();
     },
   ],
-};
+} as Meta;
 
 export const Playground: Story<Components.InoFormRow> = (args) => html`
   <ino-form-row

--- a/packages/storybook/src/stories/ino-header/ino-header.stories.ts
+++ b/packages/storybook/src/stories/ino-header/ino-header.stories.ts
@@ -1,15 +1,15 @@
 import { Components } from '@inovex.de/elements';
-import { Story } from '@storybook/web-components';
+import { Meta, Story } from '@storybook/web-components';
 import { html } from 'lit-html';
-import { defaultDecorator } from '../utils';
+import { decorateStoryWithClass } from '../utils';
 
 import './ino-header.scss';
 
 export default {
   title: 'Structure/ino-header',
   component: 'ino-header',
-  decorators: [defaultDecorator],
-};
+  decorators: [(story) => decorateStoryWithClass(story)],
+} as Meta;
 
 export const Playground: Story<Components.InoHeader> = (args) => html`
   <ino-header text="${args.text}"></ino-header>

--- a/packages/storybook/src/stories/ino-icon-button/ino-icon-button.stories.ts
+++ b/packages/storybook/src/stories/ino-icon-button/ino-icon-button.stories.ts
@@ -1,17 +1,22 @@
+import { Meta } from '@storybook/web-components';
 import { html } from 'lit-html';
-import { defaultDecorator, withColorScheme, withIconControl } from '../utils';
+import {
+  decorateStoryWithClass,
+  withColorScheme,
+  withIconControl,
+} from '../utils';
 import './ino-icon-button.scss';
 
 export default {
   title: 'Buttons/ino-icon-button',
   component: 'ino-icon-button',
-  decorators: [defaultDecorator],
+  decorators: [(story) => decorateStoryWithClass(story, 'story-icon-button')],
   parameters: {
     actions: {
       handles: ['click ino-icon-button'],
     },
   },
-};
+} as Meta;
 
 export const Playground = (args) => {
   return html`

--- a/packages/storybook/src/stories/ino-icon/ino-icon.stories.ts
+++ b/packages/storybook/src/stories/ino-icon/ino-icon.stories.ts
@@ -1,11 +1,11 @@
 import { Components } from '@inovex.de/elements';
 import { useEffect } from '@storybook/client-api';
-import { Story } from '@storybook/web-components';
+import { Meta, Story } from '@storybook/web-components';
 import { html } from 'lit-html';
 
 import ICONS from '../../../../elements/src/components/ino-icon/icons';
 
-import { defaultDecorator, withIconControl } from '../utils';
+import { decorateStoryWithClass, withIconControl } from '../utils';
 import './ino-icon.scss';
 
 const ICONS_WITHOUT_INTERNALS = ICONS.filter((icon) => !icon.startsWith('_'));
@@ -74,7 +74,7 @@ export default {
     },
   },
   decorators: [
-    defaultDecorator,
+    (story) => decorateStoryWithClass(story, 'story-icon'),
     (story) => {
       useEffect(() => {
         const searchIconHandler = function (e) {
@@ -132,7 +132,7 @@ export default {
       return story();
     },
   ],
-};
+} as Meta;
 
 export const Playground: Story<Components.InoIcon> = (args) => html`
   <ino-icon

--- a/packages/storybook/src/stories/ino-img-list/ino-img-list.stories.ts
+++ b/packages/storybook/src/stories/ino-img-list/ino-img-list.stories.ts
@@ -1,3 +1,4 @@
+import { Meta } from '@storybook/web-components';
 import { html } from 'lit-html';
 
 import beachImg from '../../assets/images/beach.jpg';
@@ -10,7 +11,7 @@ import waterfallImg from '../../assets/images/waterfall.jpg';
 export default {
   title: 'Graphic/ino-img-list',
   component: 'ino-img-list',
-};
+} as Meta;
 
 export const Playground = (args) => html`
   <ino-img-list enclose-label="${args.encloseLabel}" masonry="${args.masonry}">

--- a/packages/storybook/src/stories/ino-img/ino-img.stories.ts
+++ b/packages/storybook/src/stories/ino-img/ino-img.stories.ts
@@ -1,15 +1,15 @@
 import { Components } from '@inovex.de/elements';
-import { Story } from '@storybook/web-components';
+import { Meta, Story } from '@storybook/web-components';
 import { html } from 'lit-html';
-import { defaultDecorator, withIconControl } from '../utils';
+import { decorateStoryWithClass, withIconControl } from '../utils';
 
 import './ino-img.scss';
 
 export default {
   title: 'Graphic/<ino-img>',
   component: 'ino-img',
-  decorators: [defaultDecorator],
-};
+  decorators: [(story) => decorateStoryWithClass(story)],
+} as Meta;
 
 export const Playground: Story<Components.InoImg> = (args) => html`
   <ino-img

--- a/packages/storybook/src/stories/ino-input-file/ino-input-file.stories.ts
+++ b/packages/storybook/src/stories/ino-input-file/ino-input-file.stories.ts
@@ -1,4 +1,5 @@
 import { useEffect } from '@storybook/client-api';
+import { Meta } from '@storybook/web-components';
 import { html, TemplateResult } from 'lit-html';
 
 export default {
@@ -31,7 +32,7 @@ export default {
       handles: ['changeFile .customizable-input'],
     },
   },
-};
+} as Meta;
 
 export const Playground = (args): TemplateResult => html`
   <ino-input-file

--- a/packages/storybook/src/stories/ino-input/ino-input.stories.ts
+++ b/packages/storybook/src/stories/ino-input/ino-input.stories.ts
@@ -1,13 +1,13 @@
 import { useEffect } from '@storybook/client-api';
 import { html } from 'lit-html';
-import { defaultDecorator } from '../utils';
+import { decorateStoryWithClass } from '../utils';
 import './ino-input.scss';
 
 export default {
   title: 'Input/ino-input',
   component: 'ino-input',
   decorators: [
-    (story) => defaultDecorator(story, 'story-ino-input'),
+    (story) => decorateStoryWithClass(story, 'story-ino-input'),
     (story) => {
       useEffect(() => {
         const eventHandler = (e) => e.target.setAttribute('value', e.detail);

--- a/packages/storybook/src/stories/ino-list-divider/ino-list-divider.stories.ts
+++ b/packages/storybook/src/stories/ino-list-divider/ino-list-divider.stories.ts
@@ -1,9 +1,10 @@
+import { Meta } from '@storybook/web-components';
 import { html } from 'lit-html';
 
 export default {
   title: 'Structure/ino-list-divider',
   component: 'ino-list-divider',
-};
+} as Meta;
 
 export const Playground = (args) => html`
   <ino-list>

--- a/packages/storybook/src/stories/ino-list-item/ino-list-item.stories.ts
+++ b/packages/storybook/src/stories/ino-list-item/ino-list-item.stories.ts
@@ -1,13 +1,14 @@
 import { useEffect } from '@storybook/client-api';
+import { Meta } from '@storybook/web-components';
 import { html } from 'lit-html';
-import { defaultDecorator } from '../utils';
+import { decorateStoryWithClass } from '../utils';
 import './ino-list-item.scss';
 
 export default {
   title: 'Structure/ino-list-item',
   component: 'ino-list-item',
   decorators: [
-    (story) => defaultDecorator(story, 'story-ino-list-item'),
+    (story) => decorateStoryWithClass(story, 'story-ino-list-item'),
     (story) => {
       useEffect(() => {
         const eventHandler = (e) => {
@@ -29,7 +30,7 @@ export default {
       return story();
     },
   ],
-};
+} as Meta;
 
 export const Playground = (args) => html`
   <ino-list two-lines="${args.twoLines}">

--- a/packages/storybook/src/stories/ino-list/ino-list.stories.ts
+++ b/packages/storybook/src/stories/ino-list/ino-list.stories.ts
@@ -1,9 +1,10 @@
+import { Meta } from '@storybook/web-components';
 import { html } from 'lit-html';
 
 export default {
   title: 'Structure/ino-list ',
   component: 'ino-list',
-};
+} as Meta;
 
 export const Playground = (args) => html`
   <ino-list

--- a/packages/storybook/src/stories/ino-menu/ino-menu.stories.ts
+++ b/packages/storybook/src/stories/ino-menu/ino-menu.stories.ts
@@ -1,12 +1,13 @@
+import { Meta } from '@storybook/web-components';
 import { html } from 'lit-html';
-import { defaultDecorator } from '../utils';
+import { decorateStoryWithClass } from '../utils';
 import './ino-menu.scss';
 
 export default {
   title: `Structure/ino-menu`,
   component: 'ino-menu',
-  decorators: [(story) => defaultDecorator(story, 'story-ino-menu')],
-};
+  decorators: [(story) => decorateStoryWithClass(story, 'story-ino-menu')],
+} as Meta;
 
 export const Playground = (args) => html`
   <ino-card ino-disable-elevation>

--- a/packages/storybook/src/stories/ino-nav-drawer/ino-nav-drawer.stories.ts
+++ b/packages/storybook/src/stories/ino-nav-drawer/ino-nav-drawer.stories.ts
@@ -1,4 +1,5 @@
 import { useEffect } from '@storybook/client-api';
+import { Meta } from '@storybook/web-components';
 import { html } from 'lit-html';
 import './ino-nav-drawer.scss';
 
@@ -69,7 +70,7 @@ export default {
       return story();
     },
   ],
-};
+} as Meta;
 
 const navContent = html`
   <ino-img

--- a/packages/storybook/src/stories/ino-nav-item/ino-nav-item.stories.ts
+++ b/packages/storybook/src/stories/ino-nav-item/ino-nav-item.stories.ts
@@ -1,9 +1,10 @@
+import { Meta } from '@storybook/web-components';
 import { html } from 'lit-html';
 
 export default {
   title: `Structure/ino-nav-item`,
   component: 'ino-nav-item',
-};
+} as Meta;
 
 export const Playground = (args) => html`
   <div class="story-list">

--- a/packages/storybook/src/stories/ino-option-group/ino-option-group.scss
+++ b/packages/storybook/src/stories/ino-option-group/ino-option-group.scss
@@ -4,8 +4,8 @@
   }
 
   margin-bottom: 300px;
-}
 
-.story-option-group-customizable {
-  margin-bottom: 150px;
+  .story-option-group-customizable {
+    margin-bottom: 150px;
+  }
 }

--- a/packages/storybook/src/stories/ino-option-group/ino-option-group.stories.ts
+++ b/packages/storybook/src/stories/ino-option-group/ino-option-group.stories.ts
@@ -1,12 +1,13 @@
+import { Meta } from '@storybook/web-components';
 import { html, TemplateResult } from 'lit-html';
-import { defaultDecorator } from '../utils';
+import { decorateStoryWithClass } from '../utils';
 import './ino-option-group.scss';
 
 export default {
   title: 'Input/ino-option-group',
   component: 'ino-option-group',
-  decorators: [defaultDecorator],
-};
+  decorators: [(story) => decorateStoryWithClass(story, 'story-option-group')],
+} as Meta;
 
 export const Playground = (args): TemplateResult => html`
   <div class="story-option-group-customizable">

--- a/packages/storybook/src/stories/ino-option/ino-option.stories.ts
+++ b/packages/storybook/src/stories/ino-option/ino-option.stories.ts
@@ -1,12 +1,13 @@
+import { Meta } from '@storybook/web-components';
 import { html } from 'lit-html';
-import { defaultDecorator } from '../utils';
+import { decorateStoryWithClass } from '../utils';
 import './ino-option.scss';
 
 export default {
   title: 'Input/ino-option',
   component: 'ino-option',
-  decorators: [(story) => defaultDecorator(story, 'story-ino-option')],
-};
+  decorators: [(story) => decorateStoryWithClass(story, 'story-ino-option')],
+} as Meta;
 
 export const Playground = (args) => html`
   <div class="story-option">

--- a/packages/storybook/src/stories/ino-popover/ino-popover.stories.ts
+++ b/packages/storybook/src/stories/ino-popover/ino-popover.stories.ts
@@ -1,6 +1,7 @@
 import { useEffect } from '@storybook/client-api';
+import { Meta } from '@storybook/web-components';
 import { html } from 'lit-html';
-import { defaultDecorator } from '../utils';
+import { decorateStoryWithClass } from '../utils';
 import './ino-popover.scss';
 
 export default {
@@ -11,8 +12,8 @@ export default {
       handles: ['visibleChange ino-popover'],
     },
   },
-  decorators: [(story) => defaultDecorator(story, 'story-ino-popover')],
-};
+  decorators: [(story) => decorateStoryWithClass(story, 'story-ino-popover')],
+} as Meta;
 
 export const Playground = (args) => html`
   <ino-button id="popover-target">Popover</ino-button>

--- a/packages/storybook/src/stories/ino-progress-bar/ino-progress-bar.stories.ts
+++ b/packages/storybook/src/stories/ino-progress-bar/ino-progress-bar.stories.ts
@@ -1,15 +1,15 @@
 import { Components } from '@inovex.de/elements';
 import { useEffect } from '@storybook/client-api';
-import { Story } from '@storybook/web-components';
+import { Meta, Story } from '@storybook/web-components';
 import { html } from 'lit-html';
-import { defaultDecorator } from '../utils';
+import { decorateStoryWithClass } from '../utils';
 import './ino-progress-bar.scss';
 
 export default {
   title: 'Notification/ino-progress-bar',
   component: 'ino-progress-bar',
   decorators: [
-    (s) => defaultDecorator(s, 'story-ino-progress-bar'),
+    (s) => decorateStoryWithClass(s, 'story-ino-progress-bar'),
     (story) => {
       const clickHandler = (e) => {
         if (e.target.tagName.toLowerCase() === 'ino-button') {
@@ -57,7 +57,7 @@ export default {
       return story();
     },
   ],
-};
+} as Meta;
 
 export const Playground: Story<Components.InoProgressBar> = (args) => {
   return html`

--- a/packages/storybook/src/stories/ino-radio-group/ino-radio-group.stories.ts
+++ b/packages/storybook/src/stories/ino-radio-group/ino-radio-group.stories.ts
@@ -1,8 +1,8 @@
 import { Components } from '@inovex.de/elements';
 import { useEffect } from '@storybook/client-api';
-import { Story } from '@storybook/web-components';
+import { Meta, Story } from '@storybook/web-components';
 import { html } from 'lit-html';
-import { defaultDecorator } from '../utils';
+import { decorateStoryWithClass } from '../utils';
 
 export default {
   title: 'Input/ino-radio-group',
@@ -13,7 +13,7 @@ export default {
     },
   },
   decorators: [
-    defaultDecorator,
+    (story) => decorateStoryWithClass(story),
     (story) => {
       useEffect(() => {
         const radioGrp = document.querySelector('#radio-grp');
@@ -26,7 +26,7 @@ export default {
       return story();
     },
   ],
-};
+} as Meta;
 
 export const Playground: Story<Components.InoRadioGroup> = (args) => html`
   <ino-radio-group id="radio-grp" value="${args.value}">

--- a/packages/storybook/src/stories/ino-radio/ino-radio.stories.ts
+++ b/packages/storybook/src/stories/ino-radio/ino-radio.stories.ts
@@ -1,8 +1,8 @@
 import { Components } from '@inovex.de/elements';
 import { useEffect } from '@storybook/client-api';
-import { Story } from '@storybook/web-components';
+import { Meta, Story } from '@storybook/web-components';
 import { html } from 'lit-html';
-import { defaultDecorator } from '../utils';
+import { decorateStoryWithClass } from '../utils';
 import './ino-radio.scss';
 
 export default {
@@ -14,7 +14,7 @@ export default {
     },
   },
   decorators: [
-    (story) => defaultDecorator(story, 'story-radio'),
+    (story) => decorateStoryWithClass(story, 'story-radio'),
     (story) => {
       useEffect(() => {
         const eventHandler = (e) => e.target.setAttribute('checked', e.detail);
@@ -30,7 +30,7 @@ export default {
       return story();
     },
   ],
-};
+} as Meta;
 
 export const Playground: Story<Components.InoRadio> = (args) => html`
   <ino-radio

--- a/packages/storybook/src/stories/ino-range/ino-range.stories.ts
+++ b/packages/storybook/src/stories/ino-range/ino-range.stories.ts
@@ -1,14 +1,14 @@
 import { Components } from '@inovex.de/elements';
-import { Story } from '@storybook/web-components';
+import { Meta, Story } from '@storybook/web-components';
 import { html } from 'lit-html';
-import { defaultDecorator, withColorScheme } from '../utils';
+import { decorateStoryWithClass, withColorScheme } from '../utils';
 import './ino-range.scss';
 
 export default {
   title: 'Input/<ino-range>',
   component: 'ino-range',
-  decorators: [(story) => defaultDecorator(story, 'story-range')],
-};
+  decorators: [(story) => decorateStoryWithClass(story, 'story-range')],
+} as Meta;
 
 export const Playground: Story<Components.InoRange> = (args) => html`
   <ino-range

--- a/packages/storybook/src/stories/ino-segment-button/ino-segment-button.stories.ts
+++ b/packages/storybook/src/stories/ino-segment-button/ino-segment-button.stories.ts
@@ -1,20 +1,23 @@
 import { Components } from '@inovex.de/elements';
-import { Story } from '@storybook/web-components';
+import { Meta, Story } from '@storybook/web-components';
 import { html } from 'lit-html';
-import { defaultDecorator } from '../utils';
+import { decorateStoryWithClass } from '../utils';
 
 import './ino-segment-button.scss';
 
 export default {
   title: 'Buttons/ino-segment-button',
   component: 'ino-segment-button',
-  decorators: [(story) => defaultDecorator(story, 'story-segment-button')],
+  decorators: [
+    (story) => decorateStoryWithClass(story, 'story-segment-button'),
+  ],
   parameters: {
     actions: {
       handles: ['checkedChange'],
     },
   },
-};
+} as Meta;
+
 export const Playground: Story<Components.InoSegmentButton> = (args) => html`
   <ino-segment-button
     value="1"

--- a/packages/storybook/src/stories/ino-segment-group/ino-segment-group.stories.ts
+++ b/packages/storybook/src/stories/ino-segment-group/ino-segment-group.stories.ts
@@ -1,8 +1,8 @@
 import { Components } from '@inovex.de/elements';
 import { useEffect } from '@storybook/client-api';
-import { Story } from '@storybook/web-components';
+import { Meta, Story } from '@storybook/web-components';
 import { html } from 'lit-html';
-import { defaultDecorator } from '../utils';
+import { decorateStoryWithClass } from '../utils';
 import './ino-segment-group.scss';
 
 const eventHandler = (e: Event) => {
@@ -18,7 +18,7 @@ export default {
   title: 'Buttons/ino-segment-group',
   component: 'ino-segment-group',
   decorators: [
-    (story) => defaultDecorator(story, 'story-segment-group'),
+    (story) => decorateStoryWithClass(story, 'story-segment-group'),
     (story) => {
       useEffect(() => {
         document.addEventListener('checkedChange', eventHandler);
@@ -33,7 +33,7 @@ export default {
       handles: ['checkedChange'],
     },
   },
-};
+} as Meta;
 export const Playground: Story<Components.InoSegmentGroup> = (args) => html`
   <ino-segment-group id="segment-grp" name="${args.name}" value="${args.value}">
     <ino-segment-button value="opt-1">Option 1</ino-segment-button>

--- a/packages/storybook/src/stories/ino-select/ino-select.stories.ts
+++ b/packages/storybook/src/stories/ino-select/ino-select.stories.ts
@@ -2,7 +2,7 @@ import { Components } from '@inovex.de/elements';
 import { useEffect } from '@storybook/client-api';
 import { Story } from '@storybook/web-components';
 import { html } from 'lit-html';
-import { defaultDecorator, showSnackbar } from '../utils';
+import { decorateStoryWithClass, showSnackbar } from '../utils';
 import './ino-select.scss';
 
 const handleFormSubmission = (e) => {
@@ -21,7 +21,7 @@ export default {
     },
   },
   decorators: [
-    (story) => defaultDecorator(story, 'story-select'),
+    (story) => decorateStoryWithClass(story, 'story-select'),
     (story) => {
       useEffect(() => {
         const formElement = document.querySelector('form');

--- a/packages/storybook/src/stories/ino-sidebar/ino-sidebar.stories.ts
+++ b/packages/storybook/src/stories/ino-sidebar/ino-sidebar.stories.ts
@@ -1,8 +1,8 @@
 import { Components } from '@inovex.de/elements';
 import { useEffect } from '@storybook/client-api';
-import { Story } from '@storybook/web-components';
+import { Meta, Story } from '@storybook/web-components';
 import { html } from 'lit-html';
-import { defaultDecorator } from '../utils';
+import { decorateStoryWithClass } from '../utils';
 import './ino-sidebar.scss';
 
 const eventHandler = (e) => {
@@ -25,7 +25,7 @@ export default {
   title: 'Structure/ino-sidebar',
   component: 'ino-sidebar',
   decorators: [
-    (story) => defaultDecorator(story, 'story-sidebar'),
+    (story) => decorateStoryWithClass(story, 'story-sidebar'),
     (story) => {
       useEffect(() => {
         document.addEventListener('click', eventHandler);
@@ -36,7 +36,7 @@ export default {
       return story();
     },
   ],
-};
+} as Meta;
 
 export const Playground: Story<Components.InoSidebar> = (args) => html`
   <div class="sidebar-demo">

--- a/packages/storybook/src/stories/ino-snackbar/ino-snackbar.stories.ts
+++ b/packages/storybook/src/stories/ino-snackbar/ino-snackbar.stories.ts
@@ -1,8 +1,8 @@
 import { Components } from '@inovex.de/elements';
 import { useEffect } from '@storybook/client-api';
-import { Story } from '@storybook/web-components';
+import { Meta, Story } from '@storybook/web-components';
 import { html } from 'lit-html';
-import { defaultDecorator } from '../utils';
+import { decorateStoryWithClass } from '../utils';
 import './ino-snackbar.scss';
 
 const sampleText = 'User successfully updated!';
@@ -11,7 +11,7 @@ export default {
   title: 'Notification/ino-snackbar',
   component: 'ino-snackbar',
   decorators: [
-    (s) => defaultDecorator(s, 'story-ino-snackbar'),
+    (s) => decorateStoryWithClass(s, 'story-ino-snackbar'),
     (story) => {
       const btnClickHandler = (e) => {
         if (!e.target.classList.contains('snackbar-trigger')) {
@@ -30,7 +30,7 @@ export default {
       return story();
     },
   ],
-};
+} as Meta;
 
 export const Playground: Story<Components.InoSnackbar> = (args) => html`
   <ino-button class="snackbar-trigger" data-template-id="snackbar-default"

--- a/packages/storybook/src/stories/ino-spinner/ino-spinner.scss
+++ b/packages/storybook/src/stories/ino-spinner/ino-spinner.scss
@@ -1,8 +1,10 @@
-.flex-parent {
-  display: flex;
-  flex-wrap: wrap;
+.story-spinner {
+  .flex-parent {
+    display: flex;
+    flex-wrap: wrap;
 
-  > .flex-child {
-    margin: 0 20px;
+    > .flex-child {
+      margin: 0 20px;
+    }
   }
 }

--- a/packages/storybook/src/stories/ino-spinner/ino-spinner.stories.ts
+++ b/packages/storybook/src/stories/ino-spinner/ino-spinner.stories.ts
@@ -1,14 +1,14 @@
 import { Components } from '@inovex.de/elements';
-import { Story } from '@storybook/web-components';
+import { Meta, Story } from '@storybook/web-components';
 import { html } from 'lit-html';
-import { defaultDecorator, withColorScheme } from '../utils';
+import { decorateStoryWithClass, withColorScheme } from '../utils';
 import './ino-spinner.scss';
 
 export default {
   title: 'Notification/ino-spinner',
   component: 'ino-spinner',
-  decorators: [defaultDecorator],
-};
+  decorators: [(story) => decorateStoryWithClass(story, 'story-spinner')],
+} as Meta;
 
 export const Playground: Story<Components.InoSpinner> = (args) => html`
   <ino-spinner

--- a/packages/storybook/src/stories/ino-switch/ino-switch.stories.ts
+++ b/packages/storybook/src/stories/ino-switch/ino-switch.stories.ts
@@ -1,8 +1,8 @@
 import { Components } from '@inovex.de/elements';
 import { useEffect } from '@storybook/client-api';
-import { Story } from '@storybook/web-components';
+import { Meta, Story } from '@storybook/web-components';
 import { html } from 'lit-html';
-import { defaultDecorator, withColorScheme } from '../utils';
+import { decorateStoryWithClass, withColorScheme } from '../utils';
 import './ino-switch.scss';
 
 const eventHandler = (e) => {
@@ -17,7 +17,7 @@ export default {
   title: 'Input/ino-switch',
   component: 'ino-switch',
   decorators: [
-    (story) => defaultDecorator(story, 'story-switch'),
+    (story) => decorateStoryWithClass(story, 'story-switch'),
     (story) => {
       useEffect(() => {
         document.addEventListener('checkedChange', eventHandler);
@@ -27,7 +27,7 @@ export default {
       return story();
     },
   ],
-};
+} as Meta;
 
 export const Playground: Story<Components.InoSwitch> = (args) => html`
   <ino-switch

--- a/packages/storybook/src/stories/ino-tab-bar/ino-tab-bar.scss
+++ b/packages/storybook/src/stories/ino-tab-bar/ino-tab-bar.scss
@@ -1,13 +1,15 @@
-.customizable-tab {
-  display: block;
-  margin-left: auto;
-  margin-right: auto;
-  margin-bottom: 40px;
-  align-self: center;
-}
+.story-tab-bar {
+  .customizable-tab {
+    display: block;
+    margin-left: auto;
+    margin-right: auto;
+    margin-bottom: 40px;
+    align-self: center;
+  }
 
-.story-tab-variants {
-  display: flex;
-  justify-content: space-around;
-  flex-wrap: wrap;
+  .story-tab-variants {
+    display: flex;
+    justify-content: space-around;
+    flex-wrap: wrap;
+  }
 }

--- a/packages/storybook/src/stories/ino-tab-bar/ino-tab-bar.stories.ts
+++ b/packages/storybook/src/stories/ino-tab-bar/ino-tab-bar.stories.ts
@@ -1,8 +1,8 @@
 import { Components } from '@inovex.de/elements';
 import { useEffect } from '@storybook/client-api';
-import { Story } from '@storybook/web-components';
+import { Meta, Story } from '@storybook/web-components';
 import { html } from 'lit-html';
-import { defaultDecorator } from '../utils';
+import { decorateStoryWithClass } from '../utils';
 import './ino-tab-bar.scss';
 
 const eventHandler = (e) => e.target.setAttribute('active-tab', e.detail);
@@ -11,7 +11,7 @@ export default {
   title: `Structure/ino-tab-bar`,
   component: 'ino-tab-bar',
   decorators: [
-    defaultDecorator,
+    (story) => decorateStoryWithClass(story, 'story-tab-bar'),
     (story) => {
       useEffect(() => {
         const tabBars = document.querySelectorAll('ino-tab-bar');
@@ -26,7 +26,7 @@ export default {
       return story();
     },
   ],
-};
+} as Meta;
 
 export const Playground: Story<Components.InoTabBar> = (args) => html`
   <ino-tab-bar id="customizable-tabbar" active-tab="${args.activeTab}" auto-focus="${args.autoFocus}">

--- a/packages/storybook/src/stories/ino-tab/ino-tab.stories.ts
+++ b/packages/storybook/src/stories/ino-tab/ino-tab.stories.ts
@@ -1,13 +1,13 @@
 import { Components } from '@inovex.de/elements';
-import { Story } from '@storybook/web-components';
+import { Meta, Story } from '@storybook/web-components';
 import { html } from 'lit-html';
-import { defaultDecorator, withIconControl } from '../utils';
+import { decorateStoryWithClass, withIconControl } from '../utils';
 
 export default {
   title: `Structure/ino-tab`,
   component: 'ino-tab',
-  decorators: [defaultDecorator],
-};
+  decorators: [(story) => decorateStoryWithClass(story)],
+} as Meta;
 
 export const Playground: Story<Components.InoTab> = (args) => html`
   <ino-tab

--- a/packages/storybook/src/stories/ino-table/ino-table.stories.ts
+++ b/packages/storybook/src/stories/ino-table/ino-table.stories.ts
@@ -1,8 +1,8 @@
 import { Components } from '@inovex.de/elements';
 import { useEffect } from '@storybook/client-api';
-import { Story } from '@storybook/web-components';
+import { Meta, Story } from '@storybook/web-components';
 import { html } from 'lit-html';
-import { defaultDecorator } from '../utils';
+import { decorateStoryWithClass } from '../utils';
 
 // == event block
 const checkboxHandler = (e) => {
@@ -57,7 +57,7 @@ export default {
   title: `Structure/ino-table`,
   component: 'ino-table',
   decorators: [
-    defaultDecorator,
+    (story) => decorateStoryWithClass(story),
     (story) => {
       useEffect(() => {
         document.addEventListener('checkedChange', checkboxHandler);
@@ -67,7 +67,7 @@ export default {
       return story();
     },
   ],
-};
+} as Meta;
 
 export const Playground: Story<Components.InoTable> = () => html`
   <ino-table>

--- a/packages/storybook/src/stories/ino-textarea/ino-textarea.stories.ts
+++ b/packages/storybook/src/stories/ino-textarea/ino-textarea.stories.ts
@@ -1,8 +1,8 @@
 import { Components } from '@inovex.de/elements';
 import { useEffect } from '@storybook/client-api';
-import { Story } from '@storybook/web-components';
+import { Meta, Story } from '@storybook/web-components';
 import { html } from 'lit-html';
-import { defaultDecorator } from '../utils';
+import { decorateStoryWithClass } from '../utils';
 import './ino-textarea.scss';
 
 export default {
@@ -17,7 +17,7 @@ export default {
     },
   },
   decorators: [
-    (story) => defaultDecorator(story, 'story-textarea'),
+    (story) => decorateStoryWithClass(story, 'story-textarea'),
     (story) => {
       useEffect(() => {
         const eventHandler = (e) => e.target.setAttribute('value', e.detail);
@@ -33,7 +33,7 @@ export default {
       return story();
     },
   ],
-};
+} as Meta;
 
 export const Playground: Story<Components.InoTextarea> = (args) => html`
   <ino-textarea

--- a/packages/storybook/src/stories/ino-tooltip/ino-tooltip.stories.ts
+++ b/packages/storybook/src/stories/ino-tooltip/ino-tooltip.stories.ts
@@ -1,14 +1,14 @@
 import { Components } from '@inovex.de/elements';
-import { Story } from '@storybook/web-components';
+import { Meta, Story } from '@storybook/web-components';
 import { html } from 'lit-html';
-import { defaultDecorator, withColorScheme } from '../utils';
+import { decorateStoryWithClass, withColorScheme } from '../utils';
 import './ino-tooltip.scss';
 
 export default {
   title: `Notification/ino-tooltip`,
   component: 'ino-tooltip',
-  decorators: [(story) => defaultDecorator(story, 'story-tooltip')],
-};
+  decorators: [(story) => decorateStoryWithClass(story, 'story-tooltip')],
+} as Meta;
 
 export const Playground: Story<Components.InoTooltip> = (args) => html`
   <ino-button id="tooltip-target">Tooltip</ino-button>

--- a/packages/storybook/src/stories/utils.ts
+++ b/packages/storybook/src/stories/utils.ts
@@ -1,4 +1,4 @@
-import { Story, StoryContext } from '@storybook/web-components';
+import { Story } from '@storybook/web-components';
 import { StoryFnHtmlReturnType } from '@storybook/web-components/dist/ts3.4/client/preview/types';
 import { html } from 'lit-html';
 import ICONS from '../../../elements/src/components/ino-icon/icons';
@@ -52,12 +52,11 @@ export const withColorScheme = <T>(
 
 export const getIcons = () => ICONS.filter((icon) => !icon.startsWith('_'));
 
-export const defaultDecorator = (
+export const decorateStoryWithClass = (
   story: () => StoryFnHtmlReturnType,
-  context: StoryContext,
   className?: string
 ): StoryFnHtmlReturnType => {
-  return html` <div class="${className ?? ''}">${story()}</div> `;
+  return html`<div class="${className ?? ''}">${story()}</div>`;
 };
 
 export const showSnackbar = (message: string) => {


### PR DESCRIPTION
Closes /

## Proposed Changes

- rename function `defaultDecorator` to `decorateStoryWithClass` for clarity
- correctly decorate all stories (the function was missing or misused sometimes)
- scope all story styles
- add the `Meta` type to all story exports to enable type checking