### PR TITLE
fix(elements|ino-input): prevent undefined reference on error set

### DIFF
--- a/packages/elements/src/components.d.ts
+++ b/packages/elements/src/components.d.ts
@@ -607,11 +607,11 @@ export namespace Components {
          */
         "required"?: boolean;
         /**
-          * Sets blur on the native `input`.  Use this method instead of the global `input.blur()`.
+          * Sets blur on the native `input`. Use this method instead of the global `input.blur()`.
          */
         "setBlur": () => Promise<void>;
         /**
-          * Sets focus on the native `input`.  Use this method instead of the global `input.focus()`.
+          * Sets focus on the native `input`. Use this method instead of the global `input.focus()`.
          */
         "setFocus": () => Promise<void>;
         /**

--- a/packages/elements/src/components/ino-input/ino-input.tsx
+++ b/packages/elements/src/components/ino-input/ino-input.tsx
@@ -211,7 +211,7 @@ export class Input implements ComponentInterface {
 
   @Watch('error')
   errorHandler(value?: boolean) {
-    if (this.disabled) return;
+    if (this.disabled || !this.textfield) return;
 
     if (value) {
       this.textfield.valid = false;
@@ -219,7 +219,7 @@ export class Input implements ComponentInterface {
     } else {
       this.textfield.valid = true;
       this.textfield.useNativeValidation = true;
-      this.nativeInputEl.checkValidity();
+      this.nativeInputEl?.checkValidity();
     }
   }
 
@@ -237,16 +237,16 @@ export class Input implements ComponentInterface {
   }
 
   /**
-   * Sets focus on the native `input`. 
+   * Sets focus on the native `input`.
    * Use this method instead of the global `input.focus()`.
    */
    @Method()
    async setFocus() {
      this.textfield?.focus();
    }
- 
+
    /**
-    * Sets blur on the native `input`. 
+    * Sets blur on the native `input`.
     * Use this method instead of the global `input.blur()`.
     */
    @Method()

--- a/packages/elements/src/components/ino-input/readme.md
+++ b/packages/elements/src/components/ino-input/readme.md
@@ -188,7 +188,7 @@ Type: `Promise<HTMLInputElement>`
 
 ### `setBlur() => Promise<void>`
 
-Sets blur on the native `input`. 
+Sets blur on the native `input`.
 Use this method instead of the global `input.blur()`.
 
 #### Returns
@@ -199,7 +199,7 @@ Type: `Promise<void>`
 
 ### `setFocus() => Promise<void>`
 
-Sets focus on the native `input`. 
+Sets focus on the native `input`.
 Use this method instead of the global `input.focus()`.
 
 #### Returns

--- a/packages/storybook/elements-stencil-docs.json
+++ b/packages/storybook/elements-stencil-docs.json
@@ -1,5 +1,5 @@
 {
-  "timestamp": "2022-01-10T21:35:31",
+  "timestamp": "2022-01-25T07:21:43",
   "compiler": {
     "name": "@stencil/core",
     "version": "2.4.0",
@@ -3821,7 +3821,7 @@
           },
           "signature": "setBlur() => Promise<void>",
           "parameters": [],
-          "docs": "Sets blur on the native `input`. \nUse this method instead of the global `input.blur()`.",
+          "docs": "Sets blur on the native `input`.\nUse this method instead of the global `input.blur()`.",
           "docsTags": []
         },
         {
@@ -3832,7 +3832,7 @@
           },
           "signature": "setFocus() => Promise<void>",
           "parameters": [],
-          "docs": "Sets focus on the native `input`. \nUse this method instead of the global `input.focus()`.",
+          "docs": "Sets focus on the native `input`.\nUse this method instead of the global `input.focus()`.",
           "docsTags": []
         }
       ],


### PR DESCRIPTION
Resolves Bug depening on Angular lifecycle:

![image](https://user-images.githubusercontent.com/23154336/150929237-db612f83-1481-4fe9-bd7d-dce720240cb6.png)


## Proposed Changes

- Check wheter `this.textfield` extits by setting the error property.

## Things to check

- [ ] Does the change need to be documented?
- [ ] Does any existing example code needs to be updated?
- [ ] Is the change properly tested?
- [ ] Is it helpful to provide another example to demonstrate the new feature?
- [ ] Are there other code lines that need to be modified?
