### PR TITLE
chore: remove fonts hosted by google

### DIFF
--- a/packages/landingpage/src/views/WelcomeIndex.vue
+++ b/packages/landingpage/src/views/WelcomeIndex.vue
@@ -149,7 +149,6 @@ export default {
 
 <!-- Add "scoped" attribute to limit CSS to this component only -->
 <style scoped>
-@import url("//fonts.googleapis.com/css?family=Material+Icons");
 
 h1,
 h2,

--- a/packages/storybook/src/stories/docs/styleguide/styles.scss
+++ b/packages/storybook/src/stories/docs/styleguide/styles.scss
@@ -1,4 +1,4 @@
-@import url('https://fonts.googleapis.com/css?family=Dosis:300,400,500,600,700|Source+Code+Pro:400,500|Source+Sans+Pro:400,600');
+// @import url('https://fonts.googleapis.com/css?family=Dosis:300,400,500,600,700|Source+Code+Pro:400,500|Source+Sans+Pro:400,600');
 
 html {
   -webkit-font-smoothing: antialiased;


### PR DESCRIPTION
Closes #532 

## Proposed Changes

- Remove the fonts hosted by Google in the following packages:
  - `landingpage`
  - `storybook`
- No replacement is needed because the fonts were not in use