### PR TITLE
feat(elements|ino-select): add property `error` to display error state

### DIFF
--- a/packages/elements-angular/elements/src/directives/proxies.ts
+++ b/packages/elements-angular/elements/src/directives/proxies.ts
@@ -814,13 +814,13 @@ export class InoSegmentGroup {
 import { Select as ISelect } from '@inovex.de/elements/dist/types/components/ino-select/ino-select';
 export declare interface InoSelect extends Components.InoSelect {}
 @ProxyCmp({
-  inputs: ['disabled', 'label', 'name', 'outline', 'required', 'showLabelHint', 'value']
+  inputs: ['disabled', 'error', 'label', 'name', 'outline', 'required', 'showLabelHint', 'value']
 })
 @Component({
   selector: 'ino-select',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
-  inputs: ['disabled', 'label', 'name', 'outline', 'required', 'showLabelHint', 'value'],
+  inputs: ['disabled', 'error', 'label', 'name', 'outline', 'required', 'showLabelHint', 'value'],
   outputs: ['valueChange']
 })
 export class InoSelect {

--- a/packages/elements/src/components.d.ts
+++ b/packages/elements/src/components.d.ts
@@ -951,7 +951,11 @@ export namespace Components {
          */
         "disabled"?: boolean;
         /**
-          * The label of this element
+          * Displays the select as invalid if set to true. If the property is not set or set to false, the validation is handled by the default validation.
+         */
+        "error"?: boolean;
+        /**
+          * The label of this element.
          */
         "label"?: string;
         /**
@@ -967,7 +971,7 @@ export namespace Components {
          */
         "required"?: boolean;
         /**
-          * If true, an *optional* message is displayed if not required, otherwise a * marker is displayed if required
+          * If true, an *optional* message is displayed if not required, otherwise a * marker is displayed if required.
          */
         "showLabelHint"?: boolean;
         /**
@@ -2552,7 +2556,11 @@ declare namespace LocalJSX {
          */
         "disabled"?: boolean;
         /**
-          * The label of this element
+          * Displays the select as invalid if set to true. If the property is not set or set to false, the validation is handled by the default validation.
+         */
+        "error"?: boolean;
+        /**
+          * The label of this element.
          */
         "label"?: string;
         /**
@@ -2572,7 +2580,7 @@ declare namespace LocalJSX {
          */
         "required"?: boolean;
         /**
-          * If true, an *optional* message is displayed if not required, otherwise a * marker is displayed if required
+          * If true, an *optional* message is displayed if not required, otherwise a * marker is displayed if required.
          */
         "showLabelHint"?: boolean;
         /**

--- a/packages/elements/src/components/ino-label/ino-label.scss
+++ b/packages/elements/src/components/ino-label/ino-label.scss
@@ -3,6 +3,14 @@
 
 $label-color: rgba(0, 0, 0, 0.6);
 
+@mixin outline-border-color($color) {
+  ino-label:not(.ino-label--disabled).ino-label--outlined
+    .mdc-notched-outline
+    > div {
+    border-color: $color;
+  }
+}
+
 ino-label {
   .mdc-floating-label::after {
     content: none;

--- a/packages/elements/src/components/ino-label/ino-label.tsx
+++ b/packages/elements/src/components/ino-label/ino-label.tsx
@@ -39,7 +39,7 @@ export class Label {
   ];
 
   outlineTemplate = (label: HTMLElement) => (
-    <div class={'mdc-notched-outline'}>
+    <div class="mdc-notched-outline">
       <div class="mdc-notched-outline__leading" />
       <div class="mdc-notched-outline__notch">{label}</div>
       <div class="mdc-notched-outline__trailing" />

--- a/packages/elements/src/components/ino-select/ino-select.scss
+++ b/packages/elements/src/components/ino-select/ino-select.scss
@@ -5,6 +5,7 @@
 @use '@material/select/mdc-select';
 @use '@material/select';
 @use 'base/theme';
+@use '../ino-label/ino-label';
 
 $not-outlined-select: 'not(.mdc-select--outlined)';
 $placeholder-color: rgba(0, 0, 0, 0.6);
@@ -49,6 +50,10 @@ ino-select {
 
   .mdc-select--focused {
     @include setIconColors(var(--select-icon-color));
+
+    .mdc-select__anchor {
+      @include select.dropdown-icon-color(theme.color(primary));
+    }
   }
 
   .mdc-select {
@@ -74,10 +79,6 @@ ino-select {
       )
     );
 
-    &--focused .mdc-select__anchor {
-      @include select.dropdown-icon-color(theme.color(primary));
-    }
-
     .mdc-select__anchor:before {
       display: none;
     }
@@ -100,10 +101,6 @@ ino-select {
   .mdc-select__selected-text {
     text-overflow: ellipsis;
     overflow: hidden;
-  }
-
-  .mdc-select--invalid .mdc-select__selected-text {
-    color: theme.color(error);
   }
 
   .mdc-select--filled {
@@ -133,6 +130,11 @@ ino-select {
         left: 40px;
       }
     }
+  }
+
+  // make sure the border-color is the default if focused and invalid
+  .mdc-select.mdc-select--outlined.mdc-select--invalid.mdc-select--focused {
+    @include ino-label.outline-border-color(theme.color(primary));
   }
 
   .mdc-select--outlined {

--- a/packages/elements/src/components/ino-select/ino-select.scss
+++ b/packages/elements/src/components/ino-select/ino-select.scss
@@ -102,6 +102,10 @@ ino-select {
     overflow: hidden;
   }
 
+  .mdc-select--invalid .mdc-select__selected-text {
+    color: theme.color(error);
+  }
+
   .mdc-select--filled {
     .mdc-select__anchor {
       padding-left: 0;

--- a/packages/elements/src/components/ino-select/ino-select.tsx
+++ b/packages/elements/src/components/ino-select/ino-select.tsx
@@ -26,6 +26,7 @@ import { hasSlotContent } from '../../util/component-utils';
 export class Select implements ComponentInterface {
   // An internal instance of the material design form field.
   private mdcSelectInstance?: MDCSelect;
+  private mdcSelectContainerEl?: HTMLDivElement;
   private nativeInputElement?: HTMLInputElement;
 
   @Element() el!: HTMLElement;
@@ -101,6 +102,7 @@ export class Select implements ComponentInterface {
   @Event() valueChange!: EventEmitter<string>;
 
   connectedCallback() {
+    // in case of usage e.g. in a popover this is necessary
     this.create();
   }
 
@@ -118,12 +120,11 @@ export class Select implements ComponentInterface {
   }
 
   private create = () => {
-    const mdcSelect = this.el.querySelector('.mdc-select');
-    if (!mdcSelect) {
+    if (!this.mdcSelectContainerEl) {
       return;
     }
 
-    this.mdcSelectInstance = new MDCSelect(mdcSelect);
+    this.mdcSelectInstance = new MDCSelect(this.mdcSelectContainerEl);
 
     if (this.value) {
       this.setSelectValue(this.value);
@@ -188,7 +189,7 @@ export class Select implements ComponentInterface {
       <input
         class="ino-hidden-input"
         aria-hidden
-        ref={(el) => (this.nativeInputElement = el)}
+        ref={el => (this.nativeInputElement = el)}
         required={this.required}
         disabled={this.disabled}
       ></input>
@@ -198,7 +199,7 @@ export class Select implements ComponentInterface {
 
     return (
       <Host name={this.name}>
-        <div class={classSelect}>
+        <div class={classSelect} ref={el => (this.mdcSelectContainerEl = el)}>
           {hiddenInput}
           <div class="mdc-select__anchor" aria-required={this.required}>
             {leadingSlotHasContent && (

--- a/packages/elements/src/components/ino-select/ino-select.tsx
+++ b/packages/elements/src/components/ino-select/ino-select.tsx
@@ -191,7 +191,6 @@ export class Select implements ComponentInterface {
         ref={(el) => (this.nativeInputElement = el)}
         required={this.required}
         disabled={this.disabled}
-        type="hidden"
       ></input>
     ) : (
       ''

--- a/packages/elements/src/components/ino-select/readme.md
+++ b/packages/elements/src/components/ino-select/readme.md
@@ -102,15 +102,16 @@ The component behaves like a native select with additional features. The native 
 
 ## Properties
 
-| Property        | Attribute         | Description                                                                                                | Type      | Default     |
-| --------------- | ----------------- | ---------------------------------------------------------------------------------------------------------- | --------- | ----------- |
-| `disabled`      | `disabled`        | Disables this element.                                                                                     | `boolean` | `undefined` |
-| `label`         | `label`           | The label of this element                                                                                  | `string`  | `undefined` |
-| `name`          | `name`            | The name of this element.                                                                                  | `string`  | `undefined` |
-| `outline`       | `outline`         | Styles this select box as outlined element.                                                                | `boolean` | `undefined` |
-| `required`      | `required`        | Marks this element as required.                                                                            | `boolean` | `undefined` |
-| `showLabelHint` | `show-label-hint` | If true, an *optional* message is displayed if not required, otherwise a * marker is displayed if required | `boolean` | `undefined` |
-| `value`         | `value`           | The value of this element. (**unmanaged**)                                                                 | `string`  | `''`        |
+| Property        | Attribute         | Description                                                                                                                                     | Type      | Default     |
+| --------------- | ----------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- | --------- | ----------- |
+| `disabled`      | `disabled`        | Disables this element.                                                                                                                          | `boolean` | `undefined` |
+| `error`         | `error`           | Displays the select as invalid if set to true. If the property is not set or set to false, the validation is handled by the default validation. | `boolean` | `undefined` |
+| `label`         | `label`           | The label of this element.                                                                                                                      | `string`  | `undefined` |
+| `name`          | `name`            | The name of this element.                                                                                                                       | `string`  | `undefined` |
+| `outline`       | `outline`         | Styles this select box as outlined element.                                                                                                     | `boolean` | `undefined` |
+| `required`      | `required`        | Marks this element as required.                                                                                                                 | `boolean` | `undefined` |
+| `showLabelHint` | `show-label-hint` | If true, an *optional* message is displayed if not required, otherwise a * marker is displayed if required.                                     | `boolean` | `undefined` |
+| `value`         | `value`           | The value of this element. (**unmanaged**)                                                                                                      | `string`  | `''`        |
 
 
 ## Events

--- a/packages/storybook/custom-elements.json
+++ b/packages/storybook/custom-elements.json
@@ -4110,7 +4110,16 @@
           "description": "For the icon to be prepended"
         }
       ],
-      "cssProperties": [],
+      "cssProperties": [
+        {
+          "name": "--ino-select-height",
+          "description": "Height of the open select menu"
+        },
+        {
+          "name": "--ino-select-icon-color",
+          "description": "Icon color"
+        }
+      ],
       "cssParts": []
     },
     {

--- a/packages/storybook/custom-elements.json
+++ b/packages/storybook/custom-elements.json
@@ -3999,9 +3999,15 @@
           "required": false
         },
         {
+          "name": "error",
+          "type": "boolean",
+          "description": "Displays the select as invalid if set to true.\nIf the property is not set or set to false,\nthe validation is handled by the default validation.",
+          "required": false
+        },
+        {
           "name": "label",
           "type": "string",
-          "description": "The label of this element",
+          "description": "The label of this element.",
           "required": false
         },
         {
@@ -4025,7 +4031,7 @@
         {
           "name": "show-label-hint",
           "type": "boolean",
-          "description": "If true, an *optional* message is displayed if not required,\notherwise a * marker is displayed if required",
+          "description": "If true, an *optional* message is displayed if not required,\notherwise a * marker is displayed if required.",
           "required": false
         },
         {
@@ -4044,9 +4050,15 @@
           "required": false
         },
         {
+          "name": "error",
+          "type": "boolean",
+          "description": "Displays the select as invalid if set to true.\nIf the property is not set or set to false,\nthe validation is handled by the default validation.",
+          "required": false
+        },
+        {
           "name": "label",
           "type": "string",
-          "description": "The label of this element",
+          "description": "The label of this element.",
           "required": false
         },
         {
@@ -4070,7 +4082,7 @@
         {
           "name": "showLabelHint",
           "type": "boolean",
-          "description": "If true, an *optional* message is displayed if not required,\notherwise a * marker is displayed if required",
+          "description": "If true, an *optional* message is displayed if not required,\notherwise a * marker is displayed if required.",
           "required": false
         },
         {
@@ -4098,16 +4110,7 @@
           "description": "For the icon to be prepended"
         }
       ],
-      "cssProperties": [
-        {
-          "name": "--ino-select-height",
-          "description": "Height of the open select menu"
-        },
-        {
-          "name": "--ino-select-icon-color",
-          "description": "Icon color"
-        }
-      ],
+      "cssProperties": [],
       "cssParts": []
     },
     {

--- a/packages/storybook/src/stories/ino-select/ino-select.stories.ts
+++ b/packages/storybook/src/stories/ino-select/ino-select.stories.ts
@@ -5,12 +5,12 @@ import { html } from 'lit-html';
 import { decorateStoryWithClass, showSnackbar } from '../utils';
 import './ino-select.scss';
 
-const handleFormSubmission = (e) => {
+const handleFormSubmission = e => {
   e.preventDefault();
   showSnackbar('Form submitted.');
 };
 
-const handleSelect = (e) => e.target.setAttribute('value', e.detail);
+const handleSelect = e => e.target.setAttribute('value', e.detail);
 
 export default {
   title: 'Input/ino-select',
@@ -21,16 +21,16 @@ export default {
     },
   },
   decorators: [
-    (story) => decorateStoryWithClass(story, 'story-select'),
-    (story) => {
+    story => decorateStoryWithClass(story, 'story-select'),
+    story => {
       useEffect(() => {
         const formElement = document.querySelector('form');
         formElement?.addEventListener('submit', handleFormSubmission);
 
         const selects = document.querySelectorAll('ino-select');
-        selects.forEach((s) => s.addEventListener('valueChange', handleSelect));
+        selects.forEach(s => s.addEventListener('valueChange', handleSelect));
         return () => {
-          selects.forEach((s) =>
+          selects.forEach(s =>
             s.removeEventListener('valueChange', handleSelect)
           );
           formElement?.removeEventListener('submit', handleFormSubmission);
@@ -47,7 +47,7 @@ const optionsTemplate = html`
   <ino-option value="Option 3">Option 3</ino-option>
 `;
 
-export const Playground: Story<Components.InoSelect> = (args) => html`
+export const Playground: Story<Components.InoSelect> = args => html`
   <ino-select
     disabled="${args.disabled}"
     name="${args.name}"
@@ -132,9 +132,18 @@ export const Required = () => html`
   </ino-select>
 `;
 
+export const ErrorState = () => html`
+  <ino-select error label="Select in error state">
+    ${optionsTemplate}
+  </ino-select>
+  <ino-select error outline label="Outlined select in error state">
+    ${optionsTemplate}
+  </ino-select>
+`;
+
 export const Form = () => html`
   <form>
-    <p>Form should submit if no value is selected</p>
+    <p>Form should not submit if no value is selected</p>
     <ino-select required> ${optionsTemplate}</ino-select>
     <ino-button type="submit">Submit</ino-button>
   </form>

--- a/packages/storybook/src/stories/ino-select/ino-select.stories.ts
+++ b/packages/storybook/src/stories/ino-select/ino-select.stories.ts
@@ -56,6 +56,7 @@ export const Playground: Story<Components.InoSelect> = (args) => html`
     required="${args.required}"
     show-label-hint="${args.showLabelHint}"
     value="${args.value}"
+    error="${args.error}"
   >
     ${optionsTemplate}
   </ino-select>
@@ -68,6 +69,7 @@ Playground.args = {
   required: false,
   showLabelHint: false,
   value: 'Option 1',
+  error: false,
 };
 
 export const NoLabel = () => html`


### PR DESCRIPTION
Relates to #423

## Proposed Changes

- add Property `error` to enable error state programmatically
