### PR TITLE
fix(elements|ino-datepicker): reattach on DOM update

### DIFF
--- a/packages/elements/src/components/ino-datepicker/ino-datepicker.tsx
+++ b/packages/elements/src/components/ino-datepicker/ino-datepicker.tsx
@@ -299,6 +299,7 @@ export class Datepicker implements ComponentInterface {
       minDate: this.min,
       maxDate: this.max,
     });
+    this.create();
   }
 
   componentDidLoad() {


### PR DESCRIPTION
## Proposed Changes

- Support reattaching of datepicker by calling `this.create()` in `connectedCallback`

## Things to check

- [ ] Does the change need to be documented?
- [ ] Does any existing example code needs to be updated?
- [ ] Is the change properly tested?
- [ ] Is it helpful to provide another example to demonstrate the new feature?
- [ ] Are there other code lines that need to be modified?
