### PR TITLE
fix(elements|ino-datepicker): prevent undefined ref on mount

### DIFF
--- a/packages/elements/src/components/ino-datepicker/ino-datepicker.tsx
+++ b/packages/elements/src/components/ino-datepicker/ino-datepicker.tsx
@@ -315,8 +315,9 @@ export class Datepicker implements ComponentInterface {
 
   private create() {
     this.dispose();
+    const target = this.el.querySelector('ino-input > div') as HTMLElement;
 
-    if (this.disabled) {
+    if (this.disabled || !target) {
       return;
     }
 
@@ -344,8 +345,6 @@ export class Datepicker implements ComponentInterface {
     });
 
     const options = { ...sharedOptions, ...typeSpecificOptions };
-
-    const target = this.el.querySelector('ino-input > div') as HTMLElement;
     this.flatpickr = flatpickr(target, options);
 
     if (this.value) {


### PR DESCRIPTION
Resolves Bug depening on Angular lifecycle:

![image](https://user-images.githubusercontent.com/23154336/150934092-069b8318-6bb5-4d60-a4b6-305c49c98aa8.png)


## Proposed Changes

- check if target HTML elements exitsts before initializing flatpickr

## Things to check

- [ ] Does the change need to be documented?
- [ ] Does any existing example code needs to be updated?
- [ ] Is the change properly tested?
- [ ] Is it helpful to provide another example to demonstrate the new feature?
- [ ] Are there other code lines that need to be modified?
