### PR TITLE
style(elements|ino-chip): align hover effect even if css vars are used

### DIFF
--- a/packages/elements/src/components/ino-chip/ino-chip.scss
+++ b/packages/elements/src/components/ino-chip/ino-chip.scss
@@ -52,13 +52,13 @@ ino-chip {
 
     .ino-chip-trailing-icon {
       display: flex;
+      justify-content: center;
       --ino-icon-width: #{$icon-size};
       --ino-icon-height: #{$icon-size};
 
       .ino-chip-close-icon {
         --ino-icon-width: 15px;
         --ino-icon-height: 15px;
-        padding-top: 1px; // hacky, center vertically
       }
     }
 


### PR DESCRIPTION
When the `<ino-icon>` in the trailing slot of the `<ino-chip>` has a custom height or width (e.g. by setting `--ino-icon-width`), the ripple effect is not aligned correctly.

see:
![image](https://user-images.githubusercontent.com/22963121/157020765-19f52e63-0729-4eea-acef-2be5f5bd8e8a.png)


## Proposed Changes

- align the icon correctly so the ripple effect has the correct position
