### PR TITLE
fix(elements|ino-autocomplete): fix positioning while scrolling

### DIFF
--- a/packages/elements/src/components/ino-autocomplete/ino-autocomplete.scss
+++ b/packages/elements/src/components/ino-autocomplete/ino-autocomplete.scss
@@ -8,9 +8,11 @@
 * @prop --ino-autocomplete-list-max-height: max height of option list
 */
 :host {
+  position: relative;
+
   .menu {
-    max-height: var(--ino-autocomplete-list-max-height, 50%);
     width: var(--input-width, max-content);
+    max-height: var(--ino-autocomplete-list-max-height, 225px);
     position: absolute;
     z-index: 10;
     background-color: white;

--- a/packages/elements/src/components/ino-autocomplete/ino-autocomplete.tsx
+++ b/packages/elements/src/components/ino-autocomplete/ino-autocomplete.tsx
@@ -327,7 +327,6 @@ export class Autocomplete implements ComponentInterface {
       menu: true,
       'menu-hidden': !this.menuIsVisible,
       'menu-shown': this.menuIsVisible,
-      'mdc-list': true,
     });
 
     return (
@@ -338,10 +337,12 @@ export class Autocomplete implements ComponentInterface {
           ref={(el) => (this.menuContainer = el)}
           onMouseDown={(ev) => this.onListItemClick(ev)}
         >
-          {this.noOptionsIsVisible && (
-            <p class="no-options-text">{this.noOptionsText}</p>
-          )}
-          <slot onSlotchange={this.setupOptions} />
+          <div class="mdc-list">
+            {this.noOptionsIsVisible && (
+              <p class="no-options-text">{this.noOptionsText}</p>
+            )}
+            <slot onSlotchange={this.setupOptions}/>
+          </div>
         </div>
       </Host>
     );


### PR DESCRIPTION
## Proposed Changes

- change css styles to prevent floating option list container
- default `max-height` is set to `225px` equals to height of 6 list options

## Things to check

- [ ] Does the change need to be documented?
- [ ] Does any existing example code needs to be updated?
- [ ] Is the change properly tested?
- [ ] Is it helpful to provide another example to demonstrate the new feature?
- [ ] Are there other code lines that need to be modified?
