### PR TITLE
fix(elements|ino-markdown-editor): handle change of `initialValue`

### DIFF
--- a/packages/elements/src/components/ino-markdown-editor/ino-markdown-editor.e2e.ts
+++ b/packages/elements/src/components/ino-markdown-editor/ino-markdown-editor.e2e.ts
@@ -132,4 +132,15 @@ describe('InoMarkdownEditor', () => {
     expect(spy).toHaveReceivedEvent();
     expect(spy).toHaveReceivedEventDetail(dummyText);
   });
+
+  it('should change initial value', async () => {
+    const initialText = '# Hello World';
+    await setUpTest(initialText, ViewMode.MARKDOWN);
+    expect(await textArea.getProperty('value')).toBe(initialText);
+
+    const newInitialText = '# Hallo Welt';
+    inoMarkdownEditor.setProperty('initialValue', newInitialText);
+    await page.waitForChanges();
+    expect(await textArea.getProperty('value')).toBe(newInitialText);
+  });
 });

--- a/packages/elements/src/components/ino-markdown-editor/ino-markdown-editor.tsx
+++ b/packages/elements/src/components/ino-markdown-editor/ino-markdown-editor.tsx
@@ -48,9 +48,7 @@ export class MarkdownEditor implements ComponentInterface {
 
   @Watch('initialValue')
   handleInitialValueChange(newInitialValue: string): void {
-    this.editor.commands.setContent(this.markdownToHtml(newInitialValue), true);
-    this.textareaRef.value = this.htmlToMarkdown();
-    this.textareaRef.rows = this.textareaRef.value.split('\n').length;
+    this.initializeEditor(newInitialValue);
   }
 
   /**
@@ -93,7 +91,7 @@ export class MarkdownEditor implements ComponentInterface {
   componentDidLoad(): void {
     this.createEditor();
     if (this.initialValue) {
-      this.handleInitialValueChange(this.initialValue);
+      this.initializeEditor(this.initialValue);
     }
     this.textareaRef.addEventListener('valueChange', this.onTextareaChange);
     this.textareaRef.addEventListener('inoBlur', this.handleMarkdownBlur);
@@ -103,6 +101,12 @@ export class MarkdownEditor implements ComponentInterface {
     this.editor?.destroy();
     this.textareaRef.removeEventListener('valueChange', this.onTextareaChange);
     this.textareaRef.removeEventListener('inoBlur', this.handleMarkdownBlur);
+  }
+
+  private initializeEditor(initialValue: string): void {
+    this.editor.commands.setContent(this.markdownToHtml(initialValue), true);
+    this.textareaRef.value = this.htmlToMarkdown();
+    this.textareaRef.rows = this.textareaRef.value.split('\n').length;
   }
 
   private createEditor(): void {

--- a/packages/elements/src/components/ino-markdown-editor/ino-markdown-editor.tsx
+++ b/packages/elements/src/components/ino-markdown-editor/ino-markdown-editor.tsx
@@ -46,6 +46,13 @@ export class MarkdownEditor implements ComponentInterface {
    */
   @Prop() initialValue: string;
 
+  @Watch('initialValue')
+  handleInitialValueChange(newInitialValue: string): void {
+    this.editor.commands.setContent(this.markdownToHtml(newInitialValue), true);
+    this.textareaRef.value = this.htmlToMarkdown();
+    this.textareaRef.rows = this.textareaRef.value.split('\n').length;
+  }
+
   /**
    * Sets the view mode of the editor.
    * Can be changed between `preview` (default), `markdown` and `readonly`.
@@ -86,9 +93,7 @@ export class MarkdownEditor implements ComponentInterface {
   componentDidLoad(): void {
     this.createEditor();
     if (this.initialValue) {
-      this.editor.commands.setContent(this.markdownToHtml(), true);
-      this.textareaRef.value = this.htmlToMarkdown();
-      this.textareaRef.rows = this.textareaRef.value.split('\n').length;
+      this.handleInitialValueChange(this.initialValue);
     }
     this.textareaRef.addEventListener('valueChange', this.onTextareaChange);
     this.textareaRef.addEventListener('inoBlur', this.handleMarkdownBlur);


### PR DESCRIPTION
## Proposed Changes

- add new watcher function for property `initialValue`

## Things to check

- [ ] Does the change need to be documented?
- [ ] Does any existing example code needs to be updated?
- [ ] Is the change properly tested?
- [ ] Is it helpful to provide another example to demonstrate the new feature?
- [ ] Are there other code lines that need to be modified?
