### PR TITLE
refactor: load font `lato` from inovex host

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -15,3 +15,5 @@ proxies-list.ts
 proxies.ts
 utils.ts
 CHANGELOG.md
+
+import-fonts.ts

--- a/.prettierignore
+++ b/.prettierignore
@@ -15,5 +15,3 @@ proxies-list.ts
 proxies.ts
 utils.ts
 CHANGELOG.md
-
-import-fonts.ts

--- a/packages/elements-angular/elements/src/app-initialize.ts
+++ b/packages/elements-angular/elements/src/app-initialize.ts
@@ -1,5 +1,3 @@
-import { importLatoFont } from '@inovex.de/elements/dist/collection/util/import-fonts';
-
 import { NgZone } from '@angular/core';
 import {
   applyPolyfills,
@@ -18,7 +16,6 @@ export const appInitialize = (doc: Document, zone: NgZone) => {
       }
       didInitialize = true;
 
-      importLatoFont();
       const aelFn =
         '__zone_symbol__addEventListener' in (doc.body as any)
           ? '__zone_symbol__addEventListener'

--- a/packages/elements/package.json
+++ b/packages/elements/package.json
@@ -93,6 +93,7 @@
     "@stencil/angular-output-target": "^0.0.5",
     "@stencil/sass": "^1.4.1",
     "@types/classnames": "^2.2.6",
+    "@types/css-font-loading-module": "^0.0.6",
     "@types/jest": "26.0.14",
     "@types/puppeteer": "^3.0.2",
     "@types/resize-observer-browser": "^0.1.4",

--- a/packages/elements/package.json
+++ b/packages/elements/package.json
@@ -87,8 +87,7 @@
     "currency.js": "^1.2.2",
     "date-fns": "^2.16.1",
     "flatpickr": "^4.4.6",
-    "tippy.js": "^6.2.3",
-    "typeface-lato": "^0.0.75"
+    "tippy.js": "^6.2.3"
   },
   "devDependencies": {
     "@stencil/angular-output-target": "^0.0.5",

--- a/packages/elements/src/components/base/_typography.scss
+++ b/packages/elements/src/components/base/_typography.scss
@@ -3,13 +3,12 @@
 // ##################################
 
 // => Font Family
-
 $_font-families: (
   sans-serif: unquote('Lato, Verdana, sans-serif'),
   monospace: unquote('Courier, monospace'),
 );
 @function font-family($mode: sans-serif) {
-  @return map-get($_font-families, $mode);
+  @return var(--ino-font-family, map-get($_font-families, $mode));
 }
 
 // => Font weights

--- a/packages/elements/src/util/import-fonts.ts
+++ b/packages/elements/src/util/import-fonts.ts
@@ -1,4 +1,4 @@
-/// <reference types="css-font-loading-module" />
+import type {} from 'css-font-loading-module';
 
 enum HostedFonts {
   LATO = 'Lato',

--- a/packages/elements/src/util/import-fonts.ts
+++ b/packages/elements/src/util/import-fonts.ts
@@ -1,20 +1,25 @@
-/* eslint-disable @typescript-eslint/no-var-requires */
-try {
-  require('typeface-lato');
-} catch (e) {
-  // Workaround because of require being undefined in test environment
+function checkFont(strFamily) {
+  return (document as any)?.fonts?.check(`12px ${strFamily}`) || false;
 }
 
-// For the angular wrapper
-export function importLatoFont() {
-  const cssFile = require('typeface-lato').default;
-  addCSSToHead(cssFile);
+function addCSSToHead() {
+  const fontFamily = getComputedStyle(
+    document.documentElement
+  ).getPropertyValue('--ino-font-family');
+  console.log(checkFont('Lato'));
+  if (!fontFamily && !checkFont('Lato')) {
+    const head = document.getElementsByTagName('head')[0];
+    const style = document.createElement('style');
+    style.setAttribute('type', 'text/css');
+    style.appendChild(
+      document.createTextNode(
+        "@import url('https://static.inovex.de/css/lato.css');"
+      )
+    );
+    head.appendChild(style);
+  }
 }
 
-function addCSSToHead(css) {
-  const head = document.getElementsByTagName('head')[0];
-  const style = document.createElement('style');
-  style.setAttribute('type', 'text/css');
-  style.appendChild(document.createTextNode(css));
-  head.appendChild(style);
+export default function () {
+  addCSSToHead();
 }

--- a/packages/elements/src/util/import-fonts.ts
+++ b/packages/elements/src/util/import-fonts.ts
@@ -1,14 +1,23 @@
-function checkFont(strFamily) {
-  return (document as any)?.fonts?.check(`12px ${strFamily}`) || false;
+/// <reference types="css-font-loading-module" />
+
+enum HostedFonts {
+  LATO = 'Lato',
+}
+
+function checkFont(strFamily: HostedFonts): boolean {
+  return document.fonts?.check(`12px ${strFamily}`);
 }
 
 function addCSSToHead() {
-  const fontFamily = getComputedStyle(
-    document.documentElement
-  ).getPropertyValue('--ino-font-family');
-  console.log(checkFont('Lato'));
-  if (!fontFamily && !checkFont('Lato')) {
-    const head = document.getElementsByTagName('head')[0];
+  const isCSSVarLoaded = Boolean(
+    getComputedStyle(document.documentElement).getPropertyValue(
+      '--ino-font-family'
+    )
+  );
+
+  const isLatoLoaded = checkFont(HostedFonts.LATO);
+
+  if (!isCSSVarLoaded && !isLatoLoaded) {
     const style = document.createElement('style');
     style.setAttribute('type', 'text/css');
     style.appendChild(
@@ -16,10 +25,8 @@ function addCSSToHead() {
         "@import url('https://static.inovex.de/css/lato.css');"
       )
     );
-    head.appendChild(style);
+    document.head.appendChild(style);
   }
 }
 
-export default function () {
-  addCSSToHead();
-}
+export default addCSSToHead;

--- a/packages/elements/src/util/import-fonts.ts
+++ b/packages/elements/src/util/import-fonts.ts
@@ -1,4 +1,4 @@
-import type {} from 'css-font-loading-module';
+/// <reference types="css-font-loading-module" />
 
 enum HostedFonts {
   LATO = 'Lato',

--- a/packages/storybook/custom-elements.json
+++ b/packages/storybook/custom-elements.json
@@ -4186,7 +4186,7 @@
     {
       "name": "ino-snackbar",
       "path": "./src/components/ino-snackbar/ino-snackbar.tsx",
-      "description": "Snackbars provide brief messages about app processes at the bottom of the screen. It functions as a wrapper around the material design's [Snackbar](https://github.com/material-components/material-components-web/tree/master/packages/mdc-snackbar) component",
+      "description": "Snackbars provide brief messages about app processes. It functions as a wrapper around the material design's [Snackbar](https://github.com/material-components/material-components-web/tree/master/packages/mdc-snackbar) component.",
       "attributes": [
         {
           "name": "action-text",

--- a/yarn.lock
+++ b/yarn.lock
@@ -22574,11 +22574,6 @@ typedarray@^0.0.6:
   resolved "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typeface-lato@^0.0.75:
-  version "0.0.75"
-  resolved "https://registry.npmjs.org/typeface-lato/-/typeface-lato-0.0.75.tgz#8aa11c5611dc38416837c089b265a2abd1f7dd31"
-  integrity sha512-iA5uJD4PSTyIE4BDiSOexQeXkDkiJuX4Hu3wh3saJ06EB2TvJayab1Lbbmqq2je/LQv7KCQZHZmC0k4hedd8sw==
-
 typescript@4.3.4:
   version "4.3.4"
   resolved "https://registry.npmjs.org/typescript/-/typescript-4.3.4.tgz#3f85b986945bcf31071decdd96cf8bfa65f9dcbc"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5527,6 +5527,11 @@
   resolved "https://registry.npmjs.org/@types/cors/-/cors-2.8.10.tgz#61cc8469849e5bcdd0c7044122265c39cec10cf4"
   integrity sha512-C7srjHiVG3Ey1nR6d511dtDkCEjxuN9W1HWAEjGq8kpcwmNM6JJkpC0xvabM7BXTG2wDq8Eu33iH9aQKa7IvLQ==
 
+"@types/css-font-loading-module@^0.0.6":
+  version "0.0.6"
+  resolved "https://registry.npmjs.org/@types/css-font-loading-module/-/css-font-loading-module-0.0.6.tgz#1ac3417ed31eeb953134d29b56bca921644b87c0"
+  integrity sha512-MBvSMSxXFtIukyXRU3HhzL369rIWaqMVQD5kmDCYIFFD6Fe3lJ4c9UnLD02MLdTp7Z6ti7rO3SQtuDo7C80mmw==
+
 "@types/eslint-scope@^3.7.0":
   version "3.7.0"
   resolved "https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.0.tgz#4792816e31119ebd506902a482caec4951fabd86"


### PR DESCRIPTION
Closes #160 

## Proposed Changes

- provide global css var `--ino-font-family` for custom font
- loading _Lato_ font from static inovex host if necessary

