### PR TITLE
refactor(elements): replace deprecated division operator

### DIFF
--- a/packages/elements/src/components/base/_typography.scss
+++ b/packages/elements/src/components/base/_typography.scss
@@ -1,3 +1,5 @@
+@use 'sass:math';
+
 // ##################################
 // Font and typography
 // ##################################
@@ -68,5 +70,5 @@ $_font-sizes: (
 }
 
 @function pxToRem($px) {
-  @return $px / 16px * 1rem;
+  @return math.div($px, 16px) * 1rem;
 }


### PR DESCRIPTION
## Proposed Changes

- The `/` operator is will be deprecated with the next major version of SASS
- Replace `/` with `math.div(...)`
