### PR TITLE
Elements ino autocomplete refactoring

### DIFF
--- a/packages/elements-angular/elements/src/directives/control-value-accesors/text-value-accessor.directive.ts
+++ b/packages/elements-angular/elements/src/directives/control-value-accesors/text-value-accessor.directive.ts
@@ -4,7 +4,8 @@ import { NG_VALUE_ACCESSOR } from '@angular/forms';
 import { ValueAccessorDirective } from './value-accessor.directive';
 
 @Directive({
-  selector: 'ino-input,ino-textarea,ino-range,ino-select,ino-datepicker',
+  selector:
+    'ino-autocomplete,ino-input,ino-textarea,ino-range,ino-select,ino-datepicker',
   providers: [
     {
       provide: NG_VALUE_ACCESSOR,
@@ -17,7 +18,6 @@ export class TextValueAccessorDirective extends ValueAccessorDirective {
   constructor(el: ElementRef) {
     super(el);
   }
-
   @HostListener('valueChange', ['$event.detail'])
   _handleInputEvent(value: string): void {
     this.handleChangeEvent(value);

--- a/packages/elements-angular/elements/src/directives/proxies.ts
+++ b/packages/elements-angular/elements/src/directives/proxies.ts
@@ -15,7 +15,7 @@ export declare interface InoAutocomplete extends Components.InoAutocomplete {}
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
   inputs: ['debounceTimeout', 'noOptionsText'],
-  outputs: ['optionSelected']
+  outputs: ['valueChange']
 })
 export class InoAutocomplete {
   /** Emits in three ways:
@@ -25,12 +25,12 @@ export class InoAutocomplete {
 3. Entering a valid value and blurring the input element
 
 Contains one of the texts provided by the `<ino-options>`s. */
-  optionSelected!: IAutocomplete['optionSelected'];
+  valueChange!: IAutocomplete['valueChange'];
   protected el: HTMLElement;
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
     this.el = r.nativeElement;
-    proxyOutputs(this, this.el, ['optionSelected']);
+    proxyOutputs(this, this.el, ['valueChange']);
   }
 }
 

--- a/packages/elements-angular/elements/src/directives/proxies.ts
+++ b/packages/elements-angular/elements/src/directives/proxies.ts
@@ -8,13 +8,13 @@ import { Components } from '@inovex.de/elements';
 import { Autocomplete as IAutocomplete } from '@inovex.de/elements/dist/types/components/ino-autocomplete/ino-autocomplete';
 export declare interface InoAutocomplete extends Components.InoAutocomplete {}
 @ProxyCmp({
-  inputs: ['debounceTimeout', 'noOptionsText']
+  inputs: ['debounceTimeout', 'noOptionsText', 'value']
 })
 @Component({
   selector: 'ino-autocomplete',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
-  inputs: ['debounceTimeout', 'noOptionsText'],
+  inputs: ['debounceTimeout', 'noOptionsText', 'value'],
   outputs: ['valueChange']
 })
 export class InoAutocomplete {

--- a/packages/elements/src/components.d.ts
+++ b/packages/elements/src/components.d.ts
@@ -1554,7 +1554,7 @@ declare namespace LocalJSX {
         /**
           * Emits in three ways:  1. Clicking on an option 2. Pressing `Enter` while an option is selected 3. Entering a valid value and blurring the input element  Contains one of the texts provided by the `<ino-options>`s.
          */
-        "onOptionSelected"?: (event: CustomEvent<string>) => void;
+        "onValueChange"?: (event: CustomEvent<string>) => void;
     }
     interface InoButton {
         /**

--- a/packages/elements/src/components.d.ts
+++ b/packages/elements/src/components.d.ts
@@ -18,6 +18,10 @@ export namespace Components {
           * Text to display when there are no options found.
          */
         "noOptionsText": string;
+        /**
+          * Value of the autocomplete
+         */
+        "value": any;
     }
     interface InoButton {
         /**
@@ -1555,6 +1559,10 @@ declare namespace LocalJSX {
           * Emits in three ways:  1. Clicking on an option 2. Pressing `Enter` while an option is selected 3. Entering a valid value and blurring the input element  Contains one of the texts provided by the `<ino-options>`s.
          */
         "onValueChange"?: (event: CustomEvent<string>) => void;
+        /**
+          * Value of the autocomplete
+         */
+        "value"?: any;
     }
     interface InoButton {
         /**

--- a/packages/elements/src/components/ino-autocomplete/ino-autocomplete.scss
+++ b/packages/elements/src/components/ino-autocomplete/ino-autocomplete.scss
@@ -1,9 +1,9 @@
 @use 'base/theme';
 
+/**
+* @prop --ino-autocomplete-list-max-height: max height of option list
+*/
 :host {
-  /**
-  * @prop --ino-autocomplete-list-max-height: max height of option list
-  */
   .menu {
     max-height: var(--ino-autocomplete-list-max-height, 50%);
     width: var(--input-width, max-content);

--- a/packages/elements/src/components/ino-autocomplete/ino-autocomplete.scss
+++ b/packages/elements/src/components/ino-autocomplete/ino-autocomplete.scss
@@ -1,4 +1,8 @@
 @use 'base/theme';
+@use 'base/mdc-customize';
+@use '@material/list';
+
+@include list.core-styles;
 
 /**
 * @prop --ino-autocomplete-list-max-height: max height of option list

--- a/packages/elements/src/components/ino-autocomplete/ino-autocomplete.scss
+++ b/packages/elements/src/components/ino-autocomplete/ino-autocomplete.scss
@@ -1,8 +1,11 @@
 @use 'base/theme';
 
 ino-autocomplete {
+  /**
+  * @prop --ino-autocomplete-list-max-height: max height of option list
+  */
   .menu {
-    height: max-content;
+    max-height: var(--ino-autocomplete-list-max-height, 50%);
     width: var(--input-width, max-content);
     position: absolute;
     z-index: 10;
@@ -11,6 +14,7 @@ ino-autocomplete {
       0 1px 10px 0 rgb(0 0 0 / 12%);
     border-bottom-left-radius: 5px;
     border-bottom-right-radius: 5px;
+    overflow: auto;
   }
 
   .menu-hidden {

--- a/packages/elements/src/components/ino-autocomplete/ino-autocomplete.scss
+++ b/packages/elements/src/components/ino-autocomplete/ino-autocomplete.scss
@@ -1,6 +1,6 @@
 @use 'base/theme';
 
-ino-autocomplete {
+:host {
   /**
   * @prop --ino-autocomplete-list-max-height: max height of option list
   */

--- a/packages/elements/src/components/ino-autocomplete/ino-autocomplete.tsx
+++ b/packages/elements/src/components/ino-autocomplete/ino-autocomplete.tsx
@@ -98,10 +98,10 @@ export class Autocomplete implements ComponentInterface {
    *
    * Contains one of the texts provided by the `<ino-options>`s.
    */
-  @Event() optionSelected: EventEmitter<string>;
+  @Event() valueChange: EventEmitter<string>;
 
   emitValueOfSelectedOption = () =>
-    this.optionSelected.emit(this.getSelectedOption()?.value);
+    this.valueChange.emit(this.getSelectedOption()?.value);
 
   connectedCallback() {
     this.setupOptions();
@@ -125,7 +125,9 @@ export class Autocomplete implements ComponentInterface {
 
   @Listen('valueChange')
   onValueChange(ev: CustomEvent<string>) {
-    this.input = ev.detail;
+    if ((ev.target as HTMLElement).tagName.toLowerCase() === 'ino-input') {
+      this.input = ev.detail;
+    }
   }
 
   @Listen('click')

--- a/packages/elements/src/components/ino-autocomplete/ino-autocomplete.tsx
+++ b/packages/elements/src/components/ino-autocomplete/ino-autocomplete.tsx
@@ -306,6 +306,7 @@ export class Autocomplete implements ComponentInterface {
       menu: true,
       'menu-hidden': !this.menuIsVisible,
       'menu-shown': this.menuIsVisible,
+      'mdc-list': true,
     });
 
     return (

--- a/packages/elements/src/components/ino-autocomplete/ino-autocomplete.tsx
+++ b/packages/elements/src/components/ino-autocomplete/ino-autocomplete.tsx
@@ -21,7 +21,6 @@ import { Debouncer } from '../../util/debouncer';
 
 enum Slots {
   INPUT = 'input',
-  LIST = 'list',
 }
 
 const NO_OPTION_SELECTED = -1;
@@ -103,14 +102,12 @@ export class Autocomplete implements ComponentInterface {
   emitValueOfSelectedOption = () =>
     this.valueChange.emit(this.getSelectedOption()?.value);
 
-  connectedCallback() {
-    this.setupOptions();
+  componentWillLoad() {
     this.setupObserver();
   }
 
   componentDidLoad() {
     this.setupInput();
-    this.setupList();
   }
 
   disconnectedCallback() {
@@ -259,15 +256,14 @@ export class Autocomplete implements ComponentInterface {
     );
   }
 
-  setupList() {
-    if (!hasSlotContent(this.el, Slots.LIST)) {
-      throw new Error(
-        `The slot "${Slots.LIST}" is empty. Please provide an ino-list element to that slot.`
-      );
+  setupOptions = (mutations: MutationRecord[]) => {
+    const records = mutations.filter(
+      (m) => m.target.nodeName.toLowerCase() === 'ino-option'
+    );
+    if (records.length < 1) {
+      return;
     }
-  }
 
-  setupOptions = () => {
     this.optionEls = Array.from(this.el.getElementsByTagName('ino-option'));
     this.filteredOptionEls = this.optionEls;
     this.optionTexts = this.optionEls.map((item) => item.innerText);
@@ -333,7 +329,7 @@ export class Autocomplete implements ComponentInterface {
           {this.filteredOptionEls?.length === 0 && (
             <p class="no-options-text">{this.noOptionsText}</p>
           )}
-          <slot name={Slots.LIST} />
+          <slot />
         </div>
       </Host>
     );

--- a/packages/elements/src/components/ino-autocomplete/readme.md
+++ b/packages/elements/src/components/ino-autocomplete/readme.md
@@ -62,6 +62,7 @@ class MyComponent extends Component {
 | ----------------- | ------------------ | -------------------------------------------------------------------- | -------- | ------------- |
 | `debounceTimeout` | `debounce-timeout` | Timeout of the debouncing mechanism used when filtering the options. | `number` | `300`         |
 | `noOptionsText`   | `no-options-text`  | Text to display when there are no options found.                     | `string` | `'No Option'` |
+| `value`           | `value`            | Value of the autocomplete                                            | `any`    | `undefined`   |
 
 
 ## Events

--- a/packages/elements/src/components/ino-autocomplete/readme.md
+++ b/packages/elements/src/components/ino-autocomplete/readme.md
@@ -74,17 +74,10 @@ class MyComponent extends Component {
 
 ## Slots
 
-| Slot      | Description                                                        |
-| --------- | ------------------------------------------------------------------ |
-| `"input"` | An `<ino-input>` element that will be controlled by this component |
-| `"list"`  | An `<ino-list>` element with `<ino-option>` elements as options    |
-
-
-## CSS Custom Properties
-
-| Name                                 | Description               |
-| ------------------------------------ | ------------------------- |
-| `--ino-autocomplete-list-max-height` | max height of option list |
+| Slot        | Description                                                        |
+| ----------- | ------------------------------------------------------------------ |
+| `"default"` | A list of `<ino-option>` elements as options                       |
+| `"input"`   | An `<ino-input>` element that will be controlled by this component |
 
 
 ----------------------------------------------

--- a/packages/elements/src/components/ino-autocomplete/readme.md
+++ b/packages/elements/src/components/ino-autocomplete/readme.md
@@ -80,6 +80,13 @@ class MyComponent extends Component {
 | `"input"`   | An `<ino-input>` element that will be controlled by this component |
 
 
+## CSS Custom Properties
+
+| Name                                 | Description               |
+| ------------------------------------ | ------------------------- |
+| `--ino-autocomplete-list-max-height` | max height of option list |
+
+
 ----------------------------------------------
 
 *Built with [StencilJS](https://stenciljs.com/)*

--- a/packages/elements/src/components/ino-autocomplete/readme.md
+++ b/packages/elements/src/components/ino-autocomplete/readme.md
@@ -66,9 +66,9 @@ class MyComponent extends Component {
 
 ## Events
 
-| Event            | Description                                                                                                                                                                                                          | Type                  |
-| ---------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------- |
-| `optionSelected` | Emits in three ways:  1. Clicking on an option 2. Pressing `Enter` while an option is selected 3. Entering a valid value and blurring the input element  Contains one of the texts provided by the `<ino-options>`s. | `CustomEvent<string>` |
+| Event         | Description                                                                                                                                                                                                          | Type                  |
+| ------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------- |
+| `valueChange` | Emits in three ways:  1. Clicking on an option 2. Pressing `Enter` while an option is selected 3. Entering a valid value and blurring the input element  Contains one of the texts provided by the `<ino-options>`s. | `CustomEvent<string>` |
 
 
 ## Slots
@@ -77,6 +77,13 @@ class MyComponent extends Component {
 | --------- | ------------------------------------------------------------------ |
 | `"input"` | An `<ino-input>` element that will be controlled by this component |
 | `"list"`  | An `<ino-list>` element with `<ino-option>` elements as options    |
+
+
+## CSS Custom Properties
+
+| Name                                 | Description               |
+| ------------------------------------ | ------------------------- |
+| `--ino-autocomplete-list-max-height` | max height of option list |
 
 
 ----------------------------------------------

--- a/packages/storybook/custom-elements.json
+++ b/packages/storybook/custom-elements.json
@@ -58,12 +58,12 @@
       "methods": [],
       "slots": [
         {
-          "name": "input",
-          "description": "An `<ino-input>` element that will be controlled by this component"
+          "name": "default",
+          "description": "A list of `<ino-option>` elements as options"
         },
         {
-          "name": "list",
-          "description": "An `<ino-list>` element with `<ino-option>` elements as options"
+          "name": "input",
+          "description": "An `<ino-input>` element that will be controlled by this component"
         }
       ],
       "cssProperties": [

--- a/packages/storybook/custom-elements.json
+++ b/packages/storybook/custom-elements.json
@@ -39,7 +39,7 @@
       ],
       "events": [
         {
-          "name": "optionSelected",
+          "name": "valueChange",
           "description": "Emits in three ways:\n\n1. Clicking on an option\n2. Pressing `Enter` while an option is selected\n3. Entering a valid value and blurring the input element\n\nContains one of the texts provided by the `<ino-options>`s."
         }
       ],
@@ -54,7 +54,12 @@
           "description": "An `<ino-list>` element with `<ino-option>` elements as options"
         }
       ],
-      "cssProperties": [],
+      "cssProperties": [
+        {
+          "name": "--ino-autocomplete-list-max-height",
+          "description": "max height of option list"
+        }
+      ],
       "cssParts": []
     },
     {

--- a/packages/storybook/custom-elements.json
+++ b/packages/storybook/custom-elements.json
@@ -19,6 +19,12 @@
           "description": "Text to display when there are no options found.",
           "defaultValue": "'No Option'",
           "required": false
+        },
+        {
+          "name": "value",
+          "type": "any",
+          "description": "Value of the autocomplete",
+          "required": false
         }
       ],
       "properties": [
@@ -34,6 +40,12 @@
           "type": "string",
           "description": "Text to display when there are no options found.",
           "defaultValue": "'No Option'",
+          "required": false
+        },
+        {
+          "name": "value",
+          "type": "any",
+          "description": "Value of the autocomplete",
           "required": false
         }
       ],

--- a/packages/storybook/src/stories/ino-autocomplete/ino-autocomplete.stories.ts
+++ b/packages/storybook/src/stories/ino-autocomplete/ino-autocomplete.stories.ts
@@ -15,10 +15,10 @@ export default {
     },
   },
   decorators: [
-    (story) => decorateStoryWithClass(story),
-    (story) => {
+    story => decorateStoryWithClass(story),
+    story => {
       useEffect(() => {
-        const eventHandler = function (e: CustomEvent<string>) {
+        const eventHandler = function(e: CustomEvent<string>) {
           showSnackbar(`"${e.detail}" was selected.`);
         };
 
@@ -34,22 +34,24 @@ export default {
   ],
 } as Meta;
 
-export const Playground: Story<Components.InoAutocomplete> = (args) => html`
+const options = [];
+
+for (let i = 0; i < 500; i++) {
+  options.push(
+    html`
+      <ino-option value="value of Option ${i}">${i}</ino-option>
+    `
+  );
+}
+
+export const Playground: Story<Components.InoAutocomplete> = args => html`
   <div style="height: 300px;">
     <ino-autocomplete
       style="margin: 50px"
-      debounce-timeout="${args.debounceTimeout}"
       no-options-text="${args.noOptionsText}"
     >
       <ino-input slot="input"></ino-input>
-      <ino-option value="value of Option A">Option A</ino-option>
-      <ino-option value="value of Option B">Option B</ino-option>
-      <ino-option value="value of Option C">Option C</ino-option>
-      <ino-option value="value of Option D">Option D</ino-option>
-      <ino-option value="value of Option E">Option E</ino-option>
-      <ino-option value="value of Option F">Option F</ino-option>
-      <ino-option value="value of Option G">Option G</ino-option>
-      <ino-option value="value of Option H">Option H</ino-option>
+      ${options}
     </ino-autocomplete>
   </div>
 `;

--- a/packages/storybook/src/stories/ino-autocomplete/ino-autocomplete.stories.ts
+++ b/packages/storybook/src/stories/ino-autocomplete/ino-autocomplete.stories.ts
@@ -42,16 +42,14 @@ export const Playground: Story<Components.InoAutocomplete> = (args) => html`
       no-options-text="${args.noOptionsText}"
     >
       <ino-input slot="input"></ino-input>
-      <ino-list slot="list">
-        <ino-option value="value of Option A">Option A</ino-option>
-        <ino-option value="value of Option B">Option B</ino-option>
-        <ino-option value="value of Option C">Option C</ino-option>
-        <ino-option value="value of Option D">Option D</ino-option>
-        <ino-option value="value of Option E">Option E</ino-option>
-        <ino-option value="value of Option F">Option F</ino-option>
-        <ino-option value="value of Option G">Option G</ino-option>
-        <ino-option value="value of Option H">Option H</ino-option>
-      </ino-list>
+      <ino-option value="value of Option A">Option A</ino-option>
+      <ino-option value="value of Option B">Option B</ino-option>
+      <ino-option value="value of Option C">Option C</ino-option>
+      <ino-option value="value of Option D">Option D</ino-option>
+      <ino-option value="value of Option E">Option E</ino-option>
+      <ino-option value="value of Option F">Option F</ino-option>
+      <ino-option value="value of Option G">Option G</ino-option>
+      <ino-option value="value of Option H">Option H</ino-option>
     </ino-autocomplete>
   </div>
 `;

--- a/packages/storybook/src/stories/ino-autocomplete/ino-autocomplete.stories.ts
+++ b/packages/storybook/src/stories/ino-autocomplete/ino-autocomplete.stories.ts
@@ -11,7 +11,7 @@ export default {
   component: 'ino-autocomplete',
   parameters: {
     actions: {
-      handles: ['optionSelected'],
+      handles: ['valueChange'],
     },
   },
   decorators: [
@@ -22,10 +22,10 @@ export default {
           showSnackbar(`"${e.detail}" was selected.`);
         };
 
-        document.addEventListener('optionSelected', eventHandler);
+        document.addEventListener('valueChange', eventHandler);
 
         return () => {
-          document.removeEventListener('optionSelected', eventHandler);
+          document.removeEventListener('valueChange', eventHandler);
         };
       });
 
@@ -41,11 +41,16 @@ export const Playground: Story<Components.InoAutocomplete> = (args) => html`
       debounce-timeout="${args.debounceTimeout}"
       no-options-text="${args.noOptionsText}"
     >
-      <ino-input slot="input" />
+      <ino-input slot="input"></ino-input>
       <ino-list slot="list">
         <ino-option value="value of Option A">Option A</ino-option>
         <ino-option value="value of Option B">Option B</ino-option>
         <ino-option value="value of Option C">Option C</ino-option>
+        <ino-option value="value of Option D">Option D</ino-option>
+        <ino-option value="value of Option E">Option E</ino-option>
+        <ino-option value="value of Option F">Option F</ino-option>
+        <ino-option value="value of Option G">Option G</ino-option>
+        <ino-option value="value of Option H">Option H</ino-option>
       </ino-list>
     </ino-autocomplete>
   </div>


### PR DESCRIPTION
## Proposed Changes

**Breaking changes**
- change naming of event `optionSelected` to `valueChange`
- remove `list` slot - `ino-list` is not longer  required.
- add `default` slot for `ino-options`


- provides `max-height` of options container
  - `max-height` can be changed with css var `--ino-autocomplete-list-max-height`
- improve render performance
- provide Control-Value-Accessor for Angular

