### PR TITLE
chore: add react-outputtarget

### DIFF
--- a/packages/elements-react/package.json
+++ b/packages/elements-react/package.json
@@ -48,8 +48,8 @@
     "@trust/webcrypto": "^0.9.2",
     "@types/jest": "^26.0.14",
     "@types/node": "^14.17.0",
-    "@types/react": "^16.14.21",
-    "@types/react-dom": "^16.9.14",
+    "@types/react": "^17.0.39",
+    "@types/react-dom": "^17.0.11",
     "@types/react-router": "^4.4.5",
     "@typescript-eslint/eslint-plugin": "^4.14.2",
     "@typescript-eslint/parser": "^4.14.2",
@@ -59,18 +59,14 @@
     "eslint-plugin-prefer-arrow": "^1.2.3",
     "eslint-plugin-react": "^7.22.0",
     "np": "^3.1.0",
-    "react": "^16.9.0",
-    "react-dom": "^16.9.0",
-    "react-router": "^4.3.1",
-    "react-router-dom": "^4.3.1",
+    "react": "^17.0.2",
+    "react-dom": "^17.0.2",
     "shx": "^0.3.2",
-    "typescript": "^4.1.6"
+    "typescript": "^4.5.5"
   },
   "peerDependencies": {
-    "react": "^16.9.0",
-    "react-dom": "^16.9.0",
-    "react-router": "^4.3.1",
-    "react-router-dom": "^4.3.1"
+    "react": "^17.0.2",
+    "react-dom": "^17.0.2"
   },
   "dependencies": {
     "@inovex.de/elements": "^5.1.0"

--- a/packages/elements-react/src/components/index.ts
+++ b/packages/elements-react/src/components/index.ts
@@ -1,216 +1,61 @@
-import { JSX as StencilJSX } from '@stencil/core';
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-ignore
-import { addIcons } from '@inovex.de/elements/dist/collection/util/icons';
-import { ICON_PATHS } from '@inovex.de/elements/dist/inovex-elements/ino-icon/index.esm.js';
+/* eslint-disable */
+/* tslint:disable */
+/* auto-generated react proxies */
+import { createReactComponent } from './react-component-lib';
+
+import type { JSX } from '@inovex.de/elements';
+
 import { defineCustomElements } from '@inovex.de/elements/dist/loader';
 
-import { createReactComponent } from './createComponent';
-
-defineCustomElements(window);
-addIcons(ICON_PATHS);
-
-//
-// Export all the elements we have. This is THE react wrapper.
-//
-
-export const InoAutocomplete = createReactComponent<
-  StencilJSX.IntrinsicElements['ino-autocomplete'],
-  HTMLInoAutocompleteElement
->('ino-autocomplete');
-export const InoButton = createReactComponent<
-  StencilJSX.IntrinsicElements['ino-button'],
-  HTMLInoButtonElement
->('ino-button');
-export const InoCard = createReactComponent<
-  StencilJSX.IntrinsicElements['ino-card'],
-  HTMLInoCardElement
->('ino-card');
-export const InoCarousel = createReactComponent<
-  StencilJSX.IntrinsicElements['ino-carousel'],
-  HTMLInoCarouselElement
->('ino-carousel');
-export const InoCarouselSlide = createReactComponent<
-  StencilJSX.IntrinsicElements['ino-carousel-slide'],
-  HTMLInoCarouselSlideElement
->('ino-carousel-slide');
-export const InoCheckbox = createReactComponent<
-  StencilJSX.IntrinsicElements['ino-checkbox'],
-  HTMLInoCheckboxElement
->('ino-checkbox');
-export const InoChip = createReactComponent<
-  StencilJSX.IntrinsicElements['ino-chip'],
-  HTMLInoChipElement
->('ino-chip');
-export const InoChipSet = createReactComponent<
-  StencilJSX.IntrinsicElements['ino-chip-set'],
-  HTMLInoChipSetElement
->('ino-chip-set');
-export const InoControlItem = createReactComponent<
-  StencilJSX.IntrinsicElements['ino-control-item'],
-  HTMLInoControlItemElement
->('ino-control-item');
-export const InoDatepicker = createReactComponent<
-  StencilJSX.IntrinsicElements['ino-datepicker'],
-  HTMLInoDatepickerElement
->('ino-datepicker');
-export const InoDialog = createReactComponent<
-  StencilJSX.IntrinsicElements['ino-dialog'],
-  HTMLInoDialogElement
->('ino-dialog');
-export const InoFab = createReactComponent<
-  StencilJSX.IntrinsicElements['ino-fab'],
-  HTMLInoFabElement
->('ino-fab');
-export const InoFabSet = createReactComponent<
-  StencilJSX.IntrinsicElements['ino-fab-set'],
-  HTMLInoFabSetElement
->('ino-fab-set');
-export const InoFormRow = createReactComponent<
-  StencilJSX.IntrinsicElements['ino-form-row'],
-  HTMLInoFormRowElement
->('ino-form-row');
-export const InoHeader = createReactComponent<
-  StencilJSX.IntrinsicElements['ino-header'],
-  HTMLInoHeaderElement
->('ino-header');
-export const InoIcon = createReactComponent<
-  StencilJSX.IntrinsicElements['ino-icon'],
-  HTMLInoIconElement
->('ino-icon');
-export const InoIconButton = createReactComponent<
-  StencilJSX.IntrinsicElements['ino-icon-button'],
-  HTMLInoIconButtonElement
->('ino-icon-button');
-export const InoImg = createReactComponent<
-  StencilJSX.IntrinsicElements['ino-img'],
-  HTMLInoImgElement
->('ino-img');
-export const InoImgList = createReactComponent<
-  StencilJSX.IntrinsicElements['ino-img-list'],
-  HTMLInoImgListElement
->('ino-img-list');
-export const InoInput = createReactComponent<
-  StencilJSX.IntrinsicElements['ino-input'],
-  HTMLInoInputElement
->('ino-input');
-export const InoInputFile = createReactComponent<
-  StencilJSX.IntrinsicElements['ino-input-file'],
-  HTMLInoInputFileElement
->('ino-input-file');
-export const InoList = createReactComponent<
-  StencilJSX.IntrinsicElements['ino-list'],
-  HTMLInoListElement
->('ino-list');
-export const InoListDivider = createReactComponent<
-  StencilJSX.IntrinsicElements['ino-list-divider'],
-  HTMLInoListDividerElement
->('ino-list-divider');
-export const InoListItem = createReactComponent<
-  StencilJSX.IntrinsicElements['ino-list-item'],
-  HTMLInoListItemElement
->('ino-list-item');
-export const InoMenu = createReactComponent<
-  StencilJSX.IntrinsicElements['ino-menu'],
-  HTMLInoMenuElement
->('ino-menu');
-export const InoNavDrawer = createReactComponent<
-  StencilJSX.IntrinsicElements['ino-nav-drawer'],
-  HTMLInoNavDrawerElement
->('ino-nav-drawer');
-export const InoNavItem = createReactComponent<
-  StencilJSX.IntrinsicElements['ino-nav-item'],
-  HTMLInoNavItemElement
->('ino-nav-item');
-export const InoOption = createReactComponent<
-  StencilJSX.IntrinsicElements['ino-option'],
-  HTMLInoOptionElement
->('ino-option');
-export const InoOptionGroup = createReactComponent<
-  StencilJSX.IntrinsicElements['ino-option-group'],
-  HTMLInoOptionGroupElement
->('ino-option-group');
-export const InoPopover = createReactComponent<
-  StencilJSX.IntrinsicElements['ino-popover'],
-  HTMLInoPopoverElement
->('ino-popover');
-export const InoProgressBar = createReactComponent<
-  StencilJSX.IntrinsicElements['ino-progress-bar'],
-  HTMLInoProgressBarElement
->('ino-progress-bar');
-export const InoRadio = createReactComponent<
-  StencilJSX.IntrinsicElements['ino-radio'],
-  HTMLInoRadioElement
->('ino-radio');
-export const InoRadioGroup = createReactComponent<
-  StencilJSX.IntrinsicElements['ino-radio-group'],
-  HTMLInoRadioGroupElement
->('ino-radio-group');
-export const InoRange = createReactComponent<
-  StencilJSX.IntrinsicElements['ino-range'],
-  HTMLInoRangeElement
->('ino-range');
-export const InoSegmentButton = createReactComponent<
-  StencilJSX.IntrinsicElements['ino-segment-button'],
-  HTMLInoSegmentButtonElement
->('ino-segment-button');
-export const InoSegmentGroup = createReactComponent<
-  StencilJSX.IntrinsicElements['ino-segment-group'],
-  HTMLInoSegmentGroupElement
->('ino-segment-group');
-export const InoSelect = createReactComponent<
-  StencilJSX.IntrinsicElements['ino-select'],
-  HTMLInoSelectElement
->('ino-select');
-export const InoSidebar = createReactComponent<
-  StencilJSX.IntrinsicElements['ino-sidebar'],
-  HTMLInoSelectElement
->('ino-sidebar');
-export const InoSnackbar = createReactComponent<
-  StencilJSX.IntrinsicElements['ino-snackbar'],
-  HTMLInoSnackbarElement
->('ino-snackbar');
-export const InoSpinner = createReactComponent<
-  StencilJSX.IntrinsicElements['ino-spinner'],
-  HTMLInoSpinnerElement
->('ino-spinner');
-export const InoSwitch = createReactComponent<
-  StencilJSX.IntrinsicElements['ino-switch'],
-  HTMLInoSwitchElement
->('ino-switch');
-export const InoTab = createReactComponent<
-  StencilJSX.IntrinsicElements['ino-tab'],
-  HTMLInoTabElement
->('ino-tab');
-export const InoTabBar = createReactComponent<
-  StencilJSX.IntrinsicElements['ino-tab-bar'],
-  HTMLInoTabBarElement
->('ino-tab-bar');
-export const InoTable = createReactComponent<
-  StencilJSX.IntrinsicElements['ino-table'],
-  HTMLInoTableElement
->('ino-table');
-export const InoTableCell = createReactComponent<
-  StencilJSX.IntrinsicElements['ino-table-cell'],
-  HTMLInoTableCellElement
->('ino-table-cell');
-export const InoTableRow = createReactComponent<
-  StencilJSX.IntrinsicElements['ino-table-row'],
-  HTMLInoTableRowElement
->('ino-table-row');
-export const InoTextarea = createReactComponent<
-  StencilJSX.IntrinsicElements['ino-textarea'],
-  HTMLInoTextareaElement
->('ino-textarea');
-export const InoTooltip = createReactComponent<
-  StencilJSX.IntrinsicElements['ino-tooltip'],
-  HTMLInoTooltipElement
->('ino-tooltip');
-export const InoMarkdownEditor = createReactComponent<
-  StencilJSX.IntrinsicElements['ino-markdown-editor'],
-  HTMLInoMarkdownEditorElement
->('ino-markdown-editor');
-export const InoCurrencyInput = createReactComponent<
-  StencilJSX.IntrinsicElements['ino-currency-input'],
-  HTMLInoCurrencyInputElement
->('ino-currency-input');
+defineCustomElements();
+export const InoAutocomplete = /*@__PURE__*/createReactComponent<JSX.InoAutocomplete, HTMLInoAutocompleteElement>('ino-autocomplete');
+export const InoButton = /*@__PURE__*/createReactComponent<JSX.InoButton, HTMLInoButtonElement>('ino-button');
+export const InoCard = /*@__PURE__*/createReactComponent<JSX.InoCard, HTMLInoCardElement>('ino-card');
+export const InoCarousel = /*@__PURE__*/createReactComponent<JSX.InoCarousel, HTMLInoCarouselElement>('ino-carousel');
+export const InoCarouselSlide = /*@__PURE__*/createReactComponent<JSX.InoCarouselSlide, HTMLInoCarouselSlideElement>('ino-carousel-slide');
+export const InoCheckbox = /*@__PURE__*/createReactComponent<JSX.InoCheckbox, HTMLInoCheckboxElement>('ino-checkbox');
+export const InoChip = /*@__PURE__*/createReactComponent<JSX.InoChip, HTMLInoChipElement>('ino-chip');
+export const InoChipSet = /*@__PURE__*/createReactComponent<JSX.InoChipSet, HTMLInoChipSetElement>('ino-chip-set');
+export const InoControlItem = /*@__PURE__*/createReactComponent<JSX.InoControlItem, HTMLInoControlItemElement>('ino-control-item');
+export const InoCurrencyInput = /*@__PURE__*/createReactComponent<JSX.InoCurrencyInput, HTMLInoCurrencyInputElement>('ino-currency-input');
+export const InoDatepicker = /*@__PURE__*/createReactComponent<JSX.InoDatepicker, HTMLInoDatepickerElement>('ino-datepicker');
+export const InoDialog = /*@__PURE__*/createReactComponent<JSX.InoDialog, HTMLInoDialogElement>('ino-dialog');
+export const InoFab = /*@__PURE__*/createReactComponent<JSX.InoFab, HTMLInoFabElement>('ino-fab');
+export const InoFabSet = /*@__PURE__*/createReactComponent<JSX.InoFabSet, HTMLInoFabSetElement>('ino-fab-set');
+export const InoFormRow = /*@__PURE__*/createReactComponent<JSX.InoFormRow, HTMLInoFormRowElement>('ino-form-row');
+export const InoHeader = /*@__PURE__*/createReactComponent<JSX.InoHeader, HTMLInoHeaderElement>('ino-header');
+export const InoIcon = /*@__PURE__*/createReactComponent<JSX.InoIcon, HTMLInoIconElement>('ino-icon');
+export const InoIconButton = /*@__PURE__*/createReactComponent<JSX.InoIconButton, HTMLInoIconButtonElement>('ino-icon-button');
+export const InoImg = /*@__PURE__*/createReactComponent<JSX.InoImg, HTMLInoImgElement>('ino-img');
+export const InoImgList = /*@__PURE__*/createReactComponent<JSX.InoImgList, HTMLInoImgListElement>('ino-img-list');
+export const InoInput = /*@__PURE__*/createReactComponent<JSX.InoInput, HTMLInoInputElement>('ino-input');
+export const InoInputFile = /*@__PURE__*/createReactComponent<JSX.InoInputFile, HTMLInoInputFileElement>('ino-input-file');
+export const InoLabel = /*@__PURE__*/createReactComponent<JSX.InoLabel, HTMLInoLabelElement>('ino-label');
+export const InoList = /*@__PURE__*/createReactComponent<JSX.InoList, HTMLInoListElement>('ino-list');
+export const InoListDivider = /*@__PURE__*/createReactComponent<JSX.InoListDivider, HTMLInoListDividerElement>('ino-list-divider');
+export const InoListItem = /*@__PURE__*/createReactComponent<JSX.InoListItem, HTMLInoListItemElement>('ino-list-item');
+export const InoMarkdownEditor = /*@__PURE__*/createReactComponent<JSX.InoMarkdownEditor, HTMLInoMarkdownEditorElement>('ino-markdown-editor');
+export const InoMenu = /*@__PURE__*/createReactComponent<JSX.InoMenu, HTMLInoMenuElement>('ino-menu');
+export const InoNavDrawer = /*@__PURE__*/createReactComponent<JSX.InoNavDrawer, HTMLInoNavDrawerElement>('ino-nav-drawer');
+export const InoNavItem = /*@__PURE__*/createReactComponent<JSX.InoNavItem, HTMLInoNavItemElement>('ino-nav-item');
+export const InoOption = /*@__PURE__*/createReactComponent<JSX.InoOption, HTMLInoOptionElement>('ino-option');
+export const InoOptionGroup = /*@__PURE__*/createReactComponent<JSX.InoOptionGroup, HTMLInoOptionGroupElement>('ino-option-group');
+export const InoPopover = /*@__PURE__*/createReactComponent<JSX.InoPopover, HTMLInoPopoverElement>('ino-popover');
+export const InoProgressBar = /*@__PURE__*/createReactComponent<JSX.InoProgressBar, HTMLInoProgressBarElement>('ino-progress-bar');
+export const InoRadio = /*@__PURE__*/createReactComponent<JSX.InoRadio, HTMLInoRadioElement>('ino-radio');
+export const InoRadioGroup = /*@__PURE__*/createReactComponent<JSX.InoRadioGroup, HTMLInoRadioGroupElement>('ino-radio-group');
+export const InoRange = /*@__PURE__*/createReactComponent<JSX.InoRange, HTMLInoRangeElement>('ino-range');
+export const InoSegmentButton = /*@__PURE__*/createReactComponent<JSX.InoSegmentButton, HTMLInoSegmentButtonElement>('ino-segment-button');
+export const InoSegmentGroup = /*@__PURE__*/createReactComponent<JSX.InoSegmentGroup, HTMLInoSegmentGroupElement>('ino-segment-group');
+export const InoSelect = /*@__PURE__*/createReactComponent<JSX.InoSelect, HTMLInoSelectElement>('ino-select');
+export const InoSidebar = /*@__PURE__*/createReactComponent<JSX.InoSidebar, HTMLInoSidebarElement>('ino-sidebar');
+export const InoSnackbar = /*@__PURE__*/createReactComponent<JSX.InoSnackbar, HTMLInoSnackbarElement>('ino-snackbar');
+export const InoSpinner = /*@__PURE__*/createReactComponent<JSX.InoSpinner, HTMLInoSpinnerElement>('ino-spinner');
+export const InoSwitch = /*@__PURE__*/createReactComponent<JSX.InoSwitch, HTMLInoSwitchElement>('ino-switch');
+export const InoTab = /*@__PURE__*/createReactComponent<JSX.InoTab, HTMLInoTabElement>('ino-tab');
+export const InoTabBar = /*@__PURE__*/createReactComponent<JSX.InoTabBar, HTMLInoTabBarElement>('ino-tab-bar');
+export const InoTable = /*@__PURE__*/createReactComponent<JSX.InoTable, HTMLInoTableElement>('ino-table');
+export const InoTableCell = /*@__PURE__*/createReactComponent<JSX.InoTableCell, HTMLInoTableCellElement>('ino-table-cell');
+export const InoTableRow = /*@__PURE__*/createReactComponent<JSX.InoTableRow, HTMLInoTableRowElement>('ino-table-row');
+export const InoTextarea = /*@__PURE__*/createReactComponent<JSX.InoTextarea, HTMLInoTextareaElement>('ino-textarea');
+export const InoTooltip = /*@__PURE__*/createReactComponent<JSX.InoTooltip, HTMLInoTooltipElement>('ino-tooltip');

--- a/packages/elements-react/src/components/react-component-lib/createComponent.tsx
+++ b/packages/elements-react/src/components/react-component-lib/createComponent.tsx
@@ -1,0 +1,113 @@
+import React, { createElement } from 'react';
+
+import {
+  attachProps,
+  camelToDashCase,
+  createForwardRef,
+  dashToPascalCase,
+  isCoveredByReact,
+  mergeRefs,
+} from './utils';
+
+export interface HTMLStencilElement extends HTMLElement {
+  componentOnReady(): Promise<this>;
+}
+
+interface StencilReactInternalProps<ElementType> extends React.HTMLAttributes<ElementType> {
+  forwardedRef: React.RefObject<ElementType>;
+  ref?: React.Ref<any>;
+}
+
+export const createReactComponent = <
+  PropType,
+  ElementType extends HTMLStencilElement,
+  ContextStateType = {},
+  ExpandedPropsTypes = {}
+>(
+  tagName: string,
+  ReactComponentContext?: React.Context<ContextStateType>,
+  manipulatePropsFunction?: (
+    originalProps: StencilReactInternalProps<ElementType>,
+    propsToPass: any,
+  ) => ExpandedPropsTypes,
+  defineCustomElement?: () => void,
+) => {
+  if (defineCustomElement !== undefined) {
+    defineCustomElement();
+  }
+
+  const displayName = dashToPascalCase(tagName);
+  const ReactComponent = class extends React.Component<StencilReactInternalProps<ElementType>> {
+    componentEl!: ElementType;
+
+    setComponentElRef = (element: ElementType) => {
+      this.componentEl = element;
+    };
+
+    constructor(props: StencilReactInternalProps<ElementType>) {
+      super(props);
+    }
+
+    componentDidMount() {
+      this.componentDidUpdate(this.props);
+    }
+
+    componentDidUpdate(prevProps: StencilReactInternalProps<ElementType>) {
+      attachProps(this.componentEl, this.props, prevProps);
+    }
+
+    render() {
+      const { children, forwardedRef, style, className, ref, ...cProps } = this.props;
+
+      let propsToPass = Object.keys(cProps).reduce((acc: any, name) => {
+        const value = (cProps as any)[name];
+
+        if (name.indexOf('on') === 0 && name[2] === name[2].toUpperCase()) {
+          const eventName = name.substring(2).toLowerCase();
+          if (typeof document !== 'undefined' && isCoveredByReact(eventName)) {
+            acc[name] = value;
+          }
+        } else {
+          // we should only render strings, booleans, and numbers as attrs in html.
+          // objects, functions, arrays etc get synced via properties on mount.
+          const type = typeof value;
+
+          if (type === 'string' || type === 'boolean' || type === 'number') {
+            acc[camelToDashCase(name)] = value;
+          }
+        }
+        return acc;
+      }, {});
+
+      if (manipulatePropsFunction) {
+        propsToPass = manipulatePropsFunction(this.props, propsToPass);
+      }
+
+      const newProps: Omit<StencilReactInternalProps<ElementType>, 'forwardedRef'> = {
+        ...propsToPass,
+        ref: mergeRefs(forwardedRef, this.setComponentElRef),
+        style,
+      };
+
+      /**
+       * We use createElement here instead of
+       * React.createElement to work around a
+       * bug in Vite (https://github.com/vitejs/vite/issues/6104).
+       * React.createElement causes all elements to be rendered
+       * as <tagname> instead of the actual Web Component.
+       */
+      return createElement(tagName, newProps, children);
+    }
+
+    static get displayName() {
+      return displayName;
+    }
+  };
+
+  // If context was passed to createReactComponent then conditionally add it to the Component Class
+  if (ReactComponentContext) {
+    ReactComponent.contextType = ReactComponentContext;
+  }
+
+  return createForwardRef<PropType, ElementType>(ReactComponent, displayName);
+};

--- a/packages/elements-react/src/components/react-component-lib/createOverlayComponent.tsx
+++ b/packages/elements-react/src/components/react-component-lib/createOverlayComponent.tsx
@@ -1,0 +1,162 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+
+import { OverlayEventDetail } from './interfaces';
+import {
+  StencilReactForwardedRef,
+  attachProps,
+  dashToPascalCase,
+  defineCustomElement,
+  setRef,
+} from './utils';
+
+interface OverlayElement extends HTMLElement {
+  present: () => Promise<void>;
+  dismiss: (data?: any, role?: string | undefined) => Promise<boolean>;
+}
+
+export interface ReactOverlayProps {
+  children?: React.ReactNode;
+  isOpen: boolean;
+  onDidDismiss?: (event: CustomEvent<OverlayEventDetail>) => void;
+  onDidPresent?: (event: CustomEvent<OverlayEventDetail>) => void;
+  onWillDismiss?: (event: CustomEvent<OverlayEventDetail>) => void;
+  onWillPresent?: (event: CustomEvent<OverlayEventDetail>) => void;
+}
+
+export const createOverlayComponent = <
+  OverlayComponent extends object,
+  OverlayType extends OverlayElement
+>(
+  tagName: string,
+  controller: { create: (options: any) => Promise<OverlayType> },
+  customElement?: any
+) => {
+  defineCustomElement(tagName, customElement);
+
+  const displayName = dashToPascalCase(tagName);
+  const didDismissEventName = `on${displayName}DidDismiss`;
+  const didPresentEventName = `on${displayName}DidPresent`;
+  const willDismissEventName = `on${displayName}WillDismiss`;
+  const willPresentEventName = `on${displayName}WillPresent`;
+
+  type Props = OverlayComponent &
+    ReactOverlayProps & {
+      forwardedRef?: StencilReactForwardedRef<OverlayType>;
+    };
+
+  let isDismissing = false;
+
+  class Overlay extends React.Component<Props> {
+    overlay?: OverlayType;
+    el!: HTMLDivElement;
+
+    constructor(props: Props) {
+      super(props);
+      if (typeof document !== 'undefined') {
+        this.el = document.createElement('div');
+      }
+      this.handleDismiss = this.handleDismiss.bind(this);
+    }
+
+    static get displayName() {
+      return displayName;
+    }
+
+    componentDidMount() {
+      if (this.props.isOpen) {
+        this.present();
+      }
+    }
+
+    componentWillUnmount() {
+      if (this.overlay) {
+        this.overlay.dismiss();
+      }
+    }
+
+    handleDismiss(event: CustomEvent<OverlayEventDetail<any>>) {
+      if (this.props.onDidDismiss) {
+        this.props.onDidDismiss(event);
+      }
+      setRef(this.props.forwardedRef, null)
+    }
+
+    shouldComponentUpdate(nextProps: Props) {
+      // Check if the overlay component is about to dismiss
+      if (this.overlay && nextProps.isOpen !== this.props.isOpen && nextProps.isOpen === false) {
+        isDismissing = true;
+      }
+
+      return true;
+    }
+
+    async componentDidUpdate(prevProps: Props) {
+      if (this.overlay) {
+        attachProps(this.overlay, this.props, prevProps);
+      }
+
+      if (prevProps.isOpen !== this.props.isOpen && this.props.isOpen === true) {
+        this.present(prevProps);
+      }
+      if (this.overlay && prevProps.isOpen !== this.props.isOpen && this.props.isOpen === false) {
+        await this.overlay.dismiss();
+        isDismissing = false;
+
+        /**
+         * Now that the overlay is dismissed
+         * we need to render again so that any
+         * inner components will be unmounted
+         */
+        this.forceUpdate();
+      }
+    }
+
+    async present(prevProps?: Props) {
+      const {
+        children,
+        isOpen,
+        onDidDismiss,
+        onDidPresent,
+        onWillDismiss,
+        onWillPresent,
+        ...cProps
+      } = this.props;
+      const elementProps = {
+        ...cProps,
+        ref: this.props.forwardedRef,
+        [didDismissEventName]: this.handleDismiss,
+        [didPresentEventName]: (e: CustomEvent) =>
+          this.props.onDidPresent && this.props.onDidPresent(e),
+        [willDismissEventName]: (e: CustomEvent) =>
+          this.props.onWillDismiss && this.props.onWillDismiss(e),
+        [willPresentEventName]: (e: CustomEvent) =>
+          this.props.onWillPresent && this.props.onWillPresent(e),
+      };
+
+      this.overlay = await controller.create({
+        ...elementProps,
+        component: this.el,
+        componentProps: {},
+      });
+
+      setRef(this.props.forwardedRef, this.overlay);
+      attachProps(this.overlay, elementProps, prevProps);
+
+      await this.overlay.present();
+    }
+
+    render() {
+      /**
+       * Continue to render the component even when
+       * overlay is dismissing otherwise component
+       * will be hidden before animation is done.
+       */
+      return ReactDOM.createPortal(this.props.isOpen || isDismissing ? this.props.children : null, this.el);
+    }
+  }
+
+  return React.forwardRef<OverlayType, Props>((props, ref) => {
+    return <Overlay {...props} forwardedRef={ref} />;
+  });
+};

--- a/packages/elements-react/src/components/react-component-lib/index.ts
+++ b/packages/elements-react/src/components/react-component-lib/index.ts
@@ -1,0 +1,2 @@
+export { createReactComponent } from './createComponent';
+export { createOverlayComponent } from './createOverlayComponent';

--- a/packages/elements-react/src/components/react-component-lib/interfaces.ts
+++ b/packages/elements-react/src/components/react-component-lib/interfaces.ts
@@ -1,0 +1,34 @@
+// General types important to applications using stencil built components
+export interface EventEmitter<T = any> {
+  emit: (data?: T) => CustomEvent<T>;
+}
+
+export interface StyleReactProps {
+  class?: string;
+  className?: string;
+  style?: { [key: string]: any };
+}
+
+export interface OverlayEventDetail<T = any> {
+  data?: T;
+  role?: string;
+}
+
+export interface OverlayInterface {
+  el: HTMLElement;
+  animated: boolean;
+  keyboardClose: boolean;
+  overlayIndex: number;
+  presented: boolean;
+
+  enterAnimation?: any;
+  leaveAnimation?: any;
+
+  didPresent: EventEmitter<void>;
+  willPresent: EventEmitter<void>;
+  willDismiss: EventEmitter<OverlayEventDetail>;
+  didDismiss: EventEmitter<OverlayEventDetail>;
+
+  present(): Promise<void>;
+  dismiss(data?: any, role?: string): Promise<boolean>;
+}

--- a/packages/elements-react/src/components/react-component-lib/utils/attachProps.ts
+++ b/packages/elements-react/src/components/react-component-lib/utils/attachProps.ts
@@ -1,0 +1,114 @@
+import { camelToDashCase } from './case';
+
+export const attachProps = (node: HTMLElement, newProps: any, oldProps: any = {}) => {
+  // some test frameworks don't render DOM elements, so we test here to make sure we are dealing with DOM first
+  if (node instanceof Element) {
+    // add any classes in className to the class list
+    const className = getClassName(node.classList, newProps, oldProps);
+    if (className !== '') {
+      node.className = className;
+    }
+
+    Object.keys(newProps).forEach((name) => {
+      if (
+        name === 'children' ||
+        name === 'style' ||
+        name === 'ref' ||
+        name === 'class' ||
+        name === 'className' ||
+        name === 'forwardedRef'
+      ) {
+        return;
+      }
+      if (name.indexOf('on') === 0 && name[2] === name[2].toUpperCase()) {
+        const eventName = name.substring(2);
+        const eventNameLc = eventName[0].toLowerCase() + eventName.substring(1);
+
+        if (!isCoveredByReact(eventNameLc)) {
+          syncEvent(node, eventNameLc, newProps[name]);
+        }
+      } else {
+        (node as any)[name] = newProps[name];
+        const propType = typeof newProps[name];
+        if (propType === 'string') {
+          node.setAttribute(camelToDashCase(name), newProps[name]);
+        }
+      }
+    });
+  }
+};
+
+export const getClassName = (classList: DOMTokenList, newProps: any, oldProps: any) => {
+  const newClassProp: string = newProps.className || newProps.class;
+  const oldClassProp: string = oldProps.className || oldProps.class;
+  // map the classes to Maps for performance
+  const currentClasses = arrayToMap(classList);
+  const incomingPropClasses = arrayToMap(newClassProp ? newClassProp.split(' ') : []);
+  const oldPropClasses = arrayToMap(oldClassProp ? oldClassProp.split(' ') : []);
+  const finalClassNames: string[] = [];
+  // loop through each of the current classes on the component
+  // to see if it should be a part of the classNames added
+  currentClasses.forEach((currentClass) => {
+    if (incomingPropClasses.has(currentClass)) {
+      // add it as its already included in classnames coming in from newProps
+      finalClassNames.push(currentClass);
+      incomingPropClasses.delete(currentClass);
+    } else if (!oldPropClasses.has(currentClass)) {
+      // add it as it has NOT been removed by user
+      finalClassNames.push(currentClass);
+    }
+  });
+  incomingPropClasses.forEach((s) => finalClassNames.push(s));
+  return finalClassNames.join(' ');
+};
+
+/**
+ * Checks if an event is supported in the current execution environment.
+ * @license Modernizr 3.0.0pre (Custom Build) | MIT
+ */
+export const isCoveredByReact = (eventNameSuffix: string) => {
+  if (typeof document === 'undefined') {
+    return true;
+  } else {
+    const eventName = 'on' + eventNameSuffix;
+    let isSupported = eventName in document;
+
+    if (!isSupported) {
+      const element = document.createElement('div');
+      element.setAttribute(eventName, 'return;');
+      isSupported = typeof (element as any)[eventName] === 'function';
+    }
+
+    return isSupported;
+  }
+};
+
+export const syncEvent = (
+  node: Element & { __events?: { [key: string]: ((e: Event) => any) | undefined } },
+  eventName: string,
+  newEventHandler?: (e: Event) => any
+) => {
+  const eventStore = node.__events || (node.__events = {});
+  const oldEventHandler = eventStore[eventName];
+
+  // Remove old listener so they don't double up.
+  if (oldEventHandler) {
+    node.removeEventListener(eventName, oldEventHandler);
+  }
+
+  // Bind new listener.
+  node.addEventListener(
+    eventName,
+    (eventStore[eventName] = function handler(e: Event) {
+      if (newEventHandler) {
+        newEventHandler.call(this, e);
+      }
+    })
+  );
+};
+
+const arrayToMap = (arr: string[] | DOMTokenList) => {
+  const map = new Map<string, string>();
+  (arr as string[]).forEach((s: string) => map.set(s, s));
+  return map;
+};

--- a/packages/elements-react/src/components/react-component-lib/utils/case.ts
+++ b/packages/elements-react/src/components/react-component-lib/utils/case.ts
@@ -1,0 +1,8 @@
+export const dashToPascalCase = (str: string) =>
+  str
+    .toLowerCase()
+    .split('-')
+    .map((segment) => segment.charAt(0).toUpperCase() + segment.slice(1))
+    .join('');
+export const camelToDashCase = (str: string) =>
+  str.replace(/([A-Z])/g, (m: string) => `-${m[0].toLowerCase()}`);

--- a/packages/elements-react/src/components/react-component-lib/utils/dev.ts
+++ b/packages/elements-react/src/components/react-component-lib/utils/dev.ts
@@ -1,0 +1,14 @@
+export const isDevMode = () => {
+  return process && process.env && process.env.NODE_ENV === 'development';
+};
+
+const warnings: { [key: string]: boolean } = {};
+
+export const deprecationWarning = (key: string, message: string) => {
+  if (isDevMode()) {
+    if (!warnings[key]) {
+      console.warn(message);
+      warnings[key] = true;
+    }
+  }
+};

--- a/packages/elements-react/src/components/react-component-lib/utils/index.tsx
+++ b/packages/elements-react/src/components/react-component-lib/utils/index.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+
+import type { StyleReactProps } from '../interfaces';
+
+export type StencilReactExternalProps<PropType, ElementType> = PropType &
+  Omit<React.HTMLAttributes<ElementType>, 'style'> &
+  StyleReactProps;
+
+// This will be replaced with React.ForwardedRef when react-output-target is upgraded to React v17
+export type StencilReactForwardedRef<T> = ((instance: T | null) => void) | React.MutableRefObject<T | null> | null;
+
+export const setRef = (ref: StencilReactForwardedRef<any> | React.Ref<any> | undefined, value: any) => {
+  if (typeof ref === 'function') {
+    ref(value)
+  } else if (ref != null) {
+    // Cast as a MutableRef so we can assign current
+    (ref as React.MutableRefObject<any>).current = value
+  }
+};
+
+export const mergeRefs = (
+  ...refs: (StencilReactForwardedRef<any> | React.Ref<any> | undefined)[]
+): React.RefCallback<any> => {
+  return (value: any) => {
+    refs.forEach(ref => {
+      setRef(ref, value)
+    })
+  }
+};
+
+export const createForwardRef = <PropType, ElementType>(
+  ReactComponent: any,
+  displayName: string,
+) => {
+  const forwardRef = (
+    props: StencilReactExternalProps<PropType, ElementType>,
+    ref: StencilReactForwardedRef<ElementType>,
+  ) => {
+    return <ReactComponent {...props} forwardedRef={ref} />;
+  };
+  forwardRef.displayName = displayName;
+
+  return React.forwardRef(forwardRef);
+};
+
+export const defineCustomElement = (tagName: string, customElement: any) => {
+  if (
+    customElement !== undefined &&
+    typeof customElements !== 'undefined' &&
+    !customElements.get(tagName)
+  ) {
+    customElements.define(tagName, customElement);
+  }
+}
+
+export * from './attachProps';
+export * from './case';

--- a/packages/elements-react/tsconfig.json
+++ b/packages/elements-react/tsconfig.json
@@ -24,7 +24,8 @@
     "target": "es2017",
     "typeRoots": [
       "node_modules/@types"
-    ]
+    ],
+    "skipLibCheck": true
   },
   "include": [
     "src/**/*.ts",

--- a/packages/elements/package.json
+++ b/packages/elements/package.json
@@ -94,6 +94,7 @@
   },
   "devDependencies": {
     "@stencil/angular-output-target": "^0.4.0",
+    "@stencil/react-output-target": "^0.3.1",
     "@stencil/sass": "^1.4.1",
     "@types/classnames": "^2.2.6",
     "@types/css-font-loading-module": "^0.0.6",

--- a/packages/elements/stencil.config.ts
+++ b/packages/elements/stencil.config.ts
@@ -1,8 +1,10 @@
 import { Config } from '@stencil/core';
 import { sass } from '@stencil/sass';
 import { angularOutputTarget } from '@stencil/angular-output-target';
+import { reactOutputTarget as react } from '@stencil/react-output-target';
 
-const angularDiretivesPath =  '../elements-angular/elements/src/directives';
+const angularDiretivesPath = '../elements-angular/elements/src/directives';
+const reactProxyPath = '../elements-react/src/components';
 
 export const config: Config = {
   buildEs5: false,
@@ -20,6 +22,11 @@ export const config: Config = {
   enableCache: true,
   namespace: 'inovex-elements',
   outputTargets: [
+    react({
+      componentCorePackage: '@inovex.de/elements',
+      proxiesFile: `${reactProxyPath}/index.ts`,
+      includeDefineCustomElements: true,
+    }),
     {
       type: 'dist',
       copy: [{ src: 'assets/ino-icon', dest: 'ino-icon' }],

--- a/packages/storybook/elements-stencil-docs.json
+++ b/packages/storybook/elements-stencil-docs.json
@@ -1,5 +1,5 @@
 {
-  "timestamp": "2022-02-17T10:48:52",
+  "timestamp": "2022-02-18T08:55:41",
   "compiler": {
     "name": "@stencil/core",
     "version": "2.14.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3201,13 +3201,6 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
-"@babel/runtime@^7.1.2", "@babel/runtime@^7.3.1", "@babel/runtime@^7.5.0", "@babel/runtime@^7.5.5", "@babel/runtime@^7.7.2", "@babel/runtime@^7.8.4":
-  version "7.10.2"
-  resolved "https://registry.npmjs.org/@babel/runtime/-/runtime-7.10.2.tgz#d103f21f2602497d38348a32e008637d506db839"
-  integrity sha512-6sF3uQw2ivImfVIl62RZ7MXhO2tap69WeWK57vAaimT6AZbE4FbqjdEJIN1UqoD6wI6B+1n9UiagafH1sxjOtg==
-  dependencies:
-    regenerator-runtime "^0.13.4"
-
 "@babel/runtime@^7.10.2":
   version "7.11.2"
   resolved "https://registry.npmjs.org/@babel/runtime/-/runtime-7.11.2.tgz#f549c13c754cc40b87644b9fa9f09a6a95fe0736"
@@ -3219,6 +3212,13 @@
   version "7.16.7"
   resolved "https://registry.npmjs.org/@babel/runtime/-/runtime-7.16.7.tgz#03ff99f64106588c9c403c6ecb8c3bafbbdff1fa"
   integrity sha512-9E9FJowqAsytyOY6LG+1KuueckRL+aQW+mKvXRXnuFGyRAyepJPmEo9vgMfXUA6O9u3IeEdv9MAkppFcaQwogQ==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
+"@babel/runtime@^7.3.1", "@babel/runtime@^7.5.0", "@babel/runtime@^7.5.5", "@babel/runtime@^7.7.2", "@babel/runtime@^7.8.4":
+  version "7.10.2"
+  resolved "https://registry.npmjs.org/@babel/runtime/-/runtime-7.10.2.tgz#d103f21f2602497d38348a32e008637d506db839"
+  integrity sha512-6sF3uQw2ivImfVIl62RZ7MXhO2tap69WeWK57vAaimT6AZbE4FbqjdEJIN1UqoD6wI6B+1n9UiagafH1sxjOtg==
   dependencies:
     regenerator-runtime "^0.13.4"
 
@@ -5725,6 +5725,11 @@
   resolved "https://registry.npmjs.org/@stencil/core/-/core-2.4.0.tgz#17b45629c8986e35dcbce3f7dab7d64beede83f2"
   integrity sha512-gU6+Yyd6O0KrCSS/O6j8KKqmRo+/Dcs2fI0+APCpbAWK+nqhwDISpdnSEfGDCLMoAC08XOZCycBRk2K1VGnEcg==
 
+"@stencil/react-output-target@^0.3.1":
+  version "0.3.1"
+  resolved "https://registry.npmjs.org/@stencil/react-output-target/-/react-output-target-0.3.1.tgz#dc9cc2fea32d0e30474a87fcb2a447f90ab78696"
+  integrity sha512-6d9pPhyajFfdxkqU/pPP2SzI7wn+EklySQc4KXlI/xcdvC2H9BzLmhmR40fR1q2TQoJbJui/nvSWhbYqkE3OBQ==
+
 "@stencil/sass@^1.4.1":
   version "1.4.1"
   resolved "https://registry.npmjs.org/@stencil/sass/-/sass-1.4.1.tgz#ef5a1dd1b56c024ed08e80475e8a6f8d1c25bb10"
@@ -7415,12 +7420,12 @@
   resolved "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.4.tgz#cd667bcfdd025213aafb7ca5915a932590acdcdc"
   integrity sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==
 
-"@types/react-dom@^16.9.14":
-  version "16.9.14"
-  resolved "https://registry.npmjs.org/@types/react-dom/-/react-dom-16.9.14.tgz#674b8f116645fe5266b40b525777fc6bb8eb3bcd"
-  integrity sha512-FIX2AVmPTGP30OUJ+0vadeIFJJ07Mh1m+U0rxfgyW34p3rTlXI+nlenvAxNn4BP36YyI9IJ/+UJ7Wu22N1pI7A==
+"@types/react-dom@^17.0.11":
+  version "17.0.11"
+  resolved "https://registry.npmjs.org/@types/react-dom/-/react-dom-17.0.11.tgz#e1eadc3c5e86bdb5f7684e00274ae228e7bcc466"
+  integrity sha512-f96K3k+24RaLGVu/Y2Ng3e1EbZ8/cVJvypZWd7cy0ofCBaf2lcM46xNhycMZ2xGwbBjRql7hOlZ+e2WlJ5MH3Q==
   dependencies:
-    "@types/react" "^16"
+    "@types/react" "*"
 
 "@types/react-router@^4.4.5":
   version "4.4.5"
@@ -7445,10 +7450,10 @@
     "@types/prop-types" "*"
     csstype "^2.2.0"
 
-"@types/react@^16", "@types/react@^16.14.21":
-  version "16.14.21"
-  resolved "https://registry.npmjs.org/@types/react/-/react-16.14.21.tgz#35199b21a278355ec7a3c40003bd6a334bd4ae4a"
-  integrity sha512-rY4DzPKK/4aohyWiDRHS2fotN5rhBSK6/rz1X37KzNna9HJyqtaGAbq9fVttrEPWF5ywpfIP1ITL8Xi2QZn6Eg==
+"@types/react@^17.0.39":
+  version "17.0.39"
+  resolved "https://registry.npmjs.org/@types/react/-/react-17.0.39.tgz#d0f4cde092502a6db00a1cded6e6bf2abb7633ce"
+  integrity sha512-UVavlfAxDd/AgAacMa60Azl7ygyQNRwC/DsHZmKgNvPmRR5p70AJ5Q9EAmL2NWOJmeV+vVUI4IAP7GZrN8h8Ug==
   dependencies:
     "@types/prop-types" "*"
     "@types/scheduler" "*"
@@ -15014,18 +15019,6 @@ history@5.0.0:
   dependencies:
     "@babel/runtime" "^7.7.6"
 
-history@^4.7.2:
-  version "4.10.1"
-  resolved "https://registry.npmjs.org/history/-/history-4.10.1.tgz#33371a65e3a83b267434e2b3f3b1b4c58aad4cf3"
-  integrity sha512-36nwAD620w12kuzPAsyINPWJqlNbij+hpK1k9XRloDtym8mxzGYl2c17LnV6IAGB2Dmg4tEa7G7DlawS0+qjew==
-  dependencies:
-    "@babel/runtime" "^7.1.2"
-    loose-envify "^1.2.0"
-    resolve-pathname "^3.0.0"
-    tiny-invariant "^1.0.2"
-    tiny-warning "^1.0.0"
-    value-equal "^1.0.1"
-
 history@^5.2.0:
   version "5.2.0"
   resolved "https://registry.npmjs.org/history/-/history-5.2.0.tgz#7cdd31cf9bac3c5d31f09c231c9928fad0007b7c"
@@ -15041,11 +15034,6 @@ hmac-drbg@^1.0.0:
     hash.js "^1.0.3"
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.1"
-
-hoist-non-react-statics@^2.5.0:
-  version "2.5.5"
-  resolved "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz#c5903cf409c0dfd908f388e619d86b9c1174cb47"
-  integrity sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw==
 
 hoist-non-react-statics@^3.3.0:
   version "3.3.2"
@@ -16395,11 +16383,6 @@ is-wsl@^2.1.1, is-wsl@^2.2.0:
   integrity sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==
   dependencies:
     is-docker "^2.0.0"
-
-isarray@0.0.1:
-  version "0.0.1"
-  resolved "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz#8a18acfca9a8f4177e09abfc6038939b05d1eedf"
-  integrity sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=
 
 isarray@1.0.0, isarray@^1.0.0, isarray@~1.0.0:
   version "1.0.0"
@@ -18408,7 +18391,7 @@ loglevel@^1.6.8:
   resolved "https://registry.npmjs.org/loglevel/-/loglevel-1.7.0.tgz#728166855a740d59d38db01cf46f042caa041bb0"
   integrity sha512-i2sY04nal5jDcagM3FMfG++T69GEEM8CYuOfeOIvmXzOIcwE9a/CJPR0MFM97pYMj/u10lzz7/zd7+qwhrBTqQ==
 
-loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.2.0, loose-envify@^1.3.1, loose-envify@^1.4.0:
+loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.4.0:
   version "1.4.0"
   resolved "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
   integrity sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==
@@ -20662,13 +20645,6 @@ path-to-regexp@0.1.7:
   resolved "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz#df604178005f522f15eb4490e7247a1bfaa67f8c"
   integrity sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=
 
-path-to-regexp@^1.7.0:
-  version "1.8.0"
-  resolved "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz#887b3ba9d84393e87a0a0b9f4cb756198b53548a"
-  integrity sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==
-  dependencies:
-    isarray "0.0.1"
-
 path-type@^1.0.0:
   version "1.1.0"
   resolved "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz#59c44f7ee491da704da415da5a4070ba4f8fe441"
@@ -22117,7 +22093,7 @@ promzard@^0.3.0:
   dependencies:
     read "1"
 
-prop-types@^15.0.0, prop-types@^15.6.0, prop-types@^15.6.1, prop-types@^15.6.2, prop-types@^15.7.2:
+prop-types@^15.0.0, prop-types@^15.6.0, prop-types@^15.6.2, prop-types@^15.7.2:
   version "15.7.2"
   resolved "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
   integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
@@ -22533,7 +22509,7 @@ react-dom@16.14.0:
     prop-types "^15.6.2"
     scheduler "^0.19.1"
 
-react-dom@^16.8.1, react-dom@^16.9.0:
+react-dom@^16.8.1:
   version "16.13.1"
   resolved "https://registry.npmjs.org/react-dom/-/react-dom-16.13.1.tgz#c1bd37331a0486c078ee54c4740720993b2e0e7f"
   integrity sha512-81PIMmVLnCNLO/fFOQxdQkvEq/+Hfpv24XNJfpyZhTRfO0QcmQIF/PgCa1zCOj2w1hrn12MFLyaJ/G0+Mxtfag==
@@ -22542,6 +22518,15 @@ react-dom@^16.8.1, react-dom@^16.9.0:
     object-assign "^4.1.1"
     prop-types "^15.6.2"
     scheduler "^0.19.1"
+
+react-dom@^17.0.2:
+  version "17.0.2"
+  resolved "https://registry.npmjs.org/react-dom/-/react-dom-17.0.2.tgz#ecffb6845e3ad8dbfcdc498f0d0a939736502c23"
+  integrity sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==
+  dependencies:
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
+    scheduler "^0.20.2"
 
 react-draggable@^4.4.3:
   version "4.4.3"
@@ -22617,18 +22602,6 @@ react-popper@^2.2.4:
     react-fast-compare "^3.0.1"
     warning "^4.0.2"
 
-react-router-dom@^4.3.1:
-  version "4.3.1"
-  resolved "https://registry.npmjs.org/react-router-dom/-/react-router-dom-4.3.1.tgz#4c2619fc24c4fa87c9fd18f4fb4a43fe63fbd5c6"
-  integrity sha512-c/MlywfxDdCp7EnB7YfPMOfMD3tOtIjrQlj/CKfNMBxdmpJP8xcz5P/UAFn3JbnQCNUxsHyVVqllF9LhgVyFCA==
-  dependencies:
-    history "^4.7.2"
-    invariant "^2.2.4"
-    loose-envify "^1.3.1"
-    prop-types "^15.6.1"
-    react-router "^4.3.1"
-    warning "^4.0.1"
-
 react-router-dom@^6.0.0:
   version "6.2.1"
   resolved "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.2.1.tgz#32ec81829152fbb8a7b045bf593a22eadf019bec"
@@ -22643,19 +22616,6 @@ react-router@6.2.1, react-router@^6.0.0:
   integrity sha512-2fG0udBtxou9lXtK97eJeET2ki5//UWfQSl1rlJ7quwe6jrktK9FCCc8dQb5QY6jAv3jua8bBQRhhDOM/kVRsg==
   dependencies:
     history "^5.2.0"
-
-react-router@^4.3.1:
-  version "4.3.1"
-  resolved "https://registry.npmjs.org/react-router/-/react-router-4.3.1.tgz#aada4aef14c809cb2e686b05cee4742234506c4e"
-  integrity sha512-yrvL8AogDh2X42Dt9iknk4wF4V8bWREPirFfS9gLU1huk6qK41sg7Z/1S81jjTrGHxa3B8R3J6xIkDAA6CVarg==
-  dependencies:
-    history "^4.7.2"
-    hoist-non-react-statics "^2.5.0"
-    invariant "^2.2.4"
-    loose-envify "^1.3.1"
-    path-to-regexp "^1.7.0"
-    prop-types "^15.6.1"
-    warning "^4.0.1"
 
 react-sizeme@^3.0.1:
   version "3.0.1"
@@ -22696,7 +22656,7 @@ react@16.14.0:
     object-assign "^4.1.1"
     prop-types "^15.6.2"
 
-react@^16.8.1, react@^16.9.0:
+react@^16.8.1:
   version "16.13.1"
   resolved "https://registry.npmjs.org/react/-/react-16.13.1.tgz#2e818822f1a9743122c063d6410d85c1e3afe48e"
   integrity sha512-YMZQQq32xHLX0bz5Mnibv1/LHb3Sqzngu7xstSM+vrkE5Kzr9xE0yMByK5kMoTK30YVJE61WfbxIFFvfeDKT1w==
@@ -22704,6 +22664,14 @@ react@^16.8.1, react@^16.9.0:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
     prop-types "^15.6.2"
+
+react@^17.0.2:
+  version "17.0.2"
+  resolved "https://registry.npmjs.org/react/-/react-17.0.2.tgz#d0b5cc516d29eb3eee383f75b62864cfb6800037"
+  integrity sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==
+  dependencies:
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
 
 read-cache@^1.0.0:
   version "1.0.0"
@@ -23334,11 +23302,6 @@ resolve-from@^5.0.0:
   resolved "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz#c35225843df8f776df21c57557bc087e9dfdfc69"
   integrity sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==
 
-resolve-pathname@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.npmjs.org/resolve-pathname/-/resolve-pathname-3.0.0.tgz#99d02224d3cf263689becbb393bc560313025dcd"
-  integrity sha512-C7rARubxI8bXFNB/hqcp/4iUeIXJhJZvFPFPiSPRnhU5UPxzMFIl+2E6yY6c4k9giDJAhtV+enfA+G89N6Csng==
-
 resolve-url-loader@4.0.0:
   version "4.0.0"
   resolved "https://registry.npmjs.org/resolve-url-loader/-/resolve-url-loader-4.0.0.tgz#d50d4ddc746bb10468443167acf800dcd6c3ad57"
@@ -23648,6 +23611,14 @@ scheduler@^0.19.1:
   version "0.19.1"
   resolved "https://registry.npmjs.org/scheduler/-/scheduler-0.19.1.tgz#4f3e2ed2c1a7d65681f4c854fa8c5a1ccb40f196"
   integrity sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==
+  dependencies:
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
+
+scheduler@^0.20.2:
+  version "0.20.2"
+  resolved "https://registry.npmjs.org/scheduler/-/scheduler-0.20.2.tgz#4baee39436e34aa93b4874bddcbf0fe8b8b50e91"
+  integrity sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
@@ -25382,16 +25353,6 @@ tiny-emitter@^2.0.0:
   resolved "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.1.0.tgz#1d1a56edfc51c43e863cbb5382a72330e3555423"
   integrity sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q==
 
-tiny-invariant@^1.0.2:
-  version "1.1.0"
-  resolved "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.1.0.tgz#634c5f8efdc27714b7f386c35e6760991d230875"
-  integrity sha512-ytxQvrb1cPc9WBEI/HSeYYoGD0kWnGEOR8RY6KomWLBVhqz0RgTwVO9dLrGz7dC+nN9llyI7OKAgRq8Vq4ZBSw==
-
-tiny-warning@^1.0.0:
-  version "1.0.3"
-  resolved "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz#94a30db453df4c643d0fd566060d60a875d84754"
-  integrity sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==
-
 tippy.js@^6.2.3:
   version "6.2.3"
   resolved "https://registry.npmjs.org/tippy.js/-/tippy.js-6.2.3.tgz#0a5db67dc6bd9129233b26052b7ae2b2047fd73e"
@@ -25740,7 +25701,7 @@ typescript@4.3.4:
   resolved "https://registry.npmjs.org/typescript/-/typescript-4.3.4.tgz#3f85b986945bcf31071decdd96cf8bfa65f9dcbc"
   integrity sha512-uauPG7XZn9F/mo+7MrsRjyvbxFpzemRjKEZXS4AK83oP2KKOJPvb+9cO/gmnv8arWZvhnjVOXz7B49m1l0e9Ew==
 
-typescript@^4.1.6:
+typescript@^4.5.5:
   version "4.5.5"
   resolved "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz#d8c953832d28924a9e3d37c73d729c846c5896f3"
   integrity sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==
@@ -26199,11 +26160,6 @@ validate-npm-package-name@^3.0.0:
   dependencies:
     builtins "^1.0.3"
 
-value-equal@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.npmjs.org/value-equal/-/value-equal-1.0.1.tgz#1e0b794c734c5c0cade179c437d356d931a34d6c"
-  integrity sha512-NOJ6JZCAWr0zlxZt+xqCHNTEKOsrks2HQd4MqhP1qy4z1SkbEP467eNx6TgDKXMvUOb+OENfJCZwM+16n7fRfw==
-
 vary@^1, vary@~1.1.2:
   version "1.1.2"
   resolved "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"
@@ -26341,7 +26297,7 @@ walker@^1.0.7, walker@~1.0.5:
   dependencies:
     makeerror "1.0.x"
 
-warning@^4.0.1, warning@^4.0.2:
+warning@^4.0.2:
   version "4.0.3"
   resolved "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz#16e9e077eb8a86d6af7d64aa1e05fd85b4678ca3"
   integrity sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==


### PR DESCRIPTION
Closes #404

## Proposed Changes
- adds official react-output-target implementation by stencil to generate react components


## Things to check

- [ ] Does the change need to be documented?
- [ ] Does any existing example code needs to be updated?
- [ ] Is the change properly tested?
- [ ] Is it helpful to provide another example to demonstrate the new feature?
- [ ] Are there other code lines that need to be modified?
