### PR TITLE
style(elements|ino-nav-item): fix styles not being applied

### DIFF
--- a/packages/elements/src/components/ino-nav-item/ino-nav-item.scss
+++ b/packages/elements/src/components/ino-nav-item/ino-nav-item.scss
@@ -21,8 +21,8 @@ ino-nav-item  {
     #{rgba(theme.color(light, contrast), 0.04)}
   );
 
-  .mdc-list-item,
-  ino-list-item .mdc-list-item {
+  .mdc-deprecated-list-item,
+  ino-list-item .mdc-deprecated-list-item {
     padding: 0 16px;
     height: 60px;
     background-color: var(--nav-item-background-color);
@@ -51,13 +51,13 @@ ino-nav-item  {
       align-content: center;
     }
 
-    &.mdc-list-item--activated {
+    &.mdc-deprecated-list-item--activated {
       transition: border-left 0.1s ease-in-out;
       background-color: var(--nav-item-background-color-active);
       border-left: 2px solid var(--nav-item-color-active);
       color: var(--nav-item-color-active);
 
-      .mdc-list-item__ripple {
+      .mdc-deprecated-list-item__ripple {
         display: none;
       }
 


### PR DESCRIPTION
Closes #549 

## Proposed Changes

- the `<ino-nav-item>` is based on the `mdc-list-item`
- the classes of `mdc-list-item` changed with #349 but the `<ino-nav-item>` has not received an update
- replace classes `mdc-list-item-...` with `mdc-deprecated-list-item-...`
