### PR TITLE
refactor(elements|ino-snackbar): use default slot instead of property

### DIFF
--- a/packages/elements-angular/elements/src/directives/proxies.ts
+++ b/packages/elements-angular/elements/src/directives/proxies.ts
@@ -861,13 +861,13 @@ export class InoSidebar {
 import { Snackbar as ISnackbar } from '@inovex.de/elements/dist/types/components/ino-snackbar/ino-snackbar';
 export declare interface InoSnackbar extends Components.InoSnackbar {}
 @ProxyCmp({
-  inputs: ['actionText', 'message', 'stayVisibleOnHover', 'timeout', 'type']
+  inputs: ['actionText', 'stayVisibleOnHover', 'timeout', 'type']
 })
 @Component({
   selector: 'ino-snackbar',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
-  inputs: ['actionText', 'message', 'stayVisibleOnHover', 'timeout', 'type'],
+  inputs: ['actionText', 'stayVisibleOnHover', 'timeout', 'type'],
   outputs: ['actionClick', 'hideEl']
 })
 export class InoSnackbar {

--- a/packages/elements/src/components.d.ts
+++ b/packages/elements/src/components.d.ts
@@ -1023,10 +1023,6 @@ export namespace Components {
          */
         "actionText"?: string;
         /**
-          * The text message to display.
-         */
-        "message"?: string;
-        /**
           * If set to true, the timeout that closes the snackbar is paused when the user hovers over the snackbar.
          */
         "stayVisibleOnHover"?: boolean;
@@ -2647,10 +2643,6 @@ declare namespace LocalJSX {
           * The text to display for the action button. If no text is defined, the snack bar is displayed in an alternative feedback style.
          */
         "actionText"?: string;
-        /**
-          * The text message to display.
-         */
-        "message"?: string;
         /**
           * Event that emits as soon as the action button is clicked.
          */

--- a/packages/elements/src/components/ino-snackbar/ino-snackbar.tsx
+++ b/packages/elements/src/components/ino-snackbar/ino-snackbar.tsx
@@ -25,11 +25,6 @@ export class Snackbar implements ComponentInterface {
   @Element() el!: HTMLElement;
 
   /**
-   * The text message to display.
-   */
-  @Prop() message?: string;
-
-  /**
    * The text to display for the action button.
    * If no text is defined, the snack bar is displayed in an alternative feedback style.
    */
@@ -108,7 +103,7 @@ export class Snackbar implements ComponentInterface {
     }
   };
 
-  private handleSnackbarHide = e => {
+  private handleSnackbarHide = (e) => {
     this.hideEl!.emit();
     e.stopPropagation();
   };
@@ -138,7 +133,7 @@ export class Snackbar implements ComponentInterface {
     return (
       <Host class={hostClasses}>
         <div
-          ref={el => (this.snackbarElement = el as HTMLDivElement)}
+          ref={(el) => (this.snackbarElement = el as HTMLDivElement)}
           class={snackbarClasses}
           aria-live="assertive"
           aria-atomic="true"
@@ -154,7 +149,9 @@ export class Snackbar implements ComponentInterface {
               class="mdc-snackbar__label ino-snackbar-message-container"
               aria-atomic="false"
             >
-              <div class="ino-snackbar-text-container">{this.message}</div>
+              <div class="ino-snackbar-text-container">
+                <slot />
+              </div>
               {hasActionText && (
                 <div>
                   <button

--- a/packages/elements/src/components/ino-snackbar/readme.md
+++ b/packages/elements/src/components/ino-snackbar/readme.md
@@ -107,7 +107,6 @@ Snackbar is displayed when `show` is changed to checked.
 | Property             | Attribute               | Description                                                                                                                    | Type                             | Default     |
 | -------------------- | ----------------------- | ------------------------------------------------------------------------------------------------------------------------------ | -------------------------------- | ----------- |
 | `actionText`         | `action-text`           | The text to display for the action button. If no text is defined, the snack bar is displayed in an alternative feedback style. | `string`                         | `undefined` |
-| `message`            | `message`               | The text message to display.                                                                                                   | `string`                         | `undefined` |
 | `stayVisibleOnHover` | `stay-visible-on-hover` | If set to true, the timeout that closes the snackbar is paused when the user hovers over the snackbar.                         | `boolean`                        | `false`     |
 | `timeout`            | `timeout`               | Sets the timeout in ms until the snackbar disappears. The timeout can be disabled by setting it to a negative value.           | `number`                         | `5000`      |
 | `type`               | `type`                  | Changes the snackbar type                                                                                                      | `"error" \| "info" \| "success"` | `'info'`    |
@@ -119,16 +118,6 @@ Snackbar is displayed when `show` is changed to checked.
 | ------------- | ----------------------------------------------------------------------------------------------------- | ------------------ |
 | `actionClick` | Event that emits as soon as the action button is clicked.                                             | `CustomEvent<any>` |
 | `hideEl`      | Event that emits as soon as the snackbar hides. Listen to this event to hide or destroy this element. | `CustomEvent<any>` |
-
-
-## CSS Custom Properties
-
-| Name                    | Description                 |
-| ----------------------- | --------------------------- |
-| `--ino-snackbar-bottom` | Distance to the bottom edge |
-| `--ino-snackbar-left`   | Distance to the left edge   |
-| `--ino-snackbar-right`  | Distance to the right edge  |
-| `--ino-snackbar-top`    | Distance to the top edge    |
 
 
 ## Dependencies

--- a/packages/elements/src/components/ino-snackbar/readme.md
+++ b/packages/elements/src/components/ino-snackbar/readme.md
@@ -120,6 +120,16 @@ Snackbar is displayed when `show` is changed to checked.
 | `hideEl`      | Event that emits as soon as the snackbar hides. Listen to this event to hide or destroy this element. | `CustomEvent<any>` |
 
 
+## CSS Custom Properties
+
+| Name                    | Description                 |
+| ----------------------- | --------------------------- |
+| `--ino-snackbar-bottom` | Distance to the bottom edge |
+| `--ino-snackbar-left`   | Distance to the left edge   |
+| `--ino-snackbar-right`  | Distance to the right edge  |
+| `--ino-snackbar-top`    | Distance to the top edge    |
+
+
 ## Dependencies
 
 ### Depends on

--- a/packages/storybook/custom-elements.json
+++ b/packages/storybook/custom-elements.json
@@ -4273,12 +4273,6 @@
           "required": false
         },
         {
-          "name": "message",
-          "type": "string",
-          "description": "The text message to display.",
-          "required": false
-        },
-        {
           "name": "stay-visible-on-hover",
           "type": "boolean",
           "description": "If set to true, the timeout that closes the snackbar is paused when the user hovers over the snackbar.",
@@ -4305,12 +4299,6 @@
           "name": "actionText",
           "type": "string",
           "description": "The text to display for the action button.\nIf no text is defined, the snack bar is displayed in an alternative feedback style.",
-          "required": false
-        },
-        {
-          "name": "message",
-          "type": "string",
-          "description": "The text message to display.",
           "required": false
         },
         {

--- a/packages/storybook/src/stories/ino-snackbar/ino-snackbar.stories.ts
+++ b/packages/storybook/src/stories/ino-snackbar/ino-snackbar.stories.ts
@@ -83,16 +83,16 @@ export const Playground: Story<Components.InoSnackbar> = (args) => html`
     <ino-snackbar
       id="snackbar-default"
       action-text="${args.actionText}"
-      message="${args.message}"
       timeout="${args.timeout}"
       type="${args.type}"
     >
+      ${args.defaultSlot}
     </ino-snackbar>
   </template>
 `;
 Playground.args = {
   actionText: Texts.info.action,
-  message: Texts.info.msg,
+  defaultSlot: Texts.info.msg,
   timeout: -1,
   type: 'info',
 };
@@ -111,11 +111,9 @@ export const ActionText = () => html`
     >Show Snackbar (with action text)
   </ino-button>
   <template id="snackbar-action-text">
-    <ino-snackbar
-      id="snackbar-action-text"
-      message="${Texts.info.msg}"
-      action-text="${Texts.info.action}"
-    ></ino-snackbar>
+    <ino-snackbar id="snackbar-action-text" action-text="${Texts.info.action}">
+      ${Texts.info.msg}
+    </ino-snackbar>
   </template>
   <ino-button
     class="snackbar-trigger"
@@ -123,10 +121,9 @@ export const ActionText = () => html`
     >Show Snackbar (without action text)
   </ino-button>
   <template id="snackbar-wo-action-text">
-    <ino-snackbar
-      id="snackbar-wo-action-text"
-      message="${Texts.info.msg}"
-    ></ino-snackbar>
+    <ino-snackbar id="snackbar-wo-action-text">
+      ${Texts.info.msg}
+    </ino-snackbar>
   </template>
 `;
 
@@ -141,11 +138,12 @@ export const Types = () =>
       <template id="snackbar-type-${type}">
         <ino-snackbar
           id="snackbar-type-${type}"
-          message="${Texts[type].msg}"
           action-text="${Texts[type].action}"
           type="${type}"
           timeout="-1"
-        ></ino-snackbar>
+        >
+          <span>${Texts[type].msg}</span>
+        </ino-snackbar>
       </template>
     `
   );
@@ -159,9 +157,9 @@ export const CustomPositions: Story<Components.InoSnackbar> = () => html`
   <template id="snackbar-position-top-left">
     <ino-snackbar
       id="snackbar-position-top-left"
-      message="${Texts.info.msg}"
       style="--ino-snackbar-left: 0; --ino-snackbar-right: auto;"
     >
+      ${Texts.info.msg}
     </ino-snackbar>
   </template>
   <ino-button
@@ -172,9 +170,9 @@ export const CustomPositions: Story<Components.InoSnackbar> = () => html`
   <template id="snackbar-position-bottom-left">
     <ino-snackbar
       id="snackbar-position-bottom-left"
-      message="${Texts.info.msg}"
       style="--ino-snackbar-left: 0; --ino-snackbar-bottom: 0; --ino-snackbar-top: auto; --ino-snackbar-right: auto;"
     >
+      ${Texts.info.msg}
     </ino-snackbar>
   </template>
   <ino-button
@@ -185,9 +183,9 @@ export const CustomPositions: Story<Components.InoSnackbar> = () => html`
   <template id="snackbar-position-bottom-right">
     <ino-snackbar
       id="snackbar-position-bottom-right"
-      message="${Texts.info.msg}"
       style="--ino-snackbar-bottom: 0; --ino-snackbar-top: auto;"
     >
+      ${Texts.info.msg}
     </ino-snackbar>
   </template>
 `;


### PR DESCRIPTION
**Target branch is not the 'master'** branch !
<hr />

* Relates to #403 
* remove `message` property from ino-snackbar 
* using default slot for message


