### PR TITLE
refactor(elements|ino-autocomplete): expose menu and empty status

### DIFF
--- a/packages/elements/src/components/ino-autocomplete/ino-autocomplete.tsx
+++ b/packages/elements/src/components/ino-autocomplete/ino-autocomplete.tsx
@@ -323,6 +323,12 @@ export class Autocomplete implements ComponentInterface {
   private closeMenu = () => (this.menuIsVisible = false);
 
   render() {
+
+    const hostClasses = classNames({
+      'no-options-found': this.noOptionsIsVisible,
+      'menu-open': this.menuIsVisible
+    })
+
     const menuClasses = classNames({
       menu: true,
       'menu-hidden': !this.menuIsVisible,
@@ -330,7 +336,7 @@ export class Autocomplete implements ComponentInterface {
     });
 
     return (
-      <Host>
+      <Host class={hostClasses}>
         <slot name="input" />
         <div
           class={menuClasses}


### PR DESCRIPTION
A quick fix in order to expose information about the status of the menu (visible/hidden) and the filter status (options found/no options found).