### PR TITLE
build(elements): delete timestamp from json docs

### DIFF
--- a/packages/elements/json-docs-output-target.ts
+++ b/packages/elements/json-docs-output-target.ts
@@ -1,0 +1,32 @@
+import { JsonDocs, OutputTargetDocsCustom } from '@stencil/core/internal';
+import { resolve } from 'path';
+import { writeFileSync } from 'fs';
+
+const storybookElementsJsonPath = resolve(
+  __dirname,
+  '..',
+  'storybook',
+  'elements-stencil-docs.json'
+);
+
+type ComponentProps = keyof JsonDocs['components'][number];
+
+const KEYS_TO_DELETE: ComponentProps[] = [
+  'dirPath',
+  'readmePath',
+  'usagesDir',
+];
+
+export const JsonDocsOutputTarget: OutputTargetDocsCustom = {
+  type: 'docs-custom',
+  generator: async (docs: JsonDocs) => {
+
+    // delete timestamp to prevent merge conflicts & unused properties
+    delete docs.timestamp;
+    docs.components.forEach((component) => {
+      KEYS_TO_DELETE.forEach((key) => delete component[key]);
+    });
+
+    writeFileSync(storybookElementsJsonPath, JSON.stringify(docs, null, 2));
+  },
+};

--- a/packages/elements/stencil.config.ts
+++ b/packages/elements/stencil.config.ts
@@ -2,6 +2,7 @@ import { Config } from '@stencil/core';
 import { sass } from '@stencil/sass';
 import { angularOutputTarget } from '@stencil/angular-output-target';
 import { vueOutputTarget } from './vue-output-target';
+import { JsonDocsOutputTarget } from './json-docs-output-target';
 
 const angularDirectivesPath = '../elements-angular/elements/src/directives';
 
@@ -27,10 +28,7 @@ export const config: Config = {
       copy: [{ src: 'assets/ino-icon', dest: 'ino-icon' }],
     },
     { type: 'docs-readme' },
-    {
-      type: 'docs-json',
-      file: '../storybook/elements-stencil-docs.json',
-    },
+    JsonDocsOutputTarget,
     angularOutputTarget({
       componentCorePackage: '@inovex.de/elements',
       directivesProxyFile: `${angularDirectivesPath}/proxies.ts`,

--- a/packages/storybook/elements-stencil-docs.json
+++ b/packages/storybook/elements-stencil-docs.json
@@ -1,5 +1,4 @@
 {
-  "timestamp": "2022-04-28T13:58:01",
   "compiler": {
     "name": "@stencil/core",
     "version": "2.14.0",
@@ -8,9 +7,10 @@
   "components": [
     {
       "filePath": "./src/components/ino-autocomplete/ino-autocomplete.tsx",
-      "encapsulation": "shadow",
+      "fileName": "ino-autocomplete.tsx",
       "tag": "ino-autocomplete",
       "readme": "# ino-autocomplete\n\nA component that acts similar to the native `datalist` feature of the `<input>` element.\n\nIn contrast to other components, this one is stateful, which means that it contains its own state and is therefore less\nflexible to some extent.\n\nThis component handles the following tasks:\n\n* Management of the `value` property of the `<ino-input>` element\n* management of showing and hiding the different options filtered on the basis of the input\n* Keyboard navigation on the options\n\nThe options are filtered by `.includes(...)`, ignoring upper and lower case.\n\n### Usage\n\nThe component can be used as follows:\n\n```html\n\n<ino-autocomplete timeout=\"<number>\" no-options-text=\"<string>\">\n  <ino-input slot=\"input\" .../>\n  <ino-list slot=\"list\" ...>\n    <ino-option value=\"Value of Option A\">Option A</ino-option>\n    <ino-option value=\"Value of Option B\">Option B</ino-option>\n    <ino-option value=\"Value of Option C\">Option C</ino-option>\n  </ino-list>\n</ino-autocomplete>\n```\n\n### React\n\n```jsx\nimport { Component } from 'react';\nimport { InoAutocomplete, InoInput, InoList, InoListItem } from '@inovex.de/elements/dist/react';\n\nclass MyComponent extends Component {\n  render() {\n    return (\n      <>\n        <InoAutocomplete debounceTimeout={150} noOptionsText={\"No option found!\"}>\n          <InoInput slot=\"input\"/>\n          <InoList slot=\"list\">\n            <InoOption value=\"Value of Option A\">Option A</InoOption>\n            <InoOption value=\"Value of Option B\">Option B</InoOption>\n            <InoOption value=\"Value of Option C\">Option C</InoOption>\n          </InoList>\n        </InoAutocomplete>\n      </>\n    );\n  }\n}\n```\n",
+      "usage": {},
       "docs": "A component that acts similar to the native `datalist` feature of the `<input>` element.\n\nIn contrast to other components, this one is stateful, which means that it contains its own state and is therefore less\nflexible to some extent.\n\nThis component handles the following tasks:\n\n* Management of the `value` property of the `<ino-input>` element\n* management of showing and hiding the different options filtered on the basis of the input\n* Keyboard navigation on the options\n\nThe options are filtered by `.includes(...)`, ignoring upper and lower case.",
       "docsTags": [
         {
@@ -22,7 +22,10 @@
           "text": "default - A list of `<ino-option>` elements as options"
         }
       ],
-      "usage": {},
+      "encapsulation": "shadow",
+      "dependents": [],
+      "dependencies": [],
+      "dependencyGraph": {},
       "props": [
         {
           "name": "debounceTimeout",
@@ -87,18 +90,6 @@
           "docsTags": []
         }
       ],
-      "listeners": [
-        {
-          "event": "valueChange",
-          "capture": false,
-          "passive": false
-        },
-        {
-          "event": "keydown",
-          "capture": false,
-          "passive": false
-        }
-      ],
       "styles": [
         {
           "name": "--ino-autocomplete-list-max-height",
@@ -117,15 +108,25 @@
         }
       ],
       "parts": [],
-      "dependents": [],
-      "dependencies": [],
-      "dependencyGraph": {}
+      "listeners": [
+        {
+          "event": "valueChange",
+          "capture": false,
+          "passive": false
+        },
+        {
+          "event": "keydown",
+          "capture": false,
+          "passive": false
+        }
+      ]
     },
     {
       "filePath": "./src/components/ino-button/ino-button.tsx",
-      "encapsulation": "shadow",
+      "fileName": "ino-button.tsx",
       "tag": "ino-button",
       "readme": "# ino-button\n\nA button component with different styles and icon capability.\n\n## Usage\n\nThe component can be used as follows:\n\n### Web Component\n\n```js\ndocument\n  .querySelector('ino-button')\n  .addEventListener('click', (_) => alert('Button was clicked!'));\n```\n\n```html\n<ino-button\n  autofocus\n  disabled\n  name=\"<string>\"\n  form=\"<string>\"\n  type=\"<string>\"\n  color-scheme=\"<string>\"\n  fill=\"<string>\"\n  dense\n  onClick=\"handleClick()\"\n>\n  <ino-icon icon=\"add\"></ino-icon>\n  Button Content\n</ino-button>\n```\n\n### React\n\n#### Example #1 - Basic\n\n```jsx\nimport { Component } from 'react';\nimport { InoButton, InoIcon } from '@inovex.de/elements/dist/react';\n\nclass MyComponent extends Component {\n  render() {\n    return (\n      <InoButton\n        inoColorScheme=\"dark\"\n        inoIconLeading\n        onClick={(_) => alert('Yeah, you clicked the button!')}\n      >\n        <InoIcon inoIcon=\"add\" />\n        You can click me!\n      </InoButton>\n    );\n  }\n}\n```\n\n#### Example #2 - With Types\n\n```js\nimport React, { Component } from 'react';\nimport { InoButton } from '@inovex.de/elements/dist/react';\nimport { Components } from '@inovex.de/elements/dist/types/components';\n\nconst Button: React.FunctionComponent<Components.InoButtonAttributes> = (\n  props,\n) => {\n  const { inoColorScheme, onClick } = props;\n\n  return (\n    <InoButton inoColorScheme={inoColorScheme} inoIconLeading onClick={onClick}>\n      <InoIcon inoIcon={'add'} />\n      You can click me!\n    </InoButton>\n  );\n};\n\nclass MyComponent extends Component {\n  render() {\n    return (\n      <Button\n        inoColorScheme=\"dark\"\n        onClick={(_) => alert('Yeah, you clicked the button!')}\n      />\n    );\n  }\n}\n```\n\n## Demo\n",
+      "usage": {},
       "docs": "A button component with different styles and icon capability.",
       "docsTags": [
         {
@@ -137,7 +138,21 @@
           "text": "icon-trailing - For the icon to be appended"
         }
       ],
-      "usage": {},
+      "encapsulation": "shadow",
+      "dependents": [
+        "ino-input-file"
+      ],
+      "dependencies": [
+        "ino-spinner"
+      ],
+      "dependencyGraph": {
+        "ino-button": [
+          "ino-spinner"
+        ],
+        "ino-input-file": [
+          "ino-button"
+        ]
+      },
       "props": [
         {
           "name": "autoFocus",
@@ -338,7 +353,6 @@
       ],
       "methods": [],
       "events": [],
-      "listeners": [],
       "styles": [
         {
           "name": "--ino-button-color-primary",
@@ -412,26 +426,14 @@
         }
       ],
       "parts": [],
-      "dependents": [
-        "ino-input-file"
-      ],
-      "dependencies": [
-        "ino-spinner"
-      ],
-      "dependencyGraph": {
-        "ino-button": [
-          "ino-spinner"
-        ],
-        "ino-input-file": [
-          "ino-button"
-        ]
-      }
+      "listeners": []
     },
     {
       "filePath": "./src/components/ino-card/ino-card.tsx",
-      "encapsulation": "none",
+      "fileName": "ino-card.tsx",
       "tag": "ino-card",
       "readme": "# ino-card\n\nThe ino-card is a flexible and extensible component. It features a header, content, and footer slot that can be used to\nfully customize the appearance of the card.\n\n## Usage\n\nThe component can be used as follows:\n\n### Web Component\n\n```js\ndocument\n  .querySelector('ino-card')\n  .addEventListener('click', (_) => alert('Card was clicked!'));\n```\n\n```html\n<ino-card selected=\"<boolean>\" disable-elevation=\"<boolean>\">\n  <div slot=\"header\"><!-- Any content --></div>\n  <div slot=\"content\"><!-- Any content --></div>\n  <div slot=\"footer\"><!-- Any content --></div>\n</ino-card>\n```\n\n### React\n\n```js\nimport { Component } from 'react';\nimport { InoCard, InoButton, InoImg } from '@inovex.de/elements/dist/react';\n\nclass MyComponent extends Component {\n  render() {\n    return (\n      <InoCard inoDisableElevation>\n        <div class=\"my-card__header\" slot=\"header\">\n          <h1>My awesome card</h1>\n        <div/>\n        <div class=\"my-card__content\" slot=\"content\">\n          <InoImg src=\"assets/picture_of_me.png\"></InoImg>\n        </div>\n        <div class=\"my-card__footer\" slot=\"footer\">\n          <InoButton>Send Email</InoButton>\n        </div>\n      </InoCard>\n    );\n  }\n}\n```\n",
+      "usage": {},
       "docs": "The ino-card is a flexible and extensible component. It features a header, content, and footer slot that can be used to\nfully customize the appearance of the card.",
       "docsTags": [
         {
@@ -447,7 +449,16 @@
           "text": "footer - For the element to be placed in the card footer"
         }
       ],
-      "usage": {},
+      "encapsulation": "none",
+      "dependents": [],
+      "dependencies": [
+        "ino-icon"
+      ],
+      "dependencyGraph": {
+        "ino-card": [
+          "ino-icon"
+        ]
+      },
       "props": [
         {
           "name": "disableElevation",
@@ -486,7 +497,6 @@
       ],
       "methods": [],
       "events": [],
-      "listeners": [],
       "styles": [
         {
           "name": "--ino-card-background-color",
@@ -544,21 +554,14 @@
         }
       ],
       "parts": [],
-      "dependents": [],
-      "dependencies": [
-        "ino-icon"
-      ],
-      "dependencyGraph": {
-        "ino-card": [
-          "ino-icon"
-        ]
-      }
+      "listeners": []
     },
     {
       "filePath": "./src/components/ino-carousel/ino-carousel.tsx",
-      "encapsulation": "none",
+      "fileName": "ino-carousel.tsx",
       "tag": "ino-carousel",
       "readme": "# ino-carousel\n\nThe `ino-carousel` component works in combination with the `ino-carousel-slide` component\nand can be used to display an array of images as a slide show. What is more,\nit also features an autoplay property that allows the slides to be changed automatically.\nLastly, using the css variables described at the bottom of the page, you can easily customize\nthe dimensions of the component as well as the duration of the slide transition.\n\n## Usage\n\nTo change the slide that is currently displayed, simply set the value of the `ino-carousel`\ncomponent to the value of the corresponding slide. This is, however, not required if autoplay is\nenabled since the component automatically manages the selection of the next slide.\n\nPlease be aware that setting the value of the `ino-carousel` to a non-existent value will result\nin the component selecting an existing slide on its own.\n\nThe component can be used as follows:\n\n```html\n<ino-carousel\n  value=\"<any value>\"\n  autoplay=\"true\"\n  animated=\"true\"\n  hide-buttons=\"false\"\n  infinite=\"true\"\n  intermission=\"5000\"\n  reverse=\"false\"\n>\n  <ino-carousel-slide value=\"0\" src=\"<url>\"></ino-carousel-slide>\n  <ino-carousel-slide value=\"1\" src=\"<url>\"></ino-carousel-slide>\n  <ino-carousel-slide value=\"2\" src=\"<url>\"></ino-carousel-slide>\n</ino-carousel>\n```\n\n```jsx\nimport { Component } from 'react';\nimport {\n  InoButton,\n  InoCarousel,\n  InoCarouselSlide,\n} from '@inovex/elements/dist/react';\nimport React from 'react';\n\nclass MyComponent extends Component {\n  state = {\n    autoplay: false,\n  };\n\n  handleClick = () => {\n    this.setState((state) => ({\n      autoplay: !state.autoplay,\n    }));\n  };\n\n  render() {\n    return (\n      <InoCarousel inoAutoplay={this.state.autoplay}>\n        <InoButton onClick={() => this.handleClick()}>\n          Start/Stop Slideshow\n        </InoButton>\n        <InoCarouselSlide value={'1'} src={'url'} />\n        <InoCarouselSlide value={'2'} src={'url'} />\n      </InoCarousel>\n    );\n  }\n}\n```\n",
+      "usage": {},
       "docs": "The `ino-carousel` component works in combination with the `ino-carousel-slide` component\nand can be used to display an array of images as a slide show. What is more,\nit also features an autoplay property that allows the slides to be changed automatically.\nLastly, using the css variables described at the bottom of the page, you can easily customize\nthe dimensions of the component as well as the duration of the slide transition.",
       "docsTags": [
         {
@@ -566,7 +569,19 @@
           "text": "default - One or more `ino-carousel-slide`"
         }
       ],
-      "usage": {},
+      "encapsulation": "none",
+      "dependents": [],
+      "dependencies": [
+        "ino-icon-button"
+      ],
+      "dependencyGraph": {
+        "ino-carousel": [
+          "ino-icon-button"
+        ],
+        "ino-icon-button": [
+          "ino-icon"
+        ]
+      },
       "props": [
         {
           "name": "animated",
@@ -689,7 +704,6 @@
       ],
       "methods": [],
       "events": [],
-      "listeners": [],
       "styles": [
         {
           "name": "--ino-carousel-animation-duration",
@@ -719,27 +733,20 @@
         }
       ],
       "parts": [],
-      "dependents": [],
-      "dependencies": [
-        "ino-icon-button"
-      ],
-      "dependencyGraph": {
-        "ino-carousel": [
-          "ino-icon-button"
-        ],
-        "ino-icon-button": [
-          "ino-icon"
-        ]
-      }
+      "listeners": []
     },
     {
       "filePath": "./src/components/ino-carousel-slide/ino-carousel-slide.tsx",
-      "encapsulation": "none",
+      "fileName": "ino-carousel-slide.tsx",
       "tag": "ino-carousel-slide",
       "readme": "# ino-carousel-slide\n",
+      "usage": {},
       "docs": "",
       "docsTags": [],
-      "usage": {},
+      "encapsulation": "none",
+      "dependents": [],
+      "dependencies": [],
+      "dependencyGraph": {},
       "props": [
         {
           "name": "src",
@@ -776,19 +783,17 @@
       ],
       "methods": [],
       "events": [],
-      "listeners": [],
       "styles": [],
       "slots": [],
       "parts": [],
-      "dependents": [],
-      "dependencies": [],
-      "dependencyGraph": {}
+      "listeners": []
     },
     {
       "filePath": "./src/components/ino-checkbox/ino-checkbox.tsx",
-      "encapsulation": "shadow",
+      "fileName": "ino-checkbox.tsx",
       "tag": "ino-checkbox",
       "readme": "# ino-checkbox\n\nA checkbox that allows the user to select one or more items from a set of options.\n",
+      "usage": {},
       "docs": "A checkbox that allows the user to select one or more items from a set of options.",
       "docsTags": [
         {
@@ -796,7 +801,16 @@
           "text": "default - Label of the checkbox"
         }
       ],
-      "usage": {},
+      "encapsulation": "shadow",
+      "dependents": [
+        "ino-control-item"
+      ],
+      "dependencies": [],
+      "dependencyGraph": {
+        "ino-control-item": [
+          "ino-checkbox"
+        ]
+      },
       "props": [
         {
           "name": "checked",
@@ -908,7 +922,6 @@
           "docsTags": []
         }
       ],
-      "listeners": [],
       "styles": [
         {
           "name": "--checkbox-container-color-unchecked",
@@ -958,21 +971,14 @@
         }
       ],
       "parts": [],
-      "dependents": [
-        "ino-control-item"
-      ],
-      "dependencies": [],
-      "dependencyGraph": {
-        "ino-control-item": [
-          "ino-checkbox"
-        ]
-      }
+      "listeners": []
     },
     {
       "filePath": "./src/components/ino-chip/ino-chip.tsx",
-      "encapsulation": "none",
+      "fileName": "ino-chip.tsx",
       "tag": "ino-chip",
       "readme": "# ino-chip\n\nThe ino-chip component displays the provided content and icon as a chip.\n\n## Usage\n\nThe component can be used as follows:\n\n### Web Component\n\n```js\nconst chip = document.querySelector('ino-chip');\nchip.addEventListener('chipClicked', (e) =>\n  console.log('This chip was clicked:', e.detail),\n)\nchip.addEventListener('chipRemoved', (e) =>\n  console.log('This chip was removed:', e.detail),\n);\n```\n\n```html\n\n<ino-chip\n  color-scheme=\"<string>\"\n  disabled\n  fill=\"<string>\"\n  label=\"<string>\"\n  removable\n  selectable\n  selected\n  value=\"<string>\"\n>\n  <ino-icon slot=icon-leading\" icon=\"<string>\"></ino-icon>\n</ino-chip>\n```\n\n### React\n\n#### Example #1\n\n```tsx\nimport { Component } from 'react';\nimport { InoChipSet, InoChip } from '@inovex.de/elements/dist/react';\n\nclass MyComponent extends Component {\n\n  fruits = [\"apple\", \"banana\", \"cherry\"];\n\n  handleChipClicked(e: CustomEvent<string>) {\n    console.log(\"User clicked the fruit: \", e.detail);\n  }\n\n  render() {\n    return (\n      <div>\n        {fruits.map(fruit => (\n            <InoChip value={fruit} label={fruit} onChipClicked={this.handleChipClicked}/>\n          )\n        )}\n      </div>\n    );\n  }\n}\n```\n\n#### Example #2\n\n```tsx\nimport React, { Component } from 'react';\nimport { InoChipSet, InoChip } from '@inovex.de/elements/dist/react';\nimport { Components } from '@inovex.de/elements/dist/types/components';\n\nconst ChipSet = () => {\n\n  const fruits = [\"apple\", \"banana\", \"cherry\"];\n  const [selectedFruit, setSelectedFruit] = useState < string > (\"apple\");\n\n  return (\n    <div>\n      {fruits.map(fruit => (\n        <InoChip\n          value={fruit}\n          label={fruit}\n          selectable\n          selected={fruit === selectedFruit}\n          onChipClicked={(e) => setSelectedFruit(fruit)}\n        />\n      ))}\n    </div>\n  );\n};\n```\n\n## Additional Hints\n\n**Content**: Use the `label` attribute to set the label of the chip. To add an icon to the left side of the chip, use the  icon` attribute.\n\n### Selection\nA set of chips can be used to implement a single or multi selection from a handful of options.\nHave a look at the **Selection** and **Filter** stories.\n\n### Removable chips\n\nIf `removable` is set to `true`, the chip can be removed by the user. \nThe component then displays a small `close` icon on the right side of the chip next to the label.\n\nHowever, the component will not be hidden or destroyed but instead emits a `removeChip`-Event. Thus, the component can be removed by subscribing to the corresponding event.\n\n## Demo\n",
+      "usage": {},
       "docs": "The ino-chip component displays the provided content and icon as a chip.",
       "docsTags": [
         {
@@ -984,7 +990,16 @@
           "text": "icon-trailing - For the icon to be appended - disables the `removable` property"
         }
       ],
-      "usage": {},
+      "encapsulation": "none",
+      "dependents": [],
+      "dependencies": [
+        "ino-icon"
+      ],
+      "dependencyGraph": {
+        "ino-chip": [
+          "ino-icon"
+        ]
+      },
       "props": [
         {
           "name": "colorScheme",
@@ -1176,13 +1191,6 @@
           "docsTags": []
         }
       ],
-      "listeners": [
-        {
-          "event": "click",
-          "capture": false,
-          "passive": false
-        }
-      ],
       "styles": [],
       "slots": [
         {
@@ -1195,21 +1203,20 @@
         }
       ],
       "parts": [],
-      "dependents": [],
-      "dependencies": [
-        "ino-icon"
-      ],
-      "dependencyGraph": {
-        "ino-chip": [
-          "ino-icon"
-        ]
-      }
+      "listeners": [
+        {
+          "event": "click",
+          "capture": false,
+          "passive": false
+        }
+      ]
     },
     {
       "filePath": "./src/components/ino-control-item/ino-control-item.tsx",
-      "encapsulation": "none",
+      "fileName": "ino-control-item.tsx",
       "tag": "ino-control-item",
       "readme": "# ino-list-item\n\nA list item component that displays a single instance of choice in a list or menu with a control element (radio-button or checkbox). It functions as a wrapper around the material [list item](https://github.com/material-components/material-components-web/blob/master/packages/mdc-list/) capabilities.\n\nThis component is used as child of `ino-list` and `ino-menu` components.\n\n### Usage\n\nThe component can be used as follows:\n\n```js\ndocument\n  .querySelector('ino-control-item')\n  .addEventListener('checkedChange', (e) =>\n    console.log(\n      'The element itself or the checkbox was clicked. Its new value is:',\n      e.detail,\n    ),\n  );\n```\n\n```html\n<ino-control-item\n  role=\"checkbox|radio\"\n  checked=\"<boolean>\"\n  disabled=\"<boolean>\"\n  name=\"<string>\"\n  value=\"<string>\"\n  tab-index=\"<number>\"\n  id=\"<string>\"\n  activated\n  text=\"<string>\"\n  secondary-text=\"<string>\"\n  selected=\"<boolean>\"\n  indeterminate=\"<boolean>\"\n  oncheckedchange=\"handleCheckChange()\"\n  trailing=\"<boolean>\"\n>\n  ...\n</ino-control-item>\n```\n\n**Slot:** This component supports icons and text as children. Just declare your icon or text inside of the `ino-control-item`-Element and it will be placed according to the `trailing`-Property.\n\n**Two lines:** For items having two lines, provide an `secondary-text` and make sure you set the `two-lines` attribute in the respective parent component (only available for `ino-list`).\n\n**Trailing:** Positions the control element at the end of the line\n\n### Restrictions\n\nPlease note that only text is supported as a trailing element. However, your icons can be placed at the leading position. To do so, use the `trailing`-Property and declare your icon inside of the element as shown below.\n\n```html\n<ino-control-item\n  role=\"checkbox\"\n  trailing\n  text=\"Checkbox-Item with a leading icon\"\n>\n  <ino-icon icon=\"add\" />\n</ino-control-item>\n\n<ino-control-item\n  role=\"checkbox\"\n  text=\"Checkbox-Item with trailing metadata\"\n>\n  <p>Some Metadata</p>\n</ino-control-item>\n```\n",
+      "usage": {},
       "docs": "A list item component that displays a single instance of choice in a list or menu with a control element (radio-button or checkbox). It functions as a wrapper around the material [list item](https://github.com/material-components/material-components-web/blob/master/packages/mdc-list/) capabilities.\n\nThis component is used as child of `ino-list` and `ino-menu` components.",
       "docsTags": [
         {
@@ -1217,7 +1224,20 @@
           "text": "default - Any element"
         }
       ],
-      "usage": {},
+      "encapsulation": "none",
+      "dependents": [],
+      "dependencies": [
+        "ino-list-item",
+        "ino-checkbox",
+        "ino-radio"
+      ],
+      "dependencyGraph": {
+        "ino-control-item": [
+          "ino-list-item",
+          "ino-checkbox",
+          "ino-radio"
+        ]
+      },
       "props": [
         {
           "name": "activated",
@@ -1414,7 +1434,6 @@
           "docsTags": []
         }
       ],
-      "listeners": [],
       "styles": [],
       "slots": [
         {
@@ -1423,25 +1442,14 @@
         }
       ],
       "parts": [],
-      "dependents": [],
-      "dependencies": [
-        "ino-list-item",
-        "ino-checkbox",
-        "ino-radio"
-      ],
-      "dependencyGraph": {
-        "ino-control-item": [
-          "ino-list-item",
-          "ino-checkbox",
-          "ino-radio"
-        ]
-      }
+      "listeners": []
     },
     {
       "filePath": "./src/components/ino-currency-input/ino-currency-input.tsx",
-      "encapsulation": "none",
+      "fileName": "ino-currency-input.tsx",
       "tag": "ino-currency-input",
       "readme": "# ino-currency-input\nA component providing currency functionality by extending a `ino-input`. Main objectives of this component are the separatation of formatted currency values from its numeric values and to handle different currency locales.\n\nThe `ino-currency-input` controls an underlying `ino-input` and evaluates its value on blur. While the `ino-input` has the textual user input as value, the `ino-currency-input` provides a numeric value of the currency. In theory, you can use all `ino-input` properties. However, properties like maxlength, step, etc. make no sense for currency inputs and are thus not supported.\n\n### Usage\n\nThe component can be used as follows:\n\n```js\ndocument\n  .querySelector('ino-currency-input')\n  .addEventListener('valueChange', e => alert(`The new input value is: ${e.detail}`));\n```\n```html\n<ino-currency-input value=\"<number>\" currency-locale=\"<string>\">\n  <ino-input type=\"text\" ...></ino-input>\n</ino-currency-input>\n```\n\nThe child input element requires to be of type `text`.\n\n### Event behaviour\nThe currency input watches for value changes on the underlying `ino-input`, updates the inputs value and stops the event propagation. In order to avoid distraction for the user, the currency input only formats the input value on focus and on blur. Furthermore, the `ino-currency-input` itself emits a `valueChange` event when the user commits a currency value (on blur).\n\n### Locales\nThe currency input uses a native number formatter which supports a vary of different locales (see [Documentation](https://developer.mozilla.org/de/docs/Web/JavaScript/Reference/Global_Objects/Intl#locales_argument)). On a component level, you can provide any supported locale via the `currency-locale` attribute.\n\nHowever, it may be useful to define a global locale for currencies, This may even differ from the application's locale, for instance a Belgian application may use English as language but the German currency format. For this reason, you can provide the `currencyLocale` option on the global configuration.\n\n### React\n\n#### Example #1 - Basic\n\n```js\nimport { Component } from 'react';\nimport { InoCurrencyInput, InoInput } from '@inovex.de/elements-react';\n\nclass MyComponent extends Component {\n  onValueChange(e: any) {\n    alert(`The new value is ${e.detail}`);\n  }\n\n  render() {\n    return (\n      <InoCurrencyInput\n        placeholder=\"You can insert some text...\"\n        onValueChange={onValueChange}\n      >\n        <InoInput type=\"text\" />\n      </InoCurrencyInput>\n    );\n  }\n}\n```\n\n#### Example #2 - With Types\n\n```js\nimport React, { Component } from 'react';\nimport { InoCurrencyInput, InoInput } from '@inovex.de/elements-react';\nimport { Components } from '@inovex.de/elements/dist/types/components';\n\nconst CurrencyInput: React.FunctionComponent<Components.InoCurrencyInputAttributes> = props => {\n  const { placeholder } = props;\n\n  const onValueChange = (e: any) => {\n    alert(`The new value is ${e.detail}`);\n  };\n\n  return (\n      <InoCurrencyInput onValueChange={onValueChange}>\n        <InoInput type=\"text\" />\n      </InoCurrencyInput>\n  );\n};\n\nclass MyComponent extends Component {\n  render() {\n    return <CurrencyInput placeholder=\"You can insert some text...\" />;\n  }\n}\n```\n\n\n",
+      "usage": {},
       "docs": "A component providing currency functionality by extending a `ino-input`. Main objectives of this component are the separatation of formatted currency values from its numeric values and to handle different currency locales.\n\nThe `ino-currency-input` controls an underlying `ino-input` and evaluates its value on blur. While the `ino-input` has the textual user input as value, the `ino-currency-input` provides a numeric value of the currency. In theory, you can use all `ino-input` properties. However, properties like maxlength, step, etc. make no sense for currency inputs and are thus not supported.",
       "docsTags": [
         {
@@ -1449,7 +1457,10 @@
           "text": "default - `<ino-input>` of `type=\"text\"`"
         }
       ],
-      "usage": {},
+      "encapsulation": "none",
+      "dependents": [],
+      "dependencies": [],
+      "dependencyGraph": {},
       "props": [
         {
           "name": "currencyLocale",
@@ -1499,7 +1510,6 @@
           "docsTags": []
         }
       ],
-      "listeners": [],
       "styles": [],
       "slots": [
         {
@@ -1508,15 +1518,14 @@
         }
       ],
       "parts": [],
-      "dependents": [],
-      "dependencies": [],
-      "dependencyGraph": {}
+      "listeners": []
     },
     {
       "filePath": "./src/components/ino-datepicker/ino-datepicker.tsx",
-      "encapsulation": "none",
+      "fileName": "ino-datepicker.tsx",
       "tag": "ino-datepicker",
       "readme": "# ino-datepicker\n\nA datepicker is a ui component to select dates and times. It behaves like a native `input` but uses the [flatpickr](https://github.com/flatpickr/flatpickr) library for a better ui experience.\n\n## Usage\n\nThe component can be used as follows:\n\n### Web Component\n\n```js\ndocument\n  .querySelector('ino-datepicker')\n  .addEventListener('valueChange', (e) =>\n    alert(`The new datepicker value is: ${e.detail}`),\n  );\n```\n\n```html\n<ino-datepicker\n  autofocus\n  disabled\n  name=\"<string>\"\n  required\n  value=\"<string>\"\n  min=\"<string>\"\n  max=\"<string>\"\n  minute-step=\"<number>\"\n  hour-step=\"<number>\"\n  inline=\"<boolean>\"\n  range\n  outline\n  placeholder=\"<string>\"\n  label=\"<string>\"\n  pattern=\"<string>\"\n  date-format=\"<string>\"\n  default-date=\"<string>\"\n  default-hour=\"<number>\"\n  default-minute=\"<number>\"\n  twelve-hour-time\n  helper=\"<string>\"\n  helper-persistent\n  helper-validation\n>\n</ino-datepicker>\n```\n\n### React\n\n#### Example #1 - Basic\n\n```js\nimport { Component } from 'react';\nimport { InoDatepicker } from '@inovex.de/elements/dist/react';\n\nclass MyComponent extends Component {\n  valueChange(e: any) {\n    alert(`The new value is ${e.detail}`);\n  }\n\n  render() {\n    return (\n      <InoDatepicker\n        inoLabel=\"Select a date\"\n        inoHelper=\"Choose a date\"\n        onValueChange={valueChange}\n      />\n    );\n  }\n}\n```\n\n#### Example #2 - With Types\n\n```js\nimport React, { Component } from 'react';\nimport { InoDatepicker } from '@inovex.de/elements/dist/react';\nimport { Components } from '@inovex.de/elements/dist/types/components';\n\nconst Datepicker: React.FunctionComponent<Components.InoDatepickerAttributes> = (\n  props,\n) => {\n  const { inoLabel, inoHelper } = props;\n\n  const valueChange = (e: any) => {\n    alert(`The new value is ${e.detail}`);\n  };\n\n  return (\n    <InoDatepicker\n      inoLabel={inoLabel}\n      inoHelper={inoHelper}\n      onValueChange={valueChange}\n    />\n  );\n};\n\nclass MyComponent extends Component {\n  render() {\n    return <Datepicker inoLabel=\"Select a date\" inoHelper=\"Choose a date\" />;\n  }\n}\n```\n\n## Additional Hints\n\n### Types\n\nThis datepicker can be used as a picker for ...\n\n- date\n- time\n- datetime\n- month\n\nThe type of the picker is selected based on the  type` property. See the examples below.\n\n#### Datepicker\n\n```html\n<ino-datepicker type=\"date\" label=\"Date\"></ino-datepicker>\n```\n\n#### Timepicker\n\n```html\n<ino-datepicker type=\"time\" label=\"Time\"></ino-datepicker>\n```\n\n#### Date-Time-Picker\n\n```html\n<ino-datepicker type=\"datetime\" label=\"Datetime\"> </ino-datepicker>\n```\n\n#### Monthpicker\n\n```html\n<ino-datepicker type=\"month\" label=\"Month\"></ino-datepicker>\n```\n\n## Demo\n",
+      "usage": {},
       "docs": "A datepicker is a ui component to select dates and times. It behaves like a native `input` but uses the [flatpickr](https://github.com/flatpickr/flatpickr) library for a better ui experience.",
       "docsTags": [
         {
@@ -1528,7 +1537,22 @@
           "text": "icon-trailing - Trailing `ino-icon` of the underyling ino-input (only for inline pickers)"
         }
       ],
-      "usage": {},
+      "encapsulation": "none",
+      "dependents": [],
+      "dependencies": [
+        "ino-input",
+        "ino-icon"
+      ],
+      "dependencyGraph": {
+        "ino-datepicker": [
+          "ino-input",
+          "ino-icon"
+        ],
+        "ino-input": [
+          "ino-label",
+          "ino-icon"
+        ]
+      },
       "props": [
         {
           "name": "appendTo",
@@ -2033,18 +2057,6 @@
           "docsTags": []
         }
       ],
-      "listeners": [
-        {
-          "event": "click",
-          "capture": false,
-          "passive": false
-        },
-        {
-          "event": "clickEl",
-          "capture": false,
-          "passive": false
-        }
-      ],
       "styles": [],
       "slots": [
         {
@@ -2057,27 +2069,25 @@
         }
       ],
       "parts": [],
-      "dependents": [],
-      "dependencies": [
-        "ino-input",
-        "ino-icon"
-      ],
-      "dependencyGraph": {
-        "ino-datepicker": [
-          "ino-input",
-          "ino-icon"
-        ],
-        "ino-input": [
-          "ino-label",
-          "ino-icon"
-        ]
-      }
+      "listeners": [
+        {
+          "event": "click",
+          "capture": false,
+          "passive": false
+        },
+        {
+          "event": "clickEl",
+          "capture": false,
+          "passive": false
+        }
+      ]
     },
     {
       "filePath": "./src/components/ino-dialog/ino-dialog.tsx",
-      "encapsulation": "shadow",
+      "fileName": "ino-dialog.tsx",
       "tag": "ino-dialog",
       "readme": "# ino-dialog\n\nThe ino-dialog component displays a modal window that can be used to display additional information or notify the user.\nIt is based on the mdc-dialog and is fully customizable. The styling of a dialog's content must be provided by users.\n\n## Usage\n\nThe component can be used as follows:\n\n### Web Component\n\n```js\ndocument\n  .querySelector('ino-dialog')\n  .addEventListener('close', (e) =>\n    alert(`dialog has been closed with action: ${e.detail}`),\n  );\n```\n\n```html\n<ino-dialog>\n  <div class=\"awesome-content\"></div>\n</ino-dialog>\n```\n\n### React\n\n```jsx\nimport React from 'react';\nimport { Component } from 'react';\nimport { InoButton, InoDialog } from '@inovex.de/elements/dist/react';\n\nclass MyComponent extends Component {\n\n  state = {\n    open: false\n  };\n\n  handleEvent = () => {\n    this.setState((open) => ({\n      open: !open\n    }))\n  };\n\n  render() {\n    return (\n      <>\n        <InoButton onClick={() => this.handleEvent()}>Open Dialog</InoButton>\n        <InoDialog open={this.state.open}>\n          <div class=\"awesome-content\"/>\n        </InoDialog>\n      </>\n    );\n  }\n}\n```\n\n## Additional information\n\n### Sizing\nThe dialog is displayed in the middle (horiziontally and vertically centered) on a surface.\nIn order to customize the dialog's size, use the `--ino-dialog-height` and `--ino-dialog-width` properties.\nEither use a fixed value or use css calc (f.e. `calc(100% - 60px)` to add a margin auf `30px` on both sides).\n\n### Fullwidth\nA Fullwidth dialog is a distinct variant which has 100% width an is attached to the bottom of the page. It scrolls up and defines a small\nmargin at top for the background scrim and escape for dialog close. It's not recommenended to use this option with `--ino-dialog-width` and `--ino-dialog-height`.\n\n### Closing actions\nYou can mark elements as \"action elements\" by providing a `data-ino-dialog-action=\"action-name\"` attribute.\nOn user clicks, the dialog checks whether the target is a dialog action and, if true, emits a `close` event with `event.detail = \"action-name\"`.\n\nSubsequently, listen to the `close` Event and check the `event.detail` to retrieve the users action.\n",
+      "usage": {},
       "docs": "The ino-dialog component displays a modal window that can be used to display additional information or notify the user.\nIt is based on the mdc-dialog and is fully customizable. The styling of a dialog's content must be provided by users.",
       "docsTags": [
         {
@@ -2085,7 +2095,10 @@
           "text": "default - content of the dialog"
         }
       ],
-      "usage": {},
+      "encapsulation": "shadow",
+      "dependents": [],
+      "dependencies": [],
+      "dependencyGraph": {},
       "props": [
         {
           "name": "attachTo",
@@ -2165,14 +2178,6 @@
           "docsTags": []
         }
       ],
-      "listeners": [
-        {
-          "event": "keyup",
-          "target": "body",
-          "capture": false,
-          "passive": false
-        }
-      ],
       "styles": [
         {
           "name": "--ino-dialog-background-color",
@@ -2217,15 +2222,21 @@
         }
       ],
       "parts": [],
-      "dependents": [],
-      "dependencies": [],
-      "dependencyGraph": {}
+      "listeners": [
+        {
+          "event": "keyup",
+          "target": "body",
+          "capture": false,
+          "passive": false
+        }
+      ]
     },
     {
       "filePath": "./src/components/ino-fab/ino-fab.tsx",
-      "encapsulation": "shadow",
+      "fileName": "ino-fab.tsx",
       "tag": "ino-fab",
       "readme": "# ino-fab\n\nA floating action button represents the primary action in an application. [Floating Action Button](https://github.com/material-components/material-components-web/tree/master/packages/mdc-fab) component.\nIt appears in front of all screen content, typically as a circular shape with an icon in its center.\n\nFABs come in three types: regular, mini, and extended.\n\n### Usage\n\nThe component can be used as follows:\n\n```html\n<ino-fab\n  icon=\"<string>\"\n  label=\"<string>\"\n  extended\n  mini\n  tooltip-placement=\"<string>\"\n  disabled\n>\n</ino-fab>\n```\n\n### React\n\n#### Example #1 - Basic\n\n```js\nimport { Component } from 'react';\nimport { InoFab } from '@inovex.de/elements/dist/react';\n\nclass MyComponent extends Component {\n  handleClick = (e: any) => {\n    alert(`Fab was clicked`);\n  };\n\n  render() {\n    return (\n      <InoFab\n        inoIcon=\"star\"\n        inoLabel=\"This is a fab\"\n        onClick={this.handleClick}\n      />\n    );\n  }\n}\n```\n\n#### Example #2 - With Types\n\n```js\nimport React, { Component } from 'react';\nimport { InoFab } from '@inovex.de/elements/dist/react';\nimport { Components } from '@inovex.de/elements/dist/types/components';\n\nconst Fab: React.FunctionComponent<Components.InoFabAttributes> = (props) => {\n  const { inoLabel, inoIcon } = props;\n\n  const handleClick = (e: any) => {\n    alert(`Fab was clicked`);\n  };\n\n  return <InoFab inoIcon={inoIcon} inoLabel={inoLabel} onClick={handleClick} />;\n};\n\nclass MyComponent extends Component {\n  render() {\n    return <Fab inoLabel=\"This is a fab\" inoIcon=\"star\" />;\n  }\n}\n```\n\n## Additional Hints\n\n**Content**: Use the  label` attribute to set the text of a fab. To add an icon, use the  icon` attribute.\n\n## Demo\n",
+      "usage": {},
       "docs": "A floating action button represents the primary action in an application. [Floating Action Button](https://github.com/material-components/material-components-web/tree/master/packages/mdc-fab) component.\nIt appears in front of all screen content, typically as a circular shape with an icon in its center.\n\nFABs come in three types: regular, mini, and extended.",
       "docsTags": [
         {
@@ -2233,7 +2244,23 @@
           "text": "icon-leading - For the icon to be prepended"
         }
       ],
-      "usage": {},
+      "encapsulation": "shadow",
+      "dependents": [
+        "ino-fab-set"
+      ],
+      "dependencies": [
+        "ino-tooltip",
+        "ino-icon"
+      ],
+      "dependencyGraph": {
+        "ino-fab": [
+          "ino-tooltip",
+          "ino-icon"
+        ],
+        "ino-fab-set": [
+          "ino-fab"
+        ]
+      },
       "props": [
         {
           "name": "disabled",
@@ -2439,13 +2466,6 @@
       ],
       "methods": [],
       "events": [],
-      "listeners": [
-        {
-          "event": "click",
-          "capture": false,
-          "passive": false
-        }
-      ],
       "styles": [
         {
           "name": "--fab-background-color",
@@ -2495,28 +2515,20 @@
         }
       ],
       "parts": [],
-      "dependents": [
-        "ino-fab-set"
-      ],
-      "dependencies": [
-        "ino-tooltip",
-        "ino-icon"
-      ],
-      "dependencyGraph": {
-        "ino-fab": [
-          "ino-tooltip",
-          "ino-icon"
-        ],
-        "ino-fab-set": [
-          "ino-fab"
-        ]
-      }
+      "listeners": [
+        {
+          "event": "click",
+          "capture": false,
+          "passive": false
+        }
+      ]
     },
     {
       "filePath": "./src/components/ino-fab-set/ino-fab-set.tsx",
-      "encapsulation": "shadow",
+      "fileName": "ino-fab-set.tsx",
       "tag": "ino-fab-set",
       "readme": "# ino-fab-set\n\nThe ino-fab-set component serves as a container for multiple fab buttons. It contains actions related to the main fab\nbutton. Upon interacting with the fab button, a FAB-Set can display three to six related actions in the form of a speed\ndial.\n\n### Usage\n\nThe component can be used as follows:\n\n```html\n\n<ino-fab-set\n  top-bottom-location=\"<string>\"\n  left-right-location=\"<string>\"\n  dial-direction=\"<string>\"\n  open-dial\n>\n  <ino-fab ...></ino-fab>\n  <ino-fab ...></ino-fab>\n  ...\n</ino-fab-set>\n```\n\n### React\n\n#### Example #1 - Basic\n\n```js\nimport { Component } from 'react';\nimport { InoFab, InoFabSet } from '@inovex.de/elements/dist/react';\n\nclass MyComponent extends Component {\n  state = {\n    open: false,\n  };\n\n  handleClick = (e: any) => {\n    alert(`Fab-Set was clicked`);\n    this.setState({ open: !this.state.open });\n  };\n\n  render() {\n    return (\n      <FabSet\n        openDial={this.state.open}\n        dialDirection=\"top\"\n        onClick={handleClick}\n      >\n        <InoFab mini label=\"Profile\" icon=\"person\"/>\n        <InoFab mini label=\"Search\" icon=\"search\"/>\n        <InoFab mini label=\"Help\" icon=\"help\"/>\n      </FabSet>\n    );\n  }\n}\n```\n\n#### Example #2 - With Types\n\n```js\nimport React, { Component } from 'react';\nimport { InoFab, InoFabSet } from '@inovex.de/elements/dist/react';\nimport { Components } from '@inovex.de/elements/dist/types/components';\n\nconst FabSet: React.FunctionComponent<Components.InoFabSetAttributes> = (\n  props,\n) => {\n  const { dialDirection } = props;\n\n  return (\n    <InoFabSet dialDirection={dialDirection}>{props.children}</InoFabSet>\n  );\n};\n\nclass MyComponent extends Component {\n  render() {\n    return (\n      <FabSet dialDirection=\"top\">\n        <InoFab mini label=\"Profile\" icon=\"person\"/>\n        <InoFab mini label=\"Search\" icon=\"search\"/>\n        <InoFab mini label=\"Help\" icon=\"help\"/>\n      </FabSet>\n    );\n  }\n}\n```\n\n## Additional Hints\n\n**Content**: Put the FABs for the speed dial inside of `ino-fab-set` as `ino-fab`.\n\n### Manage icons\n\n> **Note:** To use the provided icons in your consumer project, you need to copy all contents of\n> `node_modules/@inovex.de/elements/dist/inovex-elements/ino-icon` into your `dist/ino-icon` folder. All icons are expected\n> at runtime to be located in `ino-icon/`. Please refer to the Storybook documentation to get detailed instructions\n> on how to integrate the icons with Angular, React or plain JavaScript.\n\n## Control flow\n\nThe ino-fab-set has a controlled (unmanaged) attribute `openDial`. For this reason, listen to `click` events, sync to\nyour local state and pass the state to the component again to open/close the fab-set.\n",
+      "usage": {},
       "docs": "The ino-fab-set component serves as a container for multiple fab buttons. It contains actions related to the main fab\nbutton. Upon interacting with the fab button, a FAB-Set can display three to six related actions in the form of a speed\ndial.",
       "docsTags": [
         {
@@ -2524,7 +2536,22 @@
           "text": "default - One or more `ino-fab`"
         }
       ],
-      "usage": {},
+      "encapsulation": "shadow",
+      "dependents": [],
+      "dependencies": [
+        "ino-fab",
+        "ino-icon"
+      ],
+      "dependencyGraph": {
+        "ino-fab-set": [
+          "ino-fab",
+          "ino-icon"
+        ],
+        "ino-fab": [
+          "ino-tooltip",
+          "ino-icon"
+        ]
+      },
       "props": [
         {
           "name": "dialDirection",
@@ -2620,7 +2647,6 @@
       ],
       "methods": [],
       "events": [],
-      "listeners": [],
       "styles": [],
       "slots": [
         {
@@ -2629,27 +2655,14 @@
         }
       ],
       "parts": [],
-      "dependents": [],
-      "dependencies": [
-        "ino-fab",
-        "ino-icon"
-      ],
-      "dependencyGraph": {
-        "ino-fab-set": [
-          "ino-fab",
-          "ino-icon"
-        ],
-        "ino-fab": [
-          "ino-tooltip",
-          "ino-icon"
-        ]
-      }
+      "listeners": []
     },
     {
       "filePath": "./src/components/ino-form-row/ino-form-row.tsx",
-      "encapsulation": "none",
+      "fileName": "ino-form-row.tsx",
       "tag": "ino-form-row",
       "readme": "# ino-form-row\n\nA component that styles a form element as a row with a leading label.\n\n### Usage\n\nThe component can be used as follows:\n\n```html\n\n<ino-form-row label=\"<string>\" mandatory>\n  Any desired form element\n</ino-form-row>\n```\n\n### React\n\n#### Example #1 - Basic\n\n```jsx\nimport { Component } from 'react';\nimport { InoFormRow, InoInput } from '@inovex.de/elements/dist/react';\n\nclass MyComponent extends Component {\n  render() {\n    return (\n      <>\n        <InoFormRow label=\"This is a form row\" mandatory>\n          <InoInput></InoInput>\n        </InoFormRow>\n        <InoFormRow label=\"This is another form row\" mandatory>\n          <InoInput></InoInput>\n        </InoFormRow>\n        <InoFormRow label=\"This is one more form row without mandatory field\">\n          <InoInput></InoInput>\n        </InoFormRow>\n      </>\n    );\n  }\n}\n```\n\n#### Example #2 - With Types\n\n```jsx\nimport React, { Component } from 'react';\nimport { InoFormRow, InoInput } from '@inovex.de/elements/dist/react';\nimport { Components } from '@inovex.de/elements/dist/types/components';\n\nconst FormRow: React.FunctionComponent<Components.InoFormRowAttributes> = props => {\n  const { label, mandatory } = props;\n\n  return <InoFormRow label={label} mandatory={mandatory}>{props.children}</InoFormRow>\n};\n\nclass MyComponent extends Component {\n  render() {\n    return (\n      <>\n        <FormRow label=\"This is a form row\" mandatory>\n          <InoInput></InoInput>\n        </FormRow>\n        <FormRow label=\"This is another form row\" mandatory>\n          <InoInput></InoInput>\n        </FormRow>\n        <FormRow label=\"This is one more form row without mandatory field\">\n          <InoInput></InoInput>\n        </FormRow>\n      </>\n    )\n  }\n}\n```\n",
+      "usage": {},
       "docs": "A component that styles a form element as a row with a leading label.",
       "docsTags": [
         {
@@ -2657,7 +2670,10 @@
           "text": "default - Any element"
         }
       ],
-      "usage": {},
+      "encapsulation": "none",
+      "dependents": [],
+      "dependencies": [],
+      "dependencyGraph": {},
       "props": [
         {
           "name": "label",
@@ -2694,7 +2710,6 @@
       ],
       "methods": [],
       "events": [],
-      "listeners": [],
       "styles": [],
       "slots": [
         {
@@ -2703,18 +2718,20 @@
         }
       ],
       "parts": [],
-      "dependents": [],
-      "dependencies": [],
-      "dependencyGraph": {}
+      "listeners": []
     },
     {
       "filePath": "./src/components/ino-header/ino-header.tsx",
-      "encapsulation": "shadow",
+      "fileName": "ino-header.tsx",
       "tag": "ino-header",
       "readme": "# ino-header\n\nA header component with a separator.\n\n## Usage\n\nThe component can be used as follows:\n\n### Web Component\n\n```html\n<ino-header text=\"<string>\"></ino-header>\n```\n\n### React\n\n#### Example #1 - Basic\n\n```js\nimport { Component } from 'react';\nimport { InoHeader } from '@inovex.de/elements-react/';\n\nclass MyComponent extends Component {\n  render() {\n    return <InoHeader text=\"My awesome header!\"></InoHeader>;\n  }\n}\n```\n\n## Demo\n",
+      "usage": {},
       "docs": "A header component with a separator.",
       "docsTags": [],
-      "usage": {},
+      "encapsulation": "shadow",
+      "dependents": [],
+      "dependencies": [],
+      "dependencyGraph": {},
       "props": [
         {
           "name": "text",
@@ -2735,7 +2752,6 @@
       ],
       "methods": [],
       "events": [],
-      "listeners": [],
       "styles": [
         {
           "name": "--ino-header-box-color",
@@ -2750,18 +2766,74 @@
       ],
       "slots": [],
       "parts": [],
-      "dependents": [],
-      "dependencies": [],
-      "dependencyGraph": {}
+      "listeners": []
     },
     {
       "filePath": "./src/components/ino-icon/ino-icon.tsx",
-      "encapsulation": "shadow",
+      "fileName": "ino-icon.tsx",
       "tag": "ino-icon",
       "readme": "# ino-icon\n\nA light icon component for texts and other components.\n\n### Usage\n\nThe component can be used as follows:\n\n```js\ndocument.querySelector('ino-icon').addEventListener('clickEl', (e) => {\n  // ...\n});\n```\n\n```js\ndocument\n  .querySelector('ino-icon')\n  .addEventListener('clickEl', (_) => alert('The icon was clicked'));\n```\n\n```html\n<ino-icon icon=\"<string>\" clickable onclickel=\"handleClickEl()\">\n</ino-icon>\n```\n\n### React\n\n#### Example #1 - Basic\n\n```jsx\nimport { Component } from 'react';\nimport { InoIcon } from '@inovex.de/elements/dist/react';\n\nclass MyComponent extends Component {\n  handleClick = (e: any) => {\n    alert(`Icon was clicked`);\n  };\n\n  render() {\n    return <InoIcon icon=\"search\" clickable onClickEl={handleClick} />;\n  }\n}\n```\n\n#### Example #2 - With Types\n\n```jsx\nimport React, { Component } from 'react';\nimport { InoIcon } from '@inovex.de/elements/dist/react';\nimport { Components } from '@inovex.de/elements/dist/types/components';\n\nconst Icon: React.FunctionComponent<Components.InoIconAttributes> = (props) => {\n  const { icon } = props;\n\n  const handleClick = (e: any) => {\n    alert(`Icon was clicked`);\n  };\n\n  return (\n    <InoIcon icon={icon} onClickEl={handleClick}>\n      {props.children}\n    </InoIcon>\n  );\n};\n\nclass MyComponent extends Component {\n  render() {\n    return <Icon icon=\"search\" />;\n  }\n}\n```\n\n## Additional Hints\n\nThe component inherits styles, such as the text size, from the parent element. For custom styles, use the css properties of the component.\n\n**Clickable icon:** Make an icon interactive with the optional attribute `clickable`. Clickable icons emit a `clickEl` event.\n\n### Add icons\n\nIf you would like to add custom icons, you have to add them to the `src/assets/ino-icon` folder and execute the `yarn icon:integrate-icons`\ncommand to include the newly added icons in the `icons.js` file.\n\n> **Note:** To use the provided icons in your consumer project, you need to copy all contents of\n> `node_modules/@inovex.de/elements/dist/inovex-elements/ino-icon` into your `dist/ino-icon` folder. All icons are expected\n> to be located in `ino-icon/` at runtime. Please refer to the Storybook documentation to get detailed instructions\n> on how to integrate the icons with Angular, React or plain JavaScript.\n\nAlternatively, you can also just provide the URL to your preferred icon by setting the `src` property accordingly.\n",
+      "usage": {},
       "docs": "This component is based on the ionicons (https://github.com/ionic-team/ionicons)",
       "docsTags": [],
-      "usage": {},
+      "encapsulation": "shadow",
+      "dependents": [
+        "ino-card",
+        "ino-chip",
+        "ino-datepicker",
+        "ino-fab",
+        "ino-fab-set",
+        "ino-icon-button",
+        "ino-img",
+        "ino-input",
+        "ino-input-file",
+        "ino-markdown-editor",
+        "ino-snackbar",
+        "ino-tab",
+        "ino-table-header-cell"
+      ],
+      "dependencies": [],
+      "dependencyGraph": {
+        "ino-card": [
+          "ino-icon"
+        ],
+        "ino-chip": [
+          "ino-icon"
+        ],
+        "ino-datepicker": [
+          "ino-icon"
+        ],
+        "ino-fab": [
+          "ino-icon"
+        ],
+        "ino-fab-set": [
+          "ino-icon"
+        ],
+        "ino-icon-button": [
+          "ino-icon"
+        ],
+        "ino-img": [
+          "ino-icon"
+        ],
+        "ino-input": [
+          "ino-icon"
+        ],
+        "ino-input-file": [
+          "ino-icon"
+        ],
+        "ino-markdown-editor": [
+          "ino-icon"
+        ],
+        "ino-snackbar": [
+          "ino-icon"
+        ],
+        "ino-tab": [
+          "ino-icon"
+        ],
+        "ino-table-header-cell": [
+          "ino-icon"
+        ]
+      },
       "props": [
         {
           "name": "clickable",
@@ -2856,7 +2928,6 @@
           "docsTags": []
         }
       ],
-      "listeners": [],
       "styles": [
         {
           "name": "--ino-icon-color-primary",
@@ -2881,72 +2952,43 @@
       ],
       "slots": [],
       "parts": [],
-      "dependents": [
-        "ino-card",
-        "ino-chip",
-        "ino-datepicker",
-        "ino-fab",
-        "ino-fab-set",
-        "ino-icon-button",
-        "ino-img",
-        "ino-input",
-        "ino-input-file",
-        "ino-markdown-editor",
-        "ino-snackbar",
-        "ino-tab",
-        "ino-table-header-cell"
-      ],
-      "dependencies": [],
-      "dependencyGraph": {
-        "ino-card": [
-          "ino-icon"
-        ],
-        "ino-chip": [
-          "ino-icon"
-        ],
-        "ino-datepicker": [
-          "ino-icon"
-        ],
-        "ino-fab": [
-          "ino-icon"
-        ],
-        "ino-fab-set": [
-          "ino-icon"
-        ],
-        "ino-icon-button": [
-          "ino-icon"
-        ],
-        "ino-img": [
-          "ino-icon"
-        ],
-        "ino-input": [
-          "ino-icon"
-        ],
-        "ino-input-file": [
-          "ino-icon"
-        ],
-        "ino-markdown-editor": [
-          "ino-icon"
-        ],
-        "ino-snackbar": [
-          "ino-icon"
-        ],
-        "ino-tab": [
-          "ino-icon"
-        ],
-        "ino-table-header-cell": [
-          "ino-icon"
-        ]
-      }
+      "listeners": []
     },
     {
       "filePath": "./src/components/ino-icon-button/ino-icon-button.tsx",
-      "encapsulation": "none",
+      "fileName": "ino-icon-button.tsx",
       "tag": "ino-icon-button",
       "readme": "# ino-icon-button\n\nA rounded button component that contains an icon. It functions as a wrapper around the material [icon-button](https://github.com/material-components/material-components-web/tree/master/packages/mdc-icon-button) component.\n\n### Usage\n\nThe component can be used as follows:\n\n```js\ndocument\n  .querySelector('ino-icon-button')\n  .addEventListener('click', (_) => alert('The icon button was clicked'));\n```\n\n```html\n<ino-icon-button\n  autofocus\n  disabled\n  activated=\"<boolean>\"\n  icon=\"<string>\"\n>\n</ino-icon-button>\n```\n\n### React\n\n#### Example #1 - Basic\n\n```js\nimport { Component } from 'react';\nimport { InoIconButton } from '@inovex.de/elements/dist/react';\n\nclass MyComponent extends Component {\n  handleClick = (e: any) => {\n    alert(`IconButton was clicked`);\n  };\n\n  render() {\n    return <InoIconButton icon=\"search\" onClick={handleClick} />;\n  }\n}\n```\n\n#### Example #2 - With Types\n\n```js\nimport React, { Component } from 'react';\nimport { InoIconButton } from '@inovex.de/elements/dist/react';\nimport { Components } from '@inovex.de/elements/dist/types/components';\n\nconst IconButton: React.FunctionComponent<Components.InoIconButtonAttributes> = (\n  props,\n) => {\n  const { inoIcon } = props;\n\n  const handleClick = (e: any) => {\n    alert(`IconButton was clicked`);\n  };\n\n  return (\n    <InoIconButton icon={inoIcon} onClick={handleClick}>\n      {props.children}\n    </InoIconButton>\n  );\n};\n\nclass MyComponent extends Component {\n  render() {\n    return <IconButton icon=\"search\" />;\n  }\n}\n```\n\n## Managed Icon Button\n\nButtons, and icon buttons as well, are unmanaged components which swap their state internally based on the interactions. However, in some cases, it may be useful to change this behavior and provide an external state.\n\nThis can be done by using the `activated` flag and further listing to the `click` event to change the state. _Example:_\n\n```js\nactivated = false;\n\ndocument.querySelector('ino-icon-button').addEventListener('click', (e) => {\n  const el = e.target;\n  activated = !activated;\n  activated\n    ? el.addAttribute('activated')\n    : el.removeAttribute('activated');\n});\n```\n\n```html\n<ino-icon-button icon=\"info\"></ino-icon-button>\n```\n\n## Additional Hints\n\n**Toggle Button**: To use the ino-icon-button as a toggle button the user can listen to the native `click`-Event and change the icon in the `icon`-Attribute.\n\n### Native Events\n\nThe component bubbles the native `click`-Event to the user.\n",
+      "usage": {},
       "docs": "A rounded button component that contains an icon. It functions as a wrapper around the material [icon-button](https://github.com/material-components/material-components-web/tree/master/packages/mdc-icon-button) component.",
       "docsTags": [],
-      "usage": {},
+      "encapsulation": "none",
+      "dependents": [
+        "ino-carousel",
+        "ino-nav-drawer",
+        "ino-snackbar",
+        "ino-table-header-cell"
+      ],
+      "dependencies": [
+        "ino-icon"
+      ],
+      "dependencyGraph": {
+        "ino-icon-button": [
+          "ino-icon"
+        ],
+        "ino-carousel": [
+          "ino-icon-button"
+        ],
+        "ino-nav-drawer": [
+          "ino-icon-button"
+        ],
+        "ino-snackbar": [
+          "ino-icon-button"
+        ],
+        "ino-table-header-cell": [
+          "ino-icon-button"
+        ]
+      },
       "props": [
         {
           "name": "activated",
@@ -3109,13 +3151,6 @@
           "docsTags": []
         }
       ],
-      "listeners": [
-        {
-          "event": "click",
-          "capture": false,
-          "passive": false
-        }
-      ],
       "styles": [
         {
           "name": "--ino-icon-button-background-active-color",
@@ -3150,41 +3185,32 @@
       ],
       "slots": [],
       "parts": [],
-      "dependents": [
-        "ino-carousel",
-        "ino-nav-drawer",
-        "ino-snackbar",
-        "ino-table-header-cell"
-      ],
+      "listeners": [
+        {
+          "event": "click",
+          "capture": false,
+          "passive": false
+        }
+      ]
+    },
+    {
+      "filePath": "./src/components/ino-img/ino-img.tsx",
+      "fileName": "ino-img.tsx",
+      "tag": "ino-img",
+      "readme": "# ino-img\n\nAn image component with different styles that reserves a predefined space to avoid jumping contents.\n\n### Usage\n\nThe component can be used as follows (custom preferences have an `ino`-prefix):\n\n```js\ndocument\n  .querySelector('ino-img')\n  .addEventListener('click', (_) => alert('The image was clicked'));\n```\n\n```html\n<ino-img\n  alt=\"<string>\"\n  decoding=\"<string>\"\n  width=\"<number>\"\n  height=\"<number>\"\n  sizes=\"<string>\"\n  src=\"<string>\"\n  srcset=\"<string>\"\n  usemap=\"<string>\"\n  ratio-height=\"<number>\"\n  ratio-width=\"<number>\"\n  rounded\n>\n</ino-img>\n```\n\n### React\n\n#### Example #1 - Basic\n\n```js\nimport { Component } from 'react';\nimport { InoImg } from '@inovex.de/elements/dist/react';\n\nclass MyComponent extends Component {\n  render() {\n    return (\n      <InoImg\n        height={100}\n        width={100}\n        src=\"https://cdn-images-1.medium.com/max/1600/1*HP8l7LMMt7Sh5UoO1T-yLQ.png\"\n      />\n    );\n  }\n}\n```\n\n#### Example #2 - With Types\n\n```js\nimport React, { Component } from 'react';\nimport { InoImg } from '@inovex.de/elements/dist/react';\nimport { Components } from '@inovex.de/elements/dist/types/components';\n\nconst Img: React.FunctionComponent<Components.InoImgAttributes> = (props) => {\n  const { height, width, src } = props;\n\n  return (\n    <InoImg height={height} width={width} src={src}>\n      {props.children}\n    </InoImg>\n  );\n};\n\nclass MyComponent extends Component {\n  render() {\n    return (\n      <Img\n        height={100}\n        width={100}\n        src=\"https://cdn-images-1.medium.com/max/1600/1*HP8l7LMMt7Sh5UoO1T-yLQ.png\"\n      />\n    );\n  }\n}\n```\n\n## Additional Hints\n\nIf the attribute `rounded` is true, the image is displayed with rounded corners.\n\n### Pre-defined ratios\n\nThe image component has two attributes `ratio-height` and `ratio-width`. Use them to define any desired ratio and avoid content jumping!\n\nExample: If the image `image.png` has a ratio of `16:9`, define the image component as follows:\n\n```html\n<ino-img src=\"image.png\" ratio-width=\"16\" ratio-height=\"9\"></ino-img>\n```\n\nUsing this setup, the width of the element extends to 100% (or the value defined in `width` attribute) and the computed height is based on the ratio attributes.\n",
+      "usage": {},
+      "docs": "An image component with different styles that reserves a predefined space to avoid jumping contents.",
+      "docsTags": [],
+      "encapsulation": "none",
+      "dependents": [],
       "dependencies": [
         "ino-icon"
       ],
       "dependencyGraph": {
-        "ino-icon-button": [
+        "ino-img": [
           "ino-icon"
-        ],
-        "ino-carousel": [
-          "ino-icon-button"
-        ],
-        "ino-nav-drawer": [
-          "ino-icon-button"
-        ],
-        "ino-snackbar": [
-          "ino-icon-button"
-        ],
-        "ino-table-header-cell": [
-          "ino-icon-button"
         ]
-      }
-    },
-    {
-      "filePath": "./src/components/ino-img/ino-img.tsx",
-      "encapsulation": "none",
-      "tag": "ino-img",
-      "readme": "# ino-img\n\nAn image component with different styles that reserves a predefined space to avoid jumping contents.\n\n### Usage\n\nThe component can be used as follows (custom preferences have an `ino`-prefix):\n\n```js\ndocument\n  .querySelector('ino-img')\n  .addEventListener('click', (_) => alert('The image was clicked'));\n```\n\n```html\n<ino-img\n  alt=\"<string>\"\n  decoding=\"<string>\"\n  width=\"<number>\"\n  height=\"<number>\"\n  sizes=\"<string>\"\n  src=\"<string>\"\n  srcset=\"<string>\"\n  usemap=\"<string>\"\n  ratio-height=\"<number>\"\n  ratio-width=\"<number>\"\n  rounded\n>\n</ino-img>\n```\n\n### React\n\n#### Example #1 - Basic\n\n```js\nimport { Component } from 'react';\nimport { InoImg } from '@inovex.de/elements/dist/react';\n\nclass MyComponent extends Component {\n  render() {\n    return (\n      <InoImg\n        height={100}\n        width={100}\n        src=\"https://cdn-images-1.medium.com/max/1600/1*HP8l7LMMt7Sh5UoO1T-yLQ.png\"\n      />\n    );\n  }\n}\n```\n\n#### Example #2 - With Types\n\n```js\nimport React, { Component } from 'react';\nimport { InoImg } from '@inovex.de/elements/dist/react';\nimport { Components } from '@inovex.de/elements/dist/types/components';\n\nconst Img: React.FunctionComponent<Components.InoImgAttributes> = (props) => {\n  const { height, width, src } = props;\n\n  return (\n    <InoImg height={height} width={width} src={src}>\n      {props.children}\n    </InoImg>\n  );\n};\n\nclass MyComponent extends Component {\n  render() {\n    return (\n      <Img\n        height={100}\n        width={100}\n        src=\"https://cdn-images-1.medium.com/max/1600/1*HP8l7LMMt7Sh5UoO1T-yLQ.png\"\n      />\n    );\n  }\n}\n```\n\n## Additional Hints\n\nIf the attribute `rounded` is true, the image is displayed with rounded corners.\n\n### Pre-defined ratios\n\nThe image component has two attributes `ratio-height` and `ratio-width`. Use them to define any desired ratio and avoid content jumping!\n\nExample: If the image `image.png` has a ratio of `16:9`, define the image component as follows:\n\n```html\n<ino-img src=\"image.png\" ratio-width=\"16\" ratio-height=\"9\"></ino-img>\n```\n\nUsing this setup, the width of the element extends to 100% (or the value defined in `width` attribute) and the computed height is based on the ratio attributes.\n",
-      "docs": "An image component with different styles that reserves a predefined space to avoid jumping contents.",
-      "docsTags": [],
-      "usage": {},
+      },
       "props": [
         {
           "name": "alt",
@@ -3426,25 +3452,17 @@
       ],
       "methods": [],
       "events": [],
-      "listeners": [],
       "styles": [],
       "slots": [],
       "parts": [],
-      "dependents": [],
-      "dependencies": [
-        "ino-icon"
-      ],
-      "dependencyGraph": {
-        "ino-img": [
-          "ino-icon"
-        ]
-      }
+      "listeners": []
     },
     {
       "filePath": "./src/components/ino-img-list/ino-img-list.tsx",
-      "encapsulation": "none",
+      "fileName": "ino-img-list.tsx",
       "tag": "ino-img-list",
       "readme": "# ino-img-list\n\nThe ino-img-list component is used in combination with the ino-img component to display an array of images\nin a grid-like format. It is based on the mdc-image-list component.\n\n## Usage\n\nThe component can be used as follows:\n\n```html\n<ino-img-list enclose-label masonry>\n  <ino-img\n    src=\"url/to/image\"\n    label=\"optional label\"\n    img-list-item\n  ></ino-img>\n</ino-img-list>\n```\n\n## React\n\n```jsx\nimport React from 'react';\nimport { Component } from 'react';\nimport { InoImgList, InoImg } from '@inovex.de/elements/dist/react';\n\nclass MyComponent extends Component {\n  state = {\n    source: 'url/to/img',\n    encloseLabel: true,\n  };\n\n  render() {\n    return (\n      <InoImgList encloseLabel={this.state.encloseLabel}>\n        <InoImg src={this.state.source} img-list-item></InoImg>\n      </InoImgList>\n    );\n  }\n}\n```\n",
+      "usage": {},
       "docs": "The ino-img-list component is used in combination with the ino-img component to display an array of images\nin a grid-like format. It is based on the mdc-image-list component.",
       "docsTags": [
         {
@@ -3452,7 +3470,10 @@
           "text": "default - One or more `ino-img` with `imgListItem=\"true\"`"
         }
       ],
-      "usage": {},
+      "encapsulation": "none",
+      "dependents": [],
+      "dependencies": [],
+      "dependencyGraph": {},
       "props": [
         {
           "name": "encloseLabel",
@@ -3491,7 +3512,6 @@
       ],
       "methods": [],
       "events": [],
-      "listeners": [],
       "styles": [
         {
           "name": "--ino-img-list-cols",
@@ -3506,15 +3526,14 @@
         }
       ],
       "parts": [],
-      "dependents": [],
-      "dependencies": [],
-      "dependencyGraph": {}
+      "listeners": []
     },
     {
       "filePath": "./src/components/ino-input/ino-input.tsx",
-      "encapsulation": "none",
+      "fileName": "ino-input.tsx",
       "tag": "ino-input",
       "readme": "# ino-input\n\nAn input component with styles. It functions as a wrapper around the material [textfield](https://github.com/material-components/material-components-web/tree/master/packages/mdc-textfield) component.\n\nUse this element for **simple types** like `text`, `password`, `number` or `email`. For more complex types, there are elements like a [Radio Button](../ino-radio), a [Checkbox](../ino-checkbox), a [Datepicker](../ino-datepicker) and many more.\n\n### Usage\n\nThe component can be used as follows:\n\n```js\ndocument\n  .querySelector('ino-input')\n  .addEventListener('valueChange', (e) =>\n    alert(`The new input value is: ${e.detail}`),\n  );\n```\n\n```html\n<ino-input\n  autocomplete=\"<string>\"\n  autofocus\n  disabled\n  min=\"<string>\"\n  max=\"<string>\"\n  step=\"<number>\"\n  name=\"<string>\"\n  pattern=\"<string>\"\n  placeholder=\"<string>\"\n  required\n  size=\"<number>\"\n  type=\"<string>\"\n  value=\"<string>\"\n  error\n  outline\n  label=\"<string>\"\n  helper=\"<string>\"\n  helper-persistent\n  helper-validation\n  data-list=\"<string>\"\n>\n  <datalist id=\"<string>\">\n    <option>...</option>\n  </datalist>\n  <ino-icon slot=\"icon-leading\" icon=\"...\"></ino-icon>\n  <ino-icon slot=\"icon-trailing\" icon=\"...\"></ino-icon>\n</ino-input>\n```\n\n### React\n\n#### Example #1 - Basic\n\n```js\nimport { Component } from 'react';\nimport { InoInput } from '@inovex.de/elements/dist/react';\n\nclass MyComponent extends Component {\n  onValueChange(e: any) {\n    alert(`The new value is ${e.detail}`);\n  }\n\n  render() {\n    return (\n      <InoInput\n        placeholder=\"You can insert some text...\"\n        onValueChange={onValueChange}\n      />\n    );\n  }\n}\n```\n\n#### Example #2 - With Types\n\n```js\nimport React, { Component } from 'react';\nimport { InoInput } from '@inovex.de/elements/dist/react';\nimport { Components } from '@inovex.de/elements/dist/types/components';\n\nconst Input: React.FunctionComponent<Components.InoInputAttributes> = (\n  props,\n) => {\n  const onValueChange = (e: any) => {\n    alert(`The new value is ${e.detail}`);\n  };\n\n  return (\n    <InoInput\n      placeholder=\"You can insert some text...\"\n      onValueChange={onValueChange}\n    />\n  );\n};\n\nclass MyComponent extends Component {\n  render() {\n    return <Input placeholder=\"You can insert some text...\" />;\n  }\n}\n```\n\n## Additional Hints\n\n**Outlined**: The component is by default a box component with ripple underline. Provide `outline` to use the material outline design.\n\n**Labels**: The component shows a floating label containing the value of `label`.\n\n**Helper Text**: The component shows an optional helper text underneath the input field (`helper`). By default, the helper text will be visible as soon as the user focuses on the input field. Set `helper-persistent` to show it all the time. Furthermore, use `helper-validation` to style the helper text as validation message.\n\n**Icons**: There are currently two options two place an icon: at the start/left (`icon-leading`) or at the end/right (`icon-trailing`). To specify an icon, use either the `ino-icon`-Component (preferred) or use an icon of your choice and place it inside the `ino-input`-Element. Additionally, you have to provide either `slot=\"icon-leading\"` or `slot=\"icon-trailing\"`to your icon element.\n\n**Datalist**: Provide the id of the datalist child and a list with possible selectable values will be displayed and filtered with every keystroke. See [datalist](https://developer.mozilla.org/de/docs/Web/HTML/Element/datalist) for more information.\n\n### Control flow\n\nThe input has a controlled (unmanaged) attribute `value`. For this reason, the value doesn't change on user interaction but on updates of `value`. Listen to `valueChange`, sync it with your local state and pass the new value to the component again to change value of input.\n\n```js\ndocument.querySelector('ino-input').addEventListener('valueChange', (e) => {\n  // ...\n});\n```\n\n```html\n<ino-input value=\"Here's some text\"></ino-input>\n```\n\n### Event Behaviour\n\nThe component is based on a native input with additional features. Thus, the component bubbles events triggered by the native [HTMLInputElement](https://developer.mozilla.org/en-US/docs/Web/API/HTMLInputElement) like `keyup`. The native `input` and `change` event is not bubbled because the value will only change when the value attribute changes.\n",
+      "usage": {},
       "docs": "An input component with styles. It functions as a wrapper around the material [textfield](https://github.com/material-components/material-components-web/tree/master/packages/mdc-textfield) component.\n\nUse this element for **simple types** like `text`, `password`, `number` or `email`. For more complex types, there are elements like a [Radio Button](../ino-radio), a [Checkbox](../ino-checkbox), a [Datepicker](../ino-datepicker) and many more.",
       "docsTags": [
         {
@@ -3526,7 +3545,23 @@
           "text": "icon-trailing - For the icon to be appended"
         }
       ],
-      "usage": {},
+      "encapsulation": "none",
+      "dependents": [
+        "ino-datepicker"
+      ],
+      "dependencies": [
+        "ino-label",
+        "ino-icon"
+      ],
+      "dependencyGraph": {
+        "ino-input": [
+          "ino-label",
+          "ino-icon"
+        ],
+        "ino-datepicker": [
+          "ino-input"
+        ]
+      },
       "props": [
         {
           "name": "autoFocus",
@@ -4017,23 +4052,6 @@
           "docsTags": []
         }
       ],
-      "listeners": [
-        {
-          "event": "change",
-          "capture": false,
-          "passive": false
-        },
-        {
-          "event": "focus",
-          "capture": false,
-          "passive": false
-        },
-        {
-          "event": "input",
-          "capture": false,
-          "passive": false
-        }
-      ],
       "styles": [
         {
           "name": "--ino-input-caret-color",
@@ -4067,31 +4085,47 @@
         }
       ],
       "parts": [],
-      "dependents": [
-        "ino-datepicker"
-      ],
-      "dependencies": [
-        "ino-label",
-        "ino-icon"
-      ],
-      "dependencyGraph": {
-        "ino-input": [
-          "ino-label",
-          "ino-icon"
-        ],
-        "ino-datepicker": [
-          "ino-input"
-        ]
-      }
+      "listeners": [
+        {
+          "event": "change",
+          "capture": false,
+          "passive": false
+        },
+        {
+          "event": "focus",
+          "capture": false,
+          "passive": false
+        },
+        {
+          "event": "input",
+          "capture": false,
+          "passive": false
+        }
+      ]
     },
     {
       "filePath": "./src/components/ino-input-file/ino-input-file.tsx",
-      "encapsulation": "none",
+      "fileName": "ino-input-file.tsx",
       "tag": "ino-input-file",
       "readme": "# ino-input-file\n\nAn input component for files. It functions as a wrapper around the native input capabilities having the [`type=\"file\"`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/file).\n\nThis component replaces the native behaviour with a custom `ino-button` with logic.\n\n### Usage\n\nThe component can be used as follows:\n\n```js\ndocument\n  .querySelector('ino-input-file')\n  .addEventListener('changeFile', (e) => alert(`The new file is: ${e.detail}`));\n```\n\n```html\n<ino-input-file\n  accept=\"<string>\"\n  autofocus\n  disabled\n  multiple\n  name=\"<string>\"\n  required\n\n  label=\"<string>\"\n>\n</ino-input>\n```\n\n### React\n\n#### Example #1 - Basic\n\n```js\nimport { Component } from 'react';\nimport { InoInputFile } from '@inovex.de/elements/dist/react';\n\nclass MyComponent extends Component {\n  onChangeFile(e) {\n    const fileNames = e.detail.files\n      .map((f) => [f.name, f.type, f.size + ' bytes'].join(', '))\n      .join('\\n');\n    alert(fileNames);\n  }\n\n  render() {\n    return <InoInputFile onChangeFile={this.onChangeFile} />;\n  }\n}\n```\n\n#### Example #2 - With Types\n\n```js\nimport React, { Component } from 'react';\nimport { InoInputFile } from '@inovex.de/elements/dist/react';\nimport { Components } from '@inovex.de/elements/dist/types/components';\n\nconst FileInput: React.FunctionComponent<Components.InoInputFile> = (props) => {\n  const onFileChange = (e: any) => {\n    alert(`The new file is: ${e.detail}`);\n  };\n\n  return <InoInputFile onFileChange={onFileChange} />;\n};\n\nclass MyComponent extends Component {\n  render() {\n    return <FileInput />;\n  }\n}\n```\n\n## Additional Hints\n",
+      "usage": {},
       "docs": "An input component for files. It functions as a wrapper around the native input capabilities having the [`type=\"file\"`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/file).\n\nThis component replaces the native behaviour with a custom `ino-button` with logic.",
       "docsTags": [],
-      "usage": {},
+      "encapsulation": "none",
+      "dependents": [],
+      "dependencies": [
+        "ino-button",
+        "ino-icon"
+      ],
+      "dependencyGraph": {
+        "ino-input-file": [
+          "ino-button",
+          "ino-icon"
+        ],
+        "ino-button": [
+          "ino-spinner"
+        ]
+      },
       "props": [
         {
           "name": "accept",
@@ -4270,7 +4304,6 @@
           "docsTags": []
         }
       ],
-      "listeners": [],
       "styles": [
         {
           "name": "--ino-input-file-box-height",
@@ -4285,29 +4318,34 @@
       ],
       "slots": [],
       "parts": [],
-      "dependents": [],
-      "dependencies": [
-        "ino-button",
-        "ino-icon"
-      ],
-      "dependencyGraph": {
-        "ino-input-file": [
-          "ino-button",
-          "ino-icon"
-        ],
-        "ino-button": [
-          "ino-spinner"
-        ]
-      }
+      "listeners": []
     },
     {
       "filePath": "./src/components/ino-label/ino-label.tsx",
-      "encapsulation": "none",
+      "fileName": "ino-label.tsx",
       "tag": "ino-label",
       "readme": "# ino-label\n\nThis is an internally used component for various sorts of inputs like `ino-input`, `ino-select` and `ino-textarea`. It is used to display the label for each respective component.\n\n```html\n<ino-label\n  outline=\"<boolean>\"\n  label=\"<string>\"\n  required=\"<boolean>\"\n  disabled=\"<boolean>\"\n>\n</ino-label>\n```\n",
+      "usage": {},
       "docs": "This is an internally used component for various sorts of inputs like `ino-input`, `ino-select` and `ino-textarea`. It is used to display the label for each respective component.\n\n```html\n<ino-label\n  outline=\"<boolean>\"\n  label=\"<string>\"\n  required=\"<boolean>\"\n  disabled=\"<boolean>\"\n>\n</ino-label>\n```",
       "docsTags": [],
-      "usage": {},
+      "encapsulation": "none",
+      "dependents": [
+        "ino-input",
+        "ino-select",
+        "ino-textarea"
+      ],
+      "dependencies": [],
+      "dependencyGraph": {
+        "ino-input": [
+          "ino-label"
+        ],
+        "ino-select": [
+          "ino-label"
+        ],
+        "ino-textarea": [
+          "ino-label"
+        ]
+      },
       "props": [
         {
           "name": "disabled",
@@ -4392,33 +4430,17 @@
       ],
       "methods": [],
       "events": [],
-      "listeners": [],
       "styles": [],
       "slots": [],
       "parts": [],
-      "dependents": [
-        "ino-input",
-        "ino-select",
-        "ino-textarea"
-      ],
-      "dependencies": [],
-      "dependencyGraph": {
-        "ino-input": [
-          "ino-label"
-        ],
-        "ino-select": [
-          "ino-label"
-        ],
-        "ino-textarea": [
-          "ino-label"
-        ]
-      }
+      "listeners": []
     },
     {
       "filePath": "./src/components/ino-list/ino-list.tsx",
-      "encapsulation": "none",
+      "fileName": "ino-list.tsx",
       "tag": "ino-list",
       "readme": "# ino-list\n\nA component that displays a list of choices. It functions as a wrapper around the material [list](https://github.com/material-components/material-components-web/blob/master/packages/mdc-list/) component.\n\nThis component is a composer to configure and wrap `list-item`s, `list-divider`s, `control-item`s and `nav-item`s.\n\n### Usage\n\nThe component can be used as follows:\n\n```html\n<ino-list dense two-lines>\n  <ino-list-item ...></ino-list-item>\n  <ino-list-divider></ino-list-divider>\n  <ino-control-item ...></ino-control-item>\n  <ino-nav-item ...></ino-nav-item>\n</ino-list>\n```\n\n### React\n\n#### Example #1 - Basic\n\n```js\nimport { Component } from 'react';\nimport { InoListItem, InoList, InoImg } from '@inovex.de/elements/dist/react';\n\nclass MyComponent extends Component {\n  render() {\n    return (\n      <InoList avatar>\n        <InoListItem text=\"First text item\">\n          <InoImg\n            slot=\"leading\"\n            src=\"https://cdn-images-1.medium.com/max/1600/1*HP8l7LMMt7Sh5UoO1T-yLQ.png\"\n            ratio-width=\"1\"\n            ratio-height=\"1\"\n          />\n        </InoListItem>\n        <InoListItem text=\"Second text item\">\n          <InoImg\n            slot=\"leading\"\n            src=\"https://cdn-images-1.medium.com/max/1600/1*HP8l7LMMt7Sh5UoO1T-yLQ.png\"\n            ratio-width=\"1\"\n            ratio-height=\"1\"\n          />\n        </InoListItem>\n      </InoList>\n    );\n  }\n}\n```\n\n#### Example #2 - With Types\n\n```js\nimport React, { Component } from 'react';\nimport { InoListItem, InoList, InoImg } from '@inovex.de/elements/dist/react';\nimport { Components } from '@inovex.de/elements/dist/types/components';\n\nconst List: React.FunctionComponent<Components.InoListAttributes> = (props) => {\n  const { avatar } = props;\n\n  return <InoList avatar={avatar}>{props.children}</InoList>;\n};\n\nclass MyComponent extends Component {\n  render() {\n    return (\n      <List avatar>\n        <InoListItem text=\"First text item\">\n          <InoImg\n            slot=\"leading\"\n            src=\"https://cdn-images-1.medium.com/max/1600/1*HP8l7LMMt7Sh5UoO1T-yLQ.png\"\n            ratio-width=\"1\"\n            ratio-height=\"1\"\n          />\n        </InoListItem>\n        <InoListItem text=\"Second text item\">\n          <InoImg\n            slot=\"leading\"\n            src=\"https://cdn-images-1.medium.com/max/1600/1*HP8l7LMMt7Sh5UoO1T-yLQ.png\"\n            ratio-width=\"1\"\n            ratio-height=\"1\"\n          />\n        </InoListItem>\n      </List>\n    );\n  }\n}\n```\n\n## Additional Hints\n\nProvide `two-lines` to set proper style attributes for list items having a primary and secondary line.\n",
+      "usage": {},
       "docs": "A component that displays a list of choices. It functions as a wrapper around the material [list](https://github.com/material-components/material-components-web/blob/master/packages/mdc-list/) component.\n\nThis component is a composer to configure and wrap `list-item`s, `list-divider`s, `control-item`s and `nav-item`s.",
       "docsTags": [
         {
@@ -4426,7 +4448,16 @@
           "text": "default - One or more `ino-(control|list|nav)-item` and `ino-list-divider`"
         }
       ],
-      "usage": {},
+      "encapsulation": "none",
+      "dependents": [
+        "ino-menu"
+      ],
+      "dependencies": [],
+      "dependencyGraph": {
+        "ino-menu": [
+          "ino-list"
+        ]
+      },
       "props": [
         {
           "name": "avatar",
@@ -4480,7 +4511,6 @@
       ],
       "methods": [],
       "events": [],
-      "listeners": [],
       "styles": [
         {
           "name": "--ino-list-item-border-radius",
@@ -4495,24 +4525,20 @@
         }
       ],
       "parts": [],
-      "dependents": [
-        "ino-menu"
-      ],
-      "dependencies": [],
-      "dependencyGraph": {
-        "ino-menu": [
-          "ino-list"
-        ]
-      }
+      "listeners": []
     },
     {
       "filePath": "./src/components/ino-list-divider/ino-list-divider.tsx",
-      "encapsulation": "none",
+      "fileName": "ino-list-divider.tsx",
       "tag": "ino-list-divider",
       "readme": "# ino-list-divider\n\nA list divider component that either divides two lists or list items. It functions as a wrapper around the material [list divider](https://github.com/material-components/material-components-web/blob/master/packages/mdc-divider/) capabilities.\n\nThis component is used as child of `ino-list` and `ino-menu` components.\n\n### Usage\n\nThe component can be used as follows:\n\n```html\n<ino-list-divder\n  between-lists\n  inset\n  padded\n>\n</ino-list-divider>\n```\n\n**Divide lists:** By default, a `ino-list-divider` sepeartes two `list-item` components. To split `ino-list` component itself, provide `between-lists` (only available for `ino-list`).\n",
+      "usage": {},
       "docs": "A list divider component that either divides two lists or list items. It functions as a wrapper around the material [list divider](https://github.com/material-components/material-components-web/blob/master/packages/mdc-divider/) capabilities.\n\nThis component is used as child of `ino-list` and `ino-menu` components.",
       "docsTags": [],
-      "usage": {},
+      "encapsulation": "none",
+      "dependents": [],
+      "dependencies": [],
+      "dependencyGraph": {},
       "props": [
         {
           "name": "betweenLists",
@@ -4565,19 +4591,17 @@
       ],
       "methods": [],
       "events": [],
-      "listeners": [],
       "styles": [],
       "slots": [],
       "parts": [],
-      "dependents": [],
-      "dependencies": [],
-      "dependencyGraph": {}
+      "listeners": []
     },
     {
       "filePath": "./src/components/ino-list-item/ino-list-item.tsx",
-      "encapsulation": "none",
+      "fileName": "ino-list-item.tsx",
       "tag": "ino-list-item",
       "readme": "# ino-list-item\n\nA list item component that displays a single instance of choice in a list or menu. It functions as a wrapper around the material [list item](https://github.com/material-components/material-components-web/blob/master/packages/mdc-list/) capabilities.\n\nThis component is used as child of `ino-list` and `ino-menu` components.\n\n### Usage\n\nThe component can be used as follows:\n\n```js\ndocument\n  .querySelector('ino-list-item')\n  .addEventListener('clickEl', (e) =>\n    console.log(\n      'The new list-item was clicked, the element itself is:',\n      e.detail,\n    ),\n  );\n```\n\n```html\n<ino-list-item\n  activated\n  text=\"<string>\"\n  secondary-text=\"<string>\"\n  selected\n  onclickel=\"handleClickEl()\"\n>\n  <ino-icon slot=\"leading\" ...></ino-icon>\n  <a slot=\"primary\" href=\"www.inovex.de\">...</a>\n  <ino-icon slot=\"trailing\" ...></ino-icon>\n</ino-list-item>\n```\n\n**Ino Primary/Secondary (slot):** If you want to use different elements instead of text, you can use the `primary` or `secondary` slot. To do so, just set the `slot`-attribute of your custom element to `primary` or `secondary`.\n\n**Two lines:** For items having two lines, provide an `secondary-text` and make sure you set the `two-lines` attribute in the respective parent component (only available for `ino-list`).\n\n**Leading items:** Add an item with the slot-attribute `leading` to add a leading column to the list item in LTR languages. Typically, an icon or image.\n\n**Trailing items:** Add an item with the slot-attribute `trailing` to add a trailing column to the list item in LTR languages. Typically, small text, icon or image.\n",
+      "usage": {},
       "docs": "A list item component that displays a single instance of choice in a list or menu. It functions as a wrapper around the material [list item](https://github.com/material-components/material-components-web/blob/master/packages/mdc-list/) capabilities.\n\nThis component is used as child of `ino-list` and `ino-menu` components.",
       "docsTags": [
         {
@@ -4597,7 +4621,20 @@
           "text": "secondary - For the secondary text element in a two-lined list"
         }
       ],
-      "usage": {},
+      "encapsulation": "none",
+      "dependents": [
+        "ino-control-item",
+        "ino-nav-item"
+      ],
+      "dependencies": [],
+      "dependencyGraph": {
+        "ino-control-item": [
+          "ino-list-item"
+        ],
+        "ino-nav-item": [
+          "ino-list-item"
+        ]
+      },
       "props": [
         {
           "name": "activated",
@@ -4692,18 +4729,6 @@
           "docsTags": []
         }
       ],
-      "listeners": [
-        {
-          "event": "keydown",
-          "capture": false,
-          "passive": false
-        },
-        {
-          "event": "click",
-          "capture": false,
-          "passive": false
-        }
-      ],
       "styles": [
         {
           "name": "--ino-list-item-deselected-background-color",
@@ -4775,28 +4800,44 @@
         }
       ],
       "parts": [],
-      "dependents": [
-        "ino-control-item",
-        "ino-nav-item"
-      ],
-      "dependencies": [],
-      "dependencyGraph": {
-        "ino-control-item": [
-          "ino-list-item"
-        ],
-        "ino-nav-item": [
-          "ino-list-item"
-        ]
-      }
+      "listeners": [
+        {
+          "event": "keydown",
+          "capture": false,
+          "passive": false
+        },
+        {
+          "event": "click",
+          "capture": false,
+          "passive": false
+        }
+      ]
     },
     {
       "filePath": "./src/components/ino-markdown-editor/ino-markdown-editor.tsx",
-      "encapsulation": "none",
+      "fileName": "ino-markdown-editor.tsx",
       "tag": "ino-markdown-editor",
       "readme": "# ino-markdown-editor\n\n\n",
+      "usage": {},
       "docs": "The **Preview Mode** supports following actions:\n\n| Actions ||||\n|---|\n| Link | Blockquotes | Unordered list / Bullet list | Headline 1 |\n| Italic | Strikethrough | Ordered list / Numbered  list | Headline 2 |\n| Bold | Inline code |\n\nAdditionally, there are a lot of predefined\n[keyboard shortcuts](https://tiptap.dev/api/keyboard-shortcuts#predefined-keyboard-shortcuts)\nprovided by the underlying [tiptap](https://tiptap.dev/) editor.\n\nThe **Markdown Mode** supports all syntax of [CommonMark](https://commonmark.org/help/) with two exceptions:\n\n * Support of strikethrough syntax (`~~TextToStrike~~`)\n * No support of image syntax. __Images are not allowed!__",
       "docsTags": [],
-      "usage": {},
+      "encapsulation": "none",
+      "dependents": [],
+      "dependencies": [
+        "ino-icon",
+        "ino-popover",
+        "ino-textarea"
+      ],
+      "dependencyGraph": {
+        "ino-markdown-editor": [
+          "ino-icon",
+          "ino-popover",
+          "ino-textarea"
+        ],
+        "ino-textarea": [
+          "ino-label"
+        ]
+      },
       "props": [
         {
           "name": "initialValue",
@@ -4871,7 +4912,6 @@
           "docsTags": []
         }
       ],
-      "listeners": [],
       "styles": [
         {
           "name": "--ino-markdown-editor-max-height",
@@ -4886,28 +4926,14 @@
       ],
       "slots": [],
       "parts": [],
-      "dependents": [],
-      "dependencies": [
-        "ino-icon",
-        "ino-popover",
-        "ino-textarea"
-      ],
-      "dependencyGraph": {
-        "ino-markdown-editor": [
-          "ino-icon",
-          "ino-popover",
-          "ino-textarea"
-        ],
-        "ino-textarea": [
-          "ino-label"
-        ]
-      }
+      "listeners": []
     },
     {
       "filePath": "./src/components/ino-menu/ino-menu.tsx",
-      "encapsulation": "none",
+      "fileName": "ino-menu.tsx",
       "tag": "ino-menu",
       "readme": "# ino-menu\n\nA menu component that displays a list of choices on a temporary surface which opens and closes on anchor or item click.\nThe anchor element is the parent element.\n\nThe menu items consist of different variations of the `ino-list-item` component.\n\nIf you need a more customizable menu with a different type of elements or functionalities, have a look at the `ino-popover`.\n\n### Usage\n\nThe component can be used as follows:\n\n```html\n<ino-button>\n  <ino-menu>\n    <ino-list-item ...></ino-list-item>\n    <ino-list-divider></ino-list-divider>\n  </ino-menu>\n</ino-button>\n```\n\n### React\n\n#### Example #1 - Basic\n\n```jsx\nimport { Component } from 'react';\nimport {\n  InoButton,\n  InoMenu,\n  InoListItem,\n  InoDivider,\n} from '@inovex.de/elements/dist/react';\n\nclass MyComponent extends Component {\n  render() {\n    return (\n      <InoButton>\n        Show Menu\n        <InoMenu>\n          <InoListItem text=\"Home\"/>\n          <InoListItem text=\"Projects\"/>\n          <InoDivider/>\n          <InoListItem text=\"User\"/>\n          <InoListItem text=\"Settings\"/>\n        </InoMenu>\n      </InoButton>\n    );\n  }\n}\n```\n\n## Additional Hints\n\nThe menu creates a temporary surface with an empty list composer. The items of the list are provided via the slot (see\nexample above). For more details about the list capabilities itself, check the documentation of `ino-list`\nand `ino-list-item` component.\n",
+      "usage": {},
       "docs": "A menu component that displays a list of choices on a temporary surface which opens and closes on anchor or item click.\nThe anchor element is the parent element.\n\nThe menu items consist of different variations of the `ino-list-item` component.\n\nIf you need a more customizable menu with a different type of elements or functionalities, have a look at the `ino-popover`.",
       "docsTags": [
         {
@@ -4915,7 +4941,18 @@
           "text": "default - One or more `ino-(control|list|nav)-item` and `ino-list-divider`"
         }
       ],
-      "usage": {},
+      "encapsulation": "none",
+      "dependents": [],
+      "dependencies": [
+        "ino-popover",
+        "ino-list"
+      ],
+      "dependencyGraph": {
+        "ino-menu": [
+          "ino-popover",
+          "ino-list"
+        ]
+      },
       "props": [
         {
           "name": "placement",
@@ -4994,7 +5031,6 @@
       ],
       "methods": [],
       "events": [],
-      "listeners": [],
       "styles": [],
       "slots": [
         {
@@ -5003,23 +5039,14 @@
         }
       ],
       "parts": [],
-      "dependents": [],
-      "dependencies": [
-        "ino-popover",
-        "ino-list"
-      ],
-      "dependencyGraph": {
-        "ino-menu": [
-          "ino-popover",
-          "ino-list"
-        ]
-      }
+      "listeners": []
     },
     {
       "filePath": "./src/components/ino-nav-drawer/ino-nav-drawer.tsx",
-      "encapsulation": "shadow",
+      "fileName": "ino-nav-drawer.tsx",
       "tag": "ino-nav-drawer",
       "readme": "# ino-nav-drawer\n\nA navigation drawer component with different variants, setting up the base layout for your app.\nIt functions as a wrapper around the material [drawer](https://github.com/material-components/material-components-web/blob/master/packages/mdc-drawer/) component.\n\n> Note: The navigation drawer works best with `ino-list` and `ino-nav-item`s inside.\n\n## Usage\n\nThe component can be used as follows:\n\n### Web Component\n\n```js\ndocument\n  .querySelector('ino-nav-drawer')\n  .addEventListener('openChange', (_) => alert('Drawer was toggled!')) // watch for toggle change\n  .setAttribute('open', true); // open drawer\n```\n\n```html\n<ino-nav-drawer\n  open=\"<boolean>\"\n  anchor=\"left|right\"\n  variant=\"docked|dismissible|modal\"\n>\n  <ino-list slot=\"content\">\n    <ino-nav-item text=\"View1\">\n      <ino-icon icon=\"user\">\n    </ino-nav-item>\n    <ino-nav-item text=\"View2\">\n      <ino-icon icon=\"settings\">\n    </ino-nav-item>\n  </ino-list>\n\n  <main slot=\"app\">\n    App Content\n  </main>\n</ino-nav-drawer>\n```\n\n### React\n\n#### Example #1 - Basic\n\n```js\nimport { Component } from 'react';\nimport { InoNavDrawer } from '@inovex.de/elements/dist/react';\n\nclass MyComponent extends Component {\n  render() {\n    return (\n      <InoNavDrawer\n        open=\"false\"\n        anchor=\"left\"\n        variant=\"docked\"\n        onOpen={(_) => alert('Yeah, you just opened the drawer!')}\n      >\n        <ino-list slot=\"header\">\n          <ino-img src=\"https://picsum.photos/50/50\" />\n        </ino-list>\n        <ino-list slot=\"content\">\n          <ino-nav-item text=\"Some Link\">\n            <ino-icon icon=\"onboarding\"></ino-icon>\n          </ino-nav-item>\n        </ino-list>\n        <ino-list slot=\"footer\">\n          <ino-nav-item text=\"My Profile\">\n            <ino-img\n              src=\"https://picsum.photos/id/1027/250/250.jpg\"\n              style=\"border-radius: 50%\"\n              ratio-width=\"1\"\n              ratio-height=\"1\"\n            ></ino-img>\n          </ino-nav-item>\n        </ino-list>\n\n        <main slot=\"app\">\n          <App /> /* Your app goes here */\n        </main>\n      </InoNavDrawer>\n    );\n  }\n}\n```\n\n#### Example #2 - With Types\n\n```js\nimport React, { Component } from 'react';\nimport { InoNavDrawer } from '@inovex.de/elements/dist/react';\nimport { Components } from '@inovex.de/elements/dist/types/components';\n\nconst Drawer: React.FunctionComponent<Components.InoNavDrawerAttributes> = (\n  props\n) => {\n  const { open, variant, anchor } = props;\n\n  return (\n    <InoNavDrawer open={open} variant={variant} onClick={onClick}>\n      Drawer Content\n      <main slot=\"app\">App Content</main>\n    </InoNavDrawer>\n  );\n};\n\nclass MyComponent extends Component {\n  render() {\n    return <Drawer variant=\"dismissible\" anchor=\"left\" open=\"true\" />;\n  }\n}\n```\n\n## Demo\n",
+      "usage": {},
       "docs": "A navigation drawer component with different variants, setting up the base layout for your app.\nIt functions as a wrapper around the material [drawer](https://github.com/material-components/material-components-web/blob/master/packages/mdc-drawer/) component.\n\n> Note: The navigation drawer works best with `ino-list` and `ino-nav-item`s inside.",
       "docsTags": [
         {
@@ -5047,7 +5074,19 @@
           "text": "app - For the application located next to this nav-drawer"
         }
       ],
-      "usage": {},
+      "encapsulation": "shadow",
+      "dependents": [],
+      "dependencies": [
+        "ino-icon-button"
+      ],
+      "dependencyGraph": {
+        "ino-nav-drawer": [
+          "ino-icon-button"
+        ],
+        "ino-icon-button": [
+          "ino-icon"
+        ]
+      },
       "props": [
         {
           "name": "anchor",
@@ -5127,7 +5166,6 @@
           "docsTags": []
         }
       ],
-      "listeners": [],
       "styles": [
         {
           "name": "--ino-nav-drawer-background",
@@ -5192,24 +5230,14 @@
         }
       ],
       "parts": [],
-      "dependents": [],
-      "dependencies": [
-        "ino-icon-button"
-      ],
-      "dependencyGraph": {
-        "ino-nav-drawer": [
-          "ino-icon-button"
-        ],
-        "ino-icon-button": [
-          "ino-icon"
-        ]
-      }
+      "listeners": []
     },
     {
       "filePath": "./src/components/ino-nav-item/ino-nav-item.tsx",
-      "encapsulation": "none",
+      "fileName": "ino-nav-item.tsx",
       "tag": "ino-nav-item",
       "readme": "# ino-nav-item\n\nA nav item component that displays a single instance of choice in a list or menu. It functions as a wrapper around the material [list item](https://github.com/material-components/material-components-web/blob/master/packages/mdc-list/) capabilities.\n\nThis component is used as child of `ino-list` and `ino-menu` components.\n\n> Note: This component's main use case is within the `ino-nav-drawer`.\n\n### Usage\n\nThe component can be used as follows:\n\n```js\ndocument\n  .querySelector('ino-nav-item')\n  .addEventListener('clickEl', (e) =>\n    console.log(\n      'The new nav-item was clicked, the element itself is:',\n      e.detail,\n    ),\n  );\n```\n\n```html\n<ino-nav-item activated text=\"<string>\" onclickel=\"handleClickEl()\">\n  <ino-icon ...></ino-icon>\n</ino-nav-item>\n```\n\n**Default:** Add an item with the default slot to add a first column in the nav item in LTR languages. Typically an icon or image.\n",
+      "usage": {},
       "docs": "A nav item component that displays a single instance of choice in a list or menu. It functions as a wrapper around the material [list item](https://github.com/material-components/material-components-web/blob/master/packages/mdc-list/) capabilities.\n\nThis component is used as child of `ino-list` and `ino-menu` components.\n\n> Note: This component's main use case is within the `ino-nav-drawer`.",
       "docsTags": [
         {
@@ -5217,7 +5245,16 @@
           "text": "default - Any element"
         }
       ],
-      "usage": {},
+      "encapsulation": "none",
+      "dependents": [],
+      "dependencies": [
+        "ino-list-item"
+      ],
+      "dependencyGraph": {
+        "ino-nav-item": [
+          "ino-list-item"
+        ]
+      },
       "props": [
         {
           "name": "activated",
@@ -5288,7 +5325,6 @@
       ],
       "methods": [],
       "events": [],
-      "listeners": [],
       "styles": [
         {
           "name": "--ino-nav-item-background-color",
@@ -5318,21 +5354,14 @@
         }
       ],
       "parts": [],
-      "dependents": [],
-      "dependencies": [
-        "ino-list-item"
-      ],
-      "dependencyGraph": {
-        "ino-nav-item": [
-          "ino-list-item"
-        ]
-      }
+      "listeners": []
     },
     {
       "filePath": "./src/components/ino-option/ino-option.tsx",
-      "encapsulation": "none",
+      "fileName": "ino-option.tsx",
       "tag": "ino-option",
       "readme": "# ino-option\n\nAn option component that can be used to add options to an ino-select component.\n\n### Usage\n\nThe component can be used as follows:\n\n```html\n<ino-option disabled selected value=\"<string>\"> Content </ino-option>\n```\n",
+      "usage": {},
       "docs": "An option component that can be used to add options to an ino-select component.",
       "docsTags": [
         {
@@ -5340,7 +5369,16 @@
           "text": "default - The text of the option"
         }
       ],
-      "usage": {},
+      "encapsulation": "none",
+      "dependents": [
+        "ino-option-group"
+      ],
+      "dependencies": [],
+      "dependencyGraph": {
+        "ino-option-group": [
+          "ino-option"
+        ]
+      },
       "props": [
         {
           "name": "disabled",
@@ -5405,18 +5443,6 @@
           "docsTags": []
         }
       ],
-      "listeners": [
-        {
-          "event": "click",
-          "capture": false,
-          "passive": false
-        },
-        {
-          "event": "keydown",
-          "capture": false,
-          "passive": false
-        }
-      ],
       "styles": [
         {
           "name": "--ino-option-deselected-background-color",
@@ -5466,21 +5492,25 @@
         }
       ],
       "parts": [],
-      "dependents": [
-        "ino-option-group"
-      ],
-      "dependencies": [],
-      "dependencyGraph": {
-        "ino-option-group": [
-          "ino-option"
-        ]
-      }
+      "listeners": [
+        {
+          "event": "click",
+          "capture": false,
+          "passive": false
+        },
+        {
+          "event": "keydown",
+          "capture": false,
+          "passive": false
+        }
+      ]
     },
     {
       "filePath": "./src/components/ino-option-group/ino-option-group.tsx",
-      "encapsulation": "none",
+      "fileName": "ino-option-group.tsx",
       "tag": "ino-option-group",
       "readme": "# ino-option-group\n\nA wrapper component to be used for a group of ino-options. This component adds a non-selectable header before the options.\n\nBeyond that, if you encounter problems using React or Vue in conjunction with the `ino-select`, use this component as a wrapper around your `ino-option`. This way the virtual DOM will know when to update the `ino-select` and its children, which may otherwise not work properly if the options are added dynamically while deeply nested in the `ino-select'. For more information refer to [this issue](https://github.com/ionic-team/stencil/issues/2259).\n\n### Usage\n\n```html\n<ino-select>\n  <ino-option-group label=\"My First Option Group\">\n    <ino-option value=\"Option 1\">Option 1</ino-option>\n    <ino-option value=\"Option 2\">Option 2</ino-option>\n    <ino-option value=\"Option 3\">Option 3</ino-option>\n  </ino-option-group>\n  <ino-option-group label=\"My Second Option Group\">\n    <ino-option value=\"Option 4\">Option 4</ino-option>\n    <ino-option value=\"Option 5\">Option 5</ino-option>\n    <ino-option value=\"Option 6\">Option 6</ino-option>\n  </ino-option-group>\n</ino-select>\n```\n\n### React\n\n#### Example\n\n```js\nimport { Component } from 'react';\nimport {\n  InoSelect,\n  InoOption,\n  InoOptionGroup,\n} from '@inovex.de/elements-react/dist';\n\nclass MyComponent extends Component {\n  state = {\n    selected: 'Option 1',\n  };\n\n  changeHandler = (value) => {\n    this.setState({ selected: value });\n  };\n\n  render() {\n    return (\n      <InoSelect\n        label=\"My Select\"\n        value={this.state.selected}\n        onValueChange={() => this.changeHandler(e.detail)}\n      >\n        <InoOptionGroup label={'Option Group 1'}>\n          <InoOption value=\"Option 1\">Option 1</InoOption>\n          <InoOption value=\"Option 2\">Option 2</InoOption>\n        </InoOptionGroup>\n        <InoOptionGroup label={'Option Group 2'}>\n          <InoOption value=\"Option 3\">Option 3</InoOption>\n          <InoOption value=\"Option 4\">Option 4</InoOption>\n        </InoOptionGroup>\n      </InoSelect>\n    );\n  }\n}\n```\n",
+      "usage": {},
       "docs": "A wrapper component to be used for a group of ino-options. This component adds a non-selectable header before the options.\n\nBeyond that, if you encounter problems using React or Vue in conjunction with the `ino-select`, use this component as a wrapper around your `ino-option`. This way the virtual DOM will know when to update the `ino-select` and its children, which may otherwise not work properly if the options are added dynamically while deeply nested in the `ino-select'. For more information refer to [this issue](https://github.com/ionic-team/stencil/issues/2259).",
       "docsTags": [
         {
@@ -5488,7 +5518,16 @@
           "text": "default - One or more `ino-option`"
         }
       ],
-      "usage": {},
+      "encapsulation": "none",
+      "dependents": [],
+      "dependencies": [
+        "ino-option"
+      ],
+      "dependencyGraph": {
+        "ino-option-group": [
+          "ino-option"
+        ]
+      },
       "props": [
         {
           "name": "label",
@@ -5509,7 +5548,6 @@
       ],
       "methods": [],
       "events": [],
-      "listeners": [],
       "styles": [],
       "slots": [
         {
@@ -5518,21 +5556,14 @@
         }
       ],
       "parts": [],
-      "dependents": [],
-      "dependencies": [
-        "ino-option"
-      ],
-      "dependencyGraph": {
-        "ino-option-group": [
-          "ino-option"
-        ]
-      }
+      "listeners": []
     },
     {
       "filePath": "./src/components/ino-popover/ino-popover.tsx",
-      "encapsulation": "none",
+      "fileName": "ino-popover.tsx",
       "tag": "ino-popover",
       "readme": "# ino-popover\n\nA Popover is a dialog which is bound to a specific element and appears next to it. Under the\nhood, [tippy.js](https://atomiks.github.io/tippyjs/) is used.\n\nThe Popover\nand [Tooltip](https://elements.inovex.de/dist/latest/storybook/?path=/story/notification-ino-tooltip--default-usage)\ncomponents are very similar. However, popovers are complex dialogs consisting of several HTML elements, while tooltips\ncan only display plain text.\n\n### Usage\n\nThe component can be used as follows:\n\n```html\n\n<ino-popover\n  color-scheme=\"<string>\"\n  controlled=\"<boolean>\"\n  distance=\"<number>\"\n  for=\"<string>\"\n  hide-on-blur=\"<boolean>\"\n  hide-on-esc=\"<boolean>\"\n  interactive=\"<boolean>\"\n  placement=\"<string>\"\n  trigger=\"<string>\"\n  visible=\"<boolean>\"\n>\n  Any desired HTML\n</ino-popover>\n```\n\n#### Targets\nThere are currently three ways to attach your popover to a component, which results in a slightly different structure:\n\n1. Using the `popover-trigger` slot _(preferred)_:\n\n```html\n<ino-popover trigger=\"click\">\n    <ino-button slot=\"popover-trigger\">Click to show/hide</ino-button>\n    <custom-html-content></custom-html-content>\n</ino-popover>\n```\n\n```html\n<ino-popover>\n├── <ino-button>\n└── <custom-html-content>\n```\n\n2. Using the `for` property:\n\n```html\n<ino-button id=\"my-target\" slot=\"popover-trigger\">Click to show/hide</ino-button>\n<ino-popover for=\"my-target\" trigger=\"click\">\n  <custom-html-content></custom-html-content>\n</ino-popover>\n```\n\n```html\n<ino-button>\n<ino-popover>\n└── <custom-html-content>\n```\n\n3. Using the parent element:\n\n```html\n<ino-button>\n    Click to show/hide\n    <ino-popover trigger=\"click\">\n      <custom-html-content></custom-html-content>\n    </ino-popover>\n</ino-button>\n```\n\n```html\n<ino-button>\n└── <ino-popover>\n    └── <custom-html-content>\n```\n\n\n#### Controlled vs. Uncontrolled\n\nThere are currently two ways you can manage the state of the popover.\n\n_Uncontrolled_\n\nEither you use the `trigger` property to define the method when the popover should be opened or closed (e.g. hovering in opens and hovering out closes the popover).\nThis is the easiest way as you don't have to worry about managing this state yourself.\n\n```tsx\n// ...\n\nclass MyComponent extends Component {\n  render() {\n    return (\n      <div>\n        <InoPopover trigger=\"mouseenter\">\n          <InoButton slot=\"popover-trigger\">Open Popover</InoButton>\n          This popover will show as soon as the user hovers the button above\n        </InoPopover>\n      </div>\n    );\n  }\n}\n```\n\n_Controlled_\n\nOr you use the `controlled` and `visible` property to show/hide the popover by yourself.\nThis is helpful if you want to implement custom logic when the popover should be shown or hidden.\n\n```tsx\n// ...\n\nclass MyComponent extends Component {\n\n  state = {\n    showPopover: false\n  };\n\n  setPopoverState = (show: boolean) => {\n    if (this.props.someProp) return; // Some condition\n\n    this.setState({ showPopover: show });\n  }\n\n  render() {\n    return (\n      <div>\n        <InoPopover\n          inoControlled\n          inoVisible={this.state.showPopover}\n          onInoVisibleChanged={(e) => setPopoverState(e.detail)}\n        >\n          <InoButton slot=\"popover-trigger\">\n            Open Popover\n          </InoButton>\n          This popover will show as soon as the user clicks the button above\n        </InoPopover>\n      </div>\n    );\n  }\n}\n```\n\n### React\n\n#### Example #1 - Basic\n\n```tsx\nimport { Component } from 'react';\nimport { InoPopover } from '@inovex.de/elements/dist/react';\n\nclass MyComponent extends Component {\n  render() {\n    return (\n      <InoPopover placement=\"left\" for=\"popover-positions-target\">\n        This is a simple popover on the left\n      </InoPopover>\n    );\n  }\n}\n```\n\n#### Example #2 - With Types\n\n```tsx\nimport React, { Component } from 'react';\nimport { InoPopover } from '@inovex.de/elements/dist/react';\nimport { Components } from '@inovex.de/elements/dist/types/components';\n\nconst Popover: React.FunctionComponent<Components.InoPopoverAttributes> = (\n  props,\n) => {\n  const { placement, for } = props;\n\n  return (\n    <InoPopover placement={placement} for={for}>\n      {props.children}\n    </InoPopover>\n  );\n};\n\nclass MyComponent extends Component {\n  render() {\n    return (\n      <Popover placement=\"left\" for=\"popover-positions-target\">\n        This is a simple popover on the left\n      </Popover>\n    );\n  }\n}\n```\n\n## Additional Hints\n",
+      "usage": {},
       "docs": "A Popover is a dialog which is bound to a specific element and appears next to it. Under the\nhood, [tippy.js](https://atomiks.github.io/tippyjs/) is used.\n\nThe Popover\nand [Tooltip](https://elements.inovex.de/dist/latest/storybook/?path=/story/notification-ino-tooltip--default-usage)\ncomponents are very similar. However, popovers are complex dialogs consisting of several HTML elements, while tooltips\ncan only display plain text.",
       "docsTags": [
         {
@@ -5544,7 +5575,24 @@
           "text": "default - Content of the popover"
         }
       ],
-      "usage": {},
+      "encapsulation": "none",
+      "dependents": [
+        "ino-markdown-editor",
+        "ino-menu",
+        "ino-table-header-cell"
+      ],
+      "dependencies": [],
+      "dependencyGraph": {
+        "ino-markdown-editor": [
+          "ino-popover"
+        ],
+        "ino-menu": [
+          "ino-popover"
+        ],
+        "ino-table-header-cell": [
+          "ino-popover"
+        ]
+      },
       "props": [
         {
           "name": "attachToBody",
@@ -5913,7 +5961,6 @@
           "docsTags": []
         }
       ],
-      "listeners": [],
       "styles": [],
       "slots": [
         {
@@ -5926,32 +5973,20 @@
         }
       ],
       "parts": [],
-      "dependents": [
-        "ino-markdown-editor",
-        "ino-menu",
-        "ino-table-header-cell"
-      ],
-      "dependencies": [],
-      "dependencyGraph": {
-        "ino-markdown-editor": [
-          "ino-popover"
-        ],
-        "ino-menu": [
-          "ino-popover"
-        ],
-        "ino-table-header-cell": [
-          "ino-popover"
-        ]
-      }
+      "listeners": []
     },
     {
       "filePath": "./src/components/ino-progress-bar/ino-progress-bar.tsx",
-      "encapsulation": "shadow",
+      "fileName": "ino-progress-bar.tsx",
       "tag": "ino-progress-bar",
       "readme": "# ino-progress-bar\n\nThe ino-progress-bar is a linear progress bar based on the mdc-linear-progress component.\n\n## Usage\n\nThe component can be used as follows:\n\n```html\n<ino-progress-bar\n  buffer=\"0.7\"\n  progress=\"0.4\"\n  reversed\n  indeterminate\n  label=\"Progress Bar\"\n>\n</ino-progress-bar>\n```\n\n```jsx\nimport React from 'react';\nimport { Component } from 'react';\nimport { InoProgressBar, InoButton } from '@inovex.de/elements/dist/react';\n\nclass MyComponent extends Component {\n    state = {\n      indeterminate: false\n    };\n\n    handleClick = () => {\n      this.setState((state) => ({\n        indeterminate: !state.indeterminate\n      }));\n    };\n\n    render() {\n      return (\n        <>\n          <InoButton onClick={() => this.handleClick()}>Click me!</InoButton>\n          <InoProgressBar indeterminate={this.state.indeterminate}></InoProgressBar>\n        </>\n      )\n    }\n}\n```\n",
+      "usage": {},
       "docs": "The ino-progress-bar is a linear progress bar based on the mdc-linear-progress component.",
       "docsTags": [],
-      "usage": {},
+      "encapsulation": "shadow",
+      "dependents": [],
+      "dependencies": [],
+      "dependencyGraph": {},
       "props": [
         {
           "name": "buffer",
@@ -6023,7 +6058,6 @@
       ],
       "methods": [],
       "events": [],
-      "listeners": [],
       "styles": [
         {
           "name": "--progress-bar--bar-color",
@@ -6033,15 +6067,14 @@
       ],
       "slots": [],
       "parts": [],
-      "dependents": [],
-      "dependencies": [],
-      "dependencyGraph": {}
+      "listeners": []
     },
     {
       "filePath": "./src/components/ino-radio/ino-radio.tsx",
-      "encapsulation": "shadow",
+      "fileName": "ino-radio.tsx",
       "tag": "ino-radio",
       "readme": "# ino-radio\n\nA radio component that allows the user to select an option from a set of radio-buttons. In order to have a single select functionality, please refer to the `ino-radio-group`-component. This component functions as a wrapper around the material [radio](https://github.com/material-components/material-components-web/tree/master/packages/mdc-radio) component.\n\n### Usage\n\nThe component can be used as follows:\n\n```js\ndocument\n  .querySelector('ino-radio')\n  .addEventListener('checkedChange', (_) =>\n    alert(`The radio button should be checked`),\n  );\n```\n\n```html\n<ino-radio\n  checked=\"<boolean>\"\n  disabled=\"<boolean>\"\n  name=\"<string>\"\n  value=\"<string>\"\n  id=\"<string>\"\n  oncheckedChange=\"handleCheckedChange()\"\n>\n  Label\n</ino-radio>\n```\n\n### React\n\n#### Example #1 - Basic\n\n```js\nimport { Component } from 'react';\nimport { InoRadio } from '@inovex.de/elements/dist/react';\n\nclass MyComponent extends Component {\n  render() {\n    return (\n      <InoRadio checked name=\"radio-1\">\n        Checked\n      </InoRadio>\n    );\n  }\n}\n```\n\n#### Example #2 - With Types\n\n```js\nimport React, { Component } from 'react';\nimport { InoRadio } from '@inovex.de/elements/dist/react';\nimport { Components } from '@inovex.de/elements/dist/types/components';\n\nconst Radio: React.FunctionComponent<Components.InoRadioAttributes> = (\n  props,\n) => {\n  const { checked, name } = props;\n\n  return (\n    <InoRadio checked={checked} name={name}>\n      {props.children}\n    </InoRadio>\n  );\n};\n\nclass MyComponent extends Component {\n  render() {\n    return (\n      <Radio checked name=\"radio-1\">\n        Checked\n      </Radio>\n    );\n  }\n}\n```\n\n## Additional Hints\n\n### Control flow\n\nClicking on the radio button triggers an event that contains the boolean value `true` (`e.detail`). This event is only triggered if the radio button was not previously selected (`checked=false`). In order to check one element and uncheck the other ones, please refer to the `ino-radio-group`-Component. If (`checked=true`) is passed to an element, the other elements **won't** be deselected without the use of the `ino-radio-group`.\n\n```html\n<ino-radio\n  checked={this.state.checked}\n  checkedChange={e => this.state.checked = e.detail}>\n</ino-radio>\n```\n\n## Demo\n",
+      "usage": {},
       "docs": "A radio component that allows the user to select an option from a set of radio-buttons. In order to have a single select functionality, please refer to the `ino-radio-group`-component. This component functions as a wrapper around the material [radio](https://github.com/material-components/material-components-web/tree/master/packages/mdc-radio) component.",
       "docsTags": [
         {
@@ -6049,7 +6082,16 @@
           "text": "default - Label of the checkbox"
         }
       ],
-      "usage": {},
+      "encapsulation": "shadow",
+      "dependents": [
+        "ino-control-item"
+      ],
+      "dependencies": [],
+      "dependencyGraph": {
+        "ino-control-item": [
+          "ino-radio"
+        ]
+      },
       "props": [
         {
           "name": "checked",
@@ -6129,7 +6171,6 @@
           "docsTags": []
         }
       ],
-      "listeners": [],
       "styles": [
         {
           "name": "--ino-radio-active-color",
@@ -6169,21 +6210,14 @@
         }
       ],
       "parts": [],
-      "dependents": [
-        "ino-control-item"
-      ],
-      "dependencies": [],
-      "dependencyGraph": {
-        "ino-control-item": [
-          "ino-radio"
-        ]
-      }
+      "listeners": []
     },
     {
       "filePath": "./src/components/ino-radio-group/ino-radio-group.tsx",
-      "encapsulation": "shadow",
+      "fileName": "ino-radio-group.tsx",
       "tag": "ino-radio-group",
       "readme": "# ino-radio-group\n\nA wrapper component to be used for a group of ino-radio-buttons. This component manages the single selection functionality of a group of ino-radio-buttons. Due to the shadow DOM implementation of the `ino-radio`-Element the `name`-Property cannot be used to achieve the single selection functionality.\n\n### Usage\n\n```html\n<ino-radio-group value=\"Option 1\">\n  <ino-radio value=\"Option 1\">I will be checked</ino-radio>\n  <ino-radio value=\"Option 2\">Option 2</ino-radio>\n  <ino-radio value=\"Option 3\">Option 3</ino-radio>\n</ino-radio-group>\n```\n\n### React\n\n#### Example #1 - Basic\n\n```js\nimport { Component } from 'react';\nimport { InoRadio, InoRadioGroup } from '@inovex.de/elements-react/dist';\n\nclass MyComponent extends Component {\n  state = {\n    selected: 'Option 1',\n  };\n\n  clickHandler = (value) => {\n    this.setState({ selected: value });\n  };\n\n  render() {\n    return (\n      <InoRadioGroup value={this.state.selected}>\n        <InoRadio\n          onValueChange={() => this.clickHandler('Option 1')}\n          value=\"Option 1\"\n        >\n          I will be checked\n        </InoRadio>\n        <InoRadio\n          onValueChange={() => this.clickHandler('Option 2')}\n          value=\"Option 2\"\n        >\n          Option 2\n        </InoRadio>\n        <InoRadio\n          onValueChange={() => this.clickHandler('Option 3')}\n          value=\"Option 3\"\n        >\n          Option 3\n        </InoRadio>\n      </InoRadioGroup>\n    );\n  }\n}\n```\n\n#### Example #2 - With Types\n\n```js\nimport React, { Component } from 'react';\nimport { InoRadioGroup } from '@inovex.de/elements/dist/react';\nimport { Components } from '@inovex.de/elements/dist/types/components';\n\nconst RadioGroup: React.FunctionComponent<Components.InoRadioGroupAttributes> = (\n  props,\n) => {\n  const { value } = props;\n\n  return <InoRadioGroup value={value}>{props.children}</InoRadioGroup>;\n};\n\nclass MyComponent extends Component {\n  render() {\n    return <RadioGroup value={'Option 1'}>...</RadioGroup>;\n  }\n}\n```\n\n## Additional Hints\n\n### Control flow\n\nIn order to change the checked element (and uncheck the other ones) listen to the `valueChange`-Event emitted by the `ino-radio` and pass it's value to the `ino-radio-group` via the `value`-Property.\n",
+      "usage": {},
       "docs": "A wrapper component to be used for a group of ino-radio-buttons. This component manages the single selection functionality of a group of ino-radio-buttons. Due to the shadow DOM implementation of the `ino-radio`-Element the `name`-Property cannot be used to achieve the single selection functionality.",
       "docsTags": [
         {
@@ -6191,7 +6225,10 @@
           "text": "default - One or more `ino-radio`"
         }
       ],
-      "usage": {},
+      "encapsulation": "shadow",
+      "dependents": [],
+      "dependencies": [],
+      "dependencyGraph": {},
       "props": [
         {
           "name": "value",
@@ -6212,7 +6249,6 @@
       ],
       "methods": [],
       "events": [],
-      "listeners": [],
       "styles": [],
       "slots": [
         {
@@ -6221,18 +6257,20 @@
         }
       ],
       "parts": [],
-      "dependents": [],
-      "dependencies": [],
-      "dependencyGraph": {}
+      "listeners": []
     },
     {
       "filePath": "./src/components/ino-range/ino-range.tsx",
-      "encapsulation": "none",
+      "fileName": "ino-range.tsx",
       "tag": "ino-range",
       "readme": "# ino-range\n\nA range component that allows the user select a number using a slider. It functions as a wrapper around the material [Slider](https://github.com/material-components/material-components-web/tree/master/packages/mdc-slider) component.\n\n> Note: Range sliders with multiple thumbs are not yet implemented.\n\n### Usage\n\nThe component can be used as follows:\n\n```js\ndocument\n  .querySelector('ino-datepicker')\n  .addEventListener('valueChange', (e) =>\n    alert(`The new range value is: ${e.detail}`),\n  );\n```\n\n```html\n<ino-range\n  min=\"<number>\"\n  max=\"<number>\"\n  value=\"<number>\"\n  name=\"<string>\"\n  step=\"<number>\"\n  disabled\n  color-scheme=\"<string>\"\n  discrete\n  markers\n>\n</ino-range>\n```\n\n### React\n\n#### Example #1 - Basic\n\n```js\nimport { Component } from 'react';\nimport { InoRange } from '@inovex.de/elements/dist/react';\n\nclass MyComponent extends Component {\n  render() {\n    return <InoRange inoColorScheme=\"primary\" />;\n  }\n}\n```\n\n#### Example #2 - With Types\n\n```js\nimport React, { Component } from 'react';\nimport { InoRange } from '@inovex.de/elements/dist/react';\nimport { Components } from '@inovex.de/elements/dist/types/components';\n\nconst Range: React.FunctionComponent<Components.InoRangeAttributes> = (\n  props,\n) => {\n  const { inoColorScheme } = props;\n\n  return <InoRange inoColorScheme={inoColorScheme}>{props.children}</InoRange>;\n};\n\nclass MyComponent extends Component {\n  render() {\n    return <Range inoColorScheme=\"primary\" />;\n  }\n}\n```\n\n## Additional Hints\n",
+      "usage": {},
       "docs": "A range component that allows the user select a number using a slider. It functions as a wrapper around the material [Slider](https://github.com/material-components/material-components-web/tree/master/packages/mdc-slider) component.\n\n> Note: Range sliders with multiple thumbs are not yet implemented.",
       "docsTags": [],
-      "usage": {},
+      "encapsulation": "none",
+      "dependents": [],
+      "dependencies": [],
+      "dependencyGraph": {},
       "props": [
         {
           "name": "colorScheme",
@@ -6436,19 +6474,17 @@
           "docsTags": []
         }
       ],
-      "listeners": [],
       "styles": [],
       "slots": [],
       "parts": [],
-      "dependents": [],
-      "dependencies": [],
-      "dependencyGraph": {}
+      "listeners": []
     },
     {
       "filePath": "./src/components/ino-segment-button/ino-segment-button.tsx",
-      "encapsulation": "shadow",
+      "fileName": "ino-segment-button.tsx",
       "tag": "ino-segment-button",
       "readme": "# ino-segment-button\n\nA button component that can be used in combination with the ino-segment-group component.\n\n## Usage\n\nThe component can be used as follows:\n\n### Web Component\n\n```js\ndocument\n  .querySelector('ino-segment-button')\n  .addEventListener('click', () => alert('Button was clicked!'));\n```\n\n```html\n<ino-segment-button checked disabled name=\"<string>\" dense value=\"<string>\">\n  Button Content\n</ino-segment-button>\n```\n\n### React\n\n```js\nimport { Component } from 'react';\nimport { InoSegmentButton } from '@inovex.de/elements/dist/react';\n\nclass MyComponent extends Component {\n  render() {\n    return (\n      <InoSegmentButton onClick={(_) => alert('Yeah, you clicked the button!')}>\n        You can click me!\n      </InoSegmentButton>\n    );\n  }\n}\n```\n",
+      "usage": {},
       "docs": "A button component that can be used in combination with the ino-segment-group component.",
       "docsTags": [
         {
@@ -6456,7 +6492,10 @@
           "text": "default - Label of the button"
         }
       ],
-      "usage": {},
+      "encapsulation": "shadow",
+      "dependents": [],
+      "dependencies": [],
+      "dependencyGraph": {},
       "props": [
         {
           "name": "checked",
@@ -6554,7 +6593,6 @@
           "docsTags": []
         }
       ],
-      "listeners": [],
       "styles": [
         {
           "name": "--ino-segment-button-checked-color",
@@ -6594,15 +6632,14 @@
         }
       ],
       "parts": [],
-      "dependents": [],
-      "dependencies": [],
-      "dependencyGraph": {}
+      "listeners": []
     },
     {
       "filePath": "./src/components/ino-segment-group/ino-segment-group.tsx",
-      "encapsulation": "shadow",
+      "fileName": "ino-segment-group.tsx",
       "tag": "ino-segment-group",
       "readme": "# ino-segment-group\n\nA button group that can be used as an alternative to drop-down menus.\n\n## Usage\n\nThe component can be used as follows:\n\n### Web Component\n\n```js\ndocument\n  .querySelector('ino-segment-group')\n  .addEventListener('checkedChange', (e) =>\n    console.log(`${e.target} was checked!`),\n  );\n```\n\n```html\n<ino-segment-group value=\"1\" name=\"<string>\">\n  <ino-segment-button value=\"1\">Option 1</ino-segment-button>\n  <ino-segment-button value=\"2\">Option 2</ino-segment-button>\n  <ino-segment-button value=\"3\">Option 3</ino-segment-button>\n</ino-segment-group>\n```\n\n### React\n\n```js\nimport { Component } from 'react';\nimport {\n  InoSegmentButton,\n  InoSegmentGroup,\n} from '@inovex.de/elements/dist/react';\n\nclass MyComponent extends Component {\n  state = {\n    val: 1,\n  };\n\n  handleEvent = (val) => {\n    this.setState({ val: val });\n  };\n\n  render() {\n    return (\n      <InoSegmentGroup value={this.state.val} name=\"my-group\">\n        <InoSegmentButton\n          value=\"1\"\n          onCheckedChange={() => this.handleEvent('1')}\n        >\n          Option 1\n        </InoSegmentButton>\n        <InoSegmentButton\n          value=\"2\"\n          onCheckedChange={() => this.handleEvent('2')}\n        >\n          Option 2\n        </InoSegmentButton>\n        <InoSegmentButton\n          value=\"3\"\n          onCheckedChange={() => this.handleEvent('3')}\n        >\n          Option 3\n        </InoSegmentButton>\n      </InoSegmentGroup>\n    );\n  }\n}\n```\n\n## Event handling\n\nThe `checkedChange` event can be used to set the selected option. Simply subscribe to the event and set the group value\nto the value of the button that emitted the event.\n",
+      "usage": {},
       "docs": "A button group that can be used as an alternative to drop-down menus.",
       "docsTags": [
         {
@@ -6610,7 +6647,10 @@
           "text": "default - One or more `ino-segment-button`"
         }
       ],
-      "usage": {},
+      "encapsulation": "shadow",
+      "dependents": [],
+      "dependencies": [],
+      "dependencyGraph": {},
       "props": [
         {
           "name": "name",
@@ -6647,7 +6687,6 @@
       ],
       "methods": [],
       "events": [],
-      "listeners": [],
       "styles": [],
       "slots": [
         {
@@ -6656,15 +6695,14 @@
         }
       ],
       "parts": [],
-      "dependents": [],
-      "dependencies": [],
-      "dependencyGraph": {}
+      "listeners": []
     },
     {
       "filePath": "./src/components/ino-select/ino-select.tsx",
-      "encapsulation": "none",
+      "fileName": "ino-select.tsx",
       "tag": "ino-select",
       "readme": "# ino-select\n\nA component providing single-option select menus. It functions as a wrapper around the material design's [select](https://github.com/material-components/material-components-web/tree/master/packages/mdc-select) component.\n\n### Usage\n\nThe component can be used as follows:\n\n```js\ndocument\n  .querySelector('ino-select')\n  .addEventListener('valueChange', (e) =>\n    alert(`The new select value is: ${e.detail}`),\n  );\n```\n\n```html\n<ino-select\n  autofocus\n  disabled\n  name=\"<string>\"\n  required\n  value=\"<string>\"\n  label=\"<string>\"\n  outline\n>\n  <ino-option value=\"Option 1\">Option 1</ino-option>\n  <ino-option value=\"Option 2\">Option 2</ino-option> ...\n</ino-select>\n```\n\n### React\n\n#### Example #1 - Basic\n\n```js\nimport { Component } from 'react';\nimport { InoSelect, InoOption } from '@inovex.de/elements/dist/react';\n\nclass MyComponent extends Component {\n  render() {\n    return (\n      <InoSelect; inoLabel=\"Form select\"; required>\n        <InoOption; value=\"Test\">Test</InoOption>\n      </InoSelect>;;\n    )\n  }\n}\n```\n\n#### Example #2 - With Types\n\n```js\nimport React, { Component } from 'react';\nimport { InoSelect, InoOption } from '@inovex.de/elements/dist/react';\nimport { Components } from '@inovex.de/elements/dist/types/components';\n\nconst Select: React.FunctionComponent<Components.InoSelectAttributes> = props => {\n  const { inoLabel, required } = props;\n\n  return (\n    <InoSelect;\n      inoLabel={inoLabel};\n      required={required}\n    >\n      {props.children}\n    </InoSelect>;;\n  )\n};\n\nclass MyComponent extends Component {\n  render() {\n    return (\n      <Select; inoLabel=\"Form select\"; required>\n        <InoOption; value=\"Test\">Test</InoOption>\n      </Select>;;\n    )\n  }\n}\n```\n\n## Additional Hints\n\nUse the custom `ino-option` component to add options to the select component. The `label` attribute sets an optional floating label for this element.\n\n### Control flow\n\nThe select has a controlled (unmanaged) attribute `value`. For this reason, the value doesn't change on user interaction but on updates of `value`. Listen to `valueChange`, sync it with your local state and pass the new value to the component again to change value of select.\n\n```js\ndocument\n  .querySelector('ino-select')\n  .addEventListener('valueChange', (e) => (this.state.value = e.detail));\n```\n\n### Event Behaviour\n\nThe component behaves like a native select with additional features. The native `input'` is not bubbled. The component will emit a `valueChange` event if the value of the group changes.\n",
+      "usage": {},
       "docs": "A component providing single-option select menus. It functions as a wrapper around the material design's [select](https://github.com/material-components/material-components-web/tree/master/packages/mdc-select) component.",
       "docsTags": [
         {
@@ -6676,7 +6714,16 @@
           "text": "default - One or more `ino-option(-group)`"
         }
       ],
-      "usage": {},
+      "encapsulation": "none",
+      "dependents": [],
+      "dependencies": [
+        "ino-label"
+      ],
+      "dependencyGraph": {
+        "ino-select": [
+          "ino-label"
+        ]
+      },
       "props": [
         {
           "name": "disabled",
@@ -6868,13 +6915,6 @@
           "docsTags": []
         }
       ],
-      "listeners": [
-        {
-          "event": "MDCSelect:change",
-          "capture": false,
-          "passive": false
-        }
-      ],
       "styles": [
         {
           "name": "--ino-select-height",
@@ -6898,21 +6938,20 @@
         }
       ],
       "parts": [],
-      "dependents": [],
-      "dependencies": [
-        "ino-label"
-      ],
-      "dependencyGraph": {
-        "ino-select": [
-          "ino-label"
-        ]
-      }
+      "listeners": [
+        {
+          "event": "MDCSelect:change",
+          "capture": false,
+          "passive": false
+        }
+      ]
     },
     {
       "filePath": "./src/components/ino-sidebar/ino-sidebar.tsx",
-      "encapsulation": "shadow",
+      "fileName": "ino-sidebar.tsx",
       "tag": "ino-sidebar",
       "readme": "# ino-sidebar\n\nThe ino-sidebar is a modal sidebar that can be used to display additional information.\nIt functions as a wrapper around the material [drawer](https://github.com/material-components/material-components-web/blob/master/packages/mdc-drawer/) component.\n\n## Usage\n\nThe component can be used as follows:\n\n### Web Component\n\n```js\ndocument\n    .querySelector('ino-sidebar')\n    .addEventListener('openChange', (e) => console.log(`state of sidebar changed to ${e.detail}`);\n```\n\n```html\n<ino-sidebar>\n  <div class=\"sidebar-header\" slot=\"header\">\n    <ino-icon clickable icon=\"close-s\"></ino-icon>\n  </div>\n  <div class=\"sidebar-content\" slot=\"content\">\n    <ino-list>\n      <ino-list-item text=\"List item\"></ino-list-item>\n      <ino-list-item text=\"List item\"></ino-list-item>\n    </ino-list>\n  </div>\n</ino-sidebar>\n```\n\n### React\n\n```jsx\nimport React from 'react';\nimport { Component } from 'react';\nimport { InoSidebar, InoButton } from '@inovex.de/elements/dist/react';\n\nclass MyComponent extends Component {\n\n  state = {\n    expanded: false\n  };\n\n  handleClick = () => {\n    this.setState((state) => ({\n      expanded: !state.expanded\n    }));\n  };\n\n  render() {\n    return (\n      <InoButton onClick={() => this.handleClick()}>Sidebar</InoButton>\n      <InoSidebar inoOpen={this.state.expanded}></InoSidebar>\n    )\n  }\n\n}\n```\n\n## Sidenotes\n\nThe empty `div` tag with the `tabindex=\"0\"` attribute as well as the `<div class=\"mdc-drawer-scrim\"/>` tag\nare indispensable for the sidebar to work properly. For further information,\nrefer to https://github.com/material-components/material-components-web/issues/5615 and\nhttps://github.com/material-components/material-components-web/tree/master/packages/mdc-drawer.\n",
+      "usage": {},
       "docs": "The ino-sidebar is a modal sidebar that can be used to display additional information.\nIt functions as a wrapper around the material [drawer](https://github.com/material-components/material-components-web/blob/master/packages/mdc-drawer/) component.",
       "docsTags": [
         {
@@ -6924,7 +6963,10 @@
           "text": "content - For the content"
         }
       ],
-      "usage": {},
+      "encapsulation": "shadow",
+      "dependents": [],
+      "dependencies": [],
+      "dependencyGraph": {},
       "props": [
         {
           "name": "alignRight",
@@ -6989,7 +7031,6 @@
           "docsTags": []
         }
       ],
-      "listeners": [],
       "styles": [
         {
           "name": "--sidebar-width",
@@ -7008,18 +7049,31 @@
         }
       ],
       "parts": [],
-      "dependents": [],
-      "dependencies": [],
-      "dependencyGraph": {}
+      "listeners": []
     },
     {
       "filePath": "./src/components/ino-snackbar/ino-snackbar.tsx",
-      "encapsulation": "none",
+      "fileName": "ino-snackbar.tsx",
       "tag": "ino-snackbar",
       "readme": "# ino-snackbar\n\nSnackbars provide brief messages about app processes at the bottom of the screen. It functions as a wrapper around the material design's [Snackbar](https://github.com/material-components/material-components-web/tree/master/packages/mdc-snackbar) component\n\n### Usage\n\nThe component can be used as follows:\n\n```js\ndocument\n  .querySelector('ino-snackbar')\n  .addEventListener('inoActionClick', (e) =>\n    alert('Action-Button was clicked!'),\n  );\n\ndocument\n  .querySelector('ino-snackbar')\n  .addEventListener('hideEl', (e) => alert('Snackbar hides!'));\n```\n\n```html\n<ino-snackbar\n  message=\"<string>\"\n  action-text=\"<string>\"\n  action-on-bottom\n  align-start\n  oninoactionclick=\"handleClickEl()\"\n  onhideel=\"handleHideEl()\"\n>\n</ino-snackbar>\n```\n\n### React\n\n#### Example #1 - Basic\n\n```js\nimport { Component } from 'react';\nimport { InoSnackbar } from '@inovex.de/elements/dist/react';\n\nclass MyComponent extends Component {\n  render() {\n    return (\n      <InoSnackbar\n        inoMessage=\"Message deleted\"\n        inoActionText=\"Undo\"\n        inoActionOnBottom={false}\n        inoAlignStart={false}\n      />\n    );\n  }\n}\n```\n\n#### Example #2 - With Types\n\n```js\nimport React, { Component } from 'react';\nimport { InoSnackbar } from '@inovex.de/elements/dist/react';\nimport { Components } from '@inovex.de/elements/dist/types/components';\n\nconst Snackbar: React.FunctionComponent<Components.InoSnackbarAttributes> = props => {\n  const {\n    inoMessage,\n    inoActionText,\n    inoActionOnBottom,\n    inoAlignStart\n  } = props;\n\n  return (\n    <InoSnackbar\n      inoMessage={inoMessage}\n      inoActionText={inoActionText}\n      inoActionOnBottom={inoActionOnBottom}\n      inoAlignStart={inoAlignStart}\n    >\n      {props.children}\n    </InoSnackbar>\n  );\n};\n\nclass MyComponent extends Component {\n  const conditionToRender = true;\n\n  render() {\n    return conditionToRender && (\n      <Snackbar\n        inoMessage=\"Message deleted\"\n        inoActionText=\"Undo\"\n        inoActionOnBottom={false}\n        inoAlignStart={false}\n      />\n    );\n  }\n}\n```\n\n## Additional Hints\n\nSnackbar is displayed when `show` is changed to checked.\n",
+      "usage": {},
       "docs": "Snackbars provide brief messages about app processes at the bottom of the screen. It functions as a wrapper around the material design's [Snackbar](https://github.com/material-components/material-components-web/tree/master/packages/mdc-snackbar) component",
       "docsTags": [],
-      "usage": {},
+      "encapsulation": "none",
+      "dependents": [],
+      "dependencies": [
+        "ino-icon",
+        "ino-icon-button"
+      ],
+      "dependencyGraph": {
+        "ino-snackbar": [
+          "ino-icon",
+          "ino-icon-button"
+        ],
+        "ino-icon-button": [
+          "ino-icon"
+        ]
+      },
       "props": [
         {
           "name": "actionText",
@@ -7135,7 +7189,6 @@
           "docsTags": []
         }
       ],
-      "listeners": [],
       "styles": [
         {
           "name": "--ino-snackbar-bottom",
@@ -7160,29 +7213,26 @@
       ],
       "slots": [],
       "parts": [],
-      "dependents": [],
-      "dependencies": [
-        "ino-icon",
-        "ino-icon-button"
-      ],
-      "dependencyGraph": {
-        "ino-snackbar": [
-          "ino-icon",
-          "ino-icon-button"
-        ],
-        "ino-icon-button": [
-          "ino-icon"
-        ]
-      }
+      "listeners": []
     },
     {
       "filePath": "./src/components/ino-spinner/ino-spinner.tsx",
-      "encapsulation": "none",
+      "fileName": "ino-spinner.tsx",
       "tag": "ino-spinner",
       "readme": "# ino-spinner\n\nA component which displays a variety of spinners. Use spinners to show that the app is loading content or performing another process for which the user has to wait.\n\nThis component contains three different types of spinners animated with pure CSS. It mainly relies on [Spinkit](http://tobiasahlin.com/spinkit/) and may be extended in future with more types.\n\n### Usage\n\nThe component can be used as follows:\n\n```html\n<ino-spinner\n  type=\"<string>\"\n  color-scheme=\"<string>\"\n  height=\"<number>\"\n  modal\n  width=\"<number>\"\n>\n</ino-spinner>\n```\n\n### React\n\n#### Example #1 - Basic\n\n```js\nimport { Component } from 'react';\nimport { InoSpinner } from '@inovex.de/elements/dist/react';\n\nclass MyComponent extends Component {\n  render() {\n    return <InoSpinner inoColorScheme=\"warning\" />;\n  }\n}\n```\n\n#### Example #2 - With Types\n\n```js\nimport React, { Component } from 'react';\nimport { InoSpinner } from '@inovex.de/elements/dist/react';\nimport { Components } from '@inovex.de/elements/dist/types/components';\n\nconst Spinner: React.FunctionComponent<Components.InoSpinnerAttributes> = (\n  props,\n) => {\n  const { inoColorScheme } = props;\n\n  return (\n    <InoSpinner inoColorScheme={inoColorScheme}>{props.children}</InoSpinner>\n  );\n};\n\nclass MyComponent extends Component {\n  render() {\n    return <Spinner inoColorScheme=\"warning\" />;\n  }\n}\n```\n\n## Additional Hints\n\nUse one of the provided types in `type` to give the spinner the shape. Adjust the size of the spinner by changing the `height` and `width` attributes. Finally, colorize the spinner using `color-scheme` (see the attribute docs below).\n\n**Modal:** If operations have to block the entire page, the spinner can be marked with `modal` to spread over the entire screen and overlay the current page.\n",
+      "usage": {},
       "docs": "A component which displays a variety of spinners. Use spinners to show that the app is loading content or performing another process for which the user has to wait.\n\nThis component contains three different types of spinners animated with pure CSS. It mainly relies on [Spinkit](http://tobiasahlin.com/spinkit/) and may be extended in future with more types.",
       "docsTags": [],
-      "usage": {},
+      "encapsulation": "none",
+      "dependents": [
+        "ino-button"
+      ],
+      "dependencies": [],
+      "dependencyGraph": {
+        "ino-button": [
+          "ino-spinner"
+        ]
+      },
       "props": [
         {
           "name": "colorScheme",
@@ -7306,25 +7356,17 @@
       ],
       "methods": [],
       "events": [],
-      "listeners": [],
       "styles": [],
       "slots": [],
       "parts": [],
-      "dependents": [
-        "ino-button"
-      ],
-      "dependencies": [],
-      "dependencyGraph": {
-        "ino-button": [
-          "ino-spinner"
-        ]
-      }
+      "listeners": []
     },
     {
       "filePath": "./src/components/ino-switch/ino-switch.tsx",
-      "encapsulation": "none",
+      "fileName": "ino-switch.tsx",
       "tag": "ino-switch",
       "readme": "# ino-switch\n\nInput switches toggle the state of a single item. Compared to the input checkbox, their changes usually apply without any additional submission.\n\n## Usage\n\nThe component can be used as follows:\n\n### Web Component\n\n```js\ndocument\n  .querySelector('ino-switch')\n  .addEventListener('checkedChange', (e) =>\n    alert(`The checked state is: ${e.detail}`),\n  );\n```\n\n```html\n<ino-switch checked disabled color-scheme=\"<string>\" name=\"<string>\">\n  Label\n</ino-switch>\n```\n\n### React\n\n#### Example #1 - Basic\n\n```js\nimport { Component } from 'react';\nimport { InoSwitch } from '@inovex.de/elements-react';\n\nclass MyComponent extends Component {\n  state = {\n    checked: false,\n  };\n\n  handleCheckboxClick(e) {\n    this.setState({ checked: e.detail });\n  }\n\n  render() {\n    return (\n      <InoSwitch\n        checked={this.state.checked}\n        onCheckedChange={handleCheckboxClick}\n      >\n        Apple\n      </InoSwitch>\n    );\n  }\n}\n```\n\n#### Example #2 - With Types\n\n```js\nimport React, { Component } from 'react';\nimport { InoSwitch } from '@inovex.de/elements-react';\nimport { Components } from '@inovex.de/elements-react/dist/types/components';\n\nconst Switch: React.FunctionComponent<Components.InoSwitchAttributes> = (\n  props,\n) => {\n  const { value, onClick, checked } = props;\n\n  return (\n    <InoSwitch value={value} onCheckedChange={onClick} checked={checked}>\n      {value}\n    </InoSwitch>\n  );\n};\n\nclass MyComponent extends Component {\n  state = {\n    checked: false,\n  };\n\n  handleCheckboxClick(e) {\n    this.setState({ checked: e.detail });\n  }\n\n  render() {\n    return (\n      <Switch\n        value={'Apple'}\n        checked={this.state.checked}\n        onClick={handleCheckboxClick}\n      />\n    );\n  }\n}\n```\n\n## Control flow\n\nThe input has a controlled (unmanaged) attribute `checked`. For this reason listen to `checkedChange`, sync it with your local state and pass the new value to the component again to change the value.\n",
+      "usage": {},
       "docs": "Input switches toggle the state of a single item. Compared to the input checkbox, their changes usually apply without any additional submission.",
       "docsTags": [
         {
@@ -7340,7 +7382,10 @@
           "text": "icon-off - Icon used for the unchecked state. The colors of the `color-scheme` will be used."
         }
       ],
-      "usage": {},
+      "encapsulation": "none",
+      "dependents": [],
+      "dependencies": [],
+      "dependencyGraph": {},
       "props": [
         {
           "name": "checked",
@@ -7446,7 +7491,6 @@
           "docsTags": []
         }
       ],
-      "listeners": [],
       "styles": [],
       "slots": [
         {
@@ -7463,18 +7507,26 @@
         }
       ],
       "parts": [],
-      "dependents": [],
-      "dependencies": [],
-      "dependencyGraph": {}
+      "listeners": []
     },
     {
       "filePath": "./src/components/ino-tab/ino-tab.tsx",
-      "encapsulation": "none",
+      "fileName": "ino-tab.tsx",
       "tag": "ino-tab",
       "readme": "# ino-tab\n\nTabs organize and allow navigation between groups of content that are related and at the same hierarchical level. Each Tab governs the visibility of one group of content. It functions as a wrapper around the material [Tab](https://github.com/material-components/material-components-web/tree/master/packages/mdc-tab) component.\n\n### Usage\n\nThe component can be used as follows:\n\n```html\n<ino-tab\n  label=\"<string>\"\n  icon=\"<string>\"\n  indicator-content-width\n  stacked\n>\n</ino-tab>\n```\n\n### React\n\n#### Example #1 - Basic\n\n```js\nimport { Component } from 'react';\nimport { InoTab, InoTabBar } from '@inovex.de/elements/dist/react';\n\nclass MyComponent extends Component {\n  render() {\n    return (\n      <InoTabBar inoActiveTab={2}>\n        <InoTab inoLabel=\"Tab #1\" />\n        <InoTab inoLabel=\"Tab #2\" />\n        <InoTab inoLabel=\"Tab #3\" />\n      </InoTabBar>\n    );\n  }\n}\n```\n\n#### Example #2 - With Types\n\n```js\nimport React, { Component } from 'react';\nimport { InoTab, InoTabBar } from '@inovex.de/elements/dist/react';\nimport { Components } from '@inovex.de/elements/dist/types/components';\n\nconst TabBar: React.FunctionComponent<Components.InoTabBarAttributes> = (\n  props,\n) => {\n  const { inoActiveTab } = props;\n\n  return <InoTabBar inoActiveTab={inoActiveTab}>{props.children}</InoTabBar>;\n};\n\nclass MyComponent extends Component {\n  render() {\n    return (\n      <TabBar inoActiveTab={2}>\n        <InoTab inoLabel=\"Tab #1\" />\n        <InoTab inoLabel=\"Tab #2\" />\n        <InoTab inoLabel=\"Tab #3\" />\n      </TabBar>\n    );\n  }\n}\n```\n\n## Additional Hints\n\n**Content**: Provide the text of a Tab and, if desired, an icon of the tab in `icon`.\n",
+      "usage": {},
       "docs": "Tabs organize and allow navigation between groups of content that are related and at the same hierarchical level. Each Tab governs the visibility of one group of content. It functions as a wrapper around the material [Tab](https://github.com/material-components/material-components-web/tree/master/packages/mdc-tab) component.",
       "docsTags": [],
-      "usage": {},
+      "encapsulation": "none",
+      "dependents": [],
+      "dependencies": [
+        "ino-icon"
+      ],
+      "dependencyGraph": {
+        "ino-tab": [
+          "ino-icon"
+        ]
+      },
       "props": [
         {
           "name": "icon",
@@ -7555,31 +7607,23 @@
           "docsTags": []
         }
       ],
+      "styles": [],
+      "slots": [],
+      "parts": [],
       "listeners": [
         {
           "event": "MDCTab:interacted",
           "capture": false,
           "passive": false
         }
-      ],
-      "styles": [],
-      "slots": [],
-      "parts": [],
-      "dependents": [],
-      "dependencies": [
-        "ino-icon"
-      ],
-      "dependencyGraph": {
-        "ino-tab": [
-          "ino-icon"
-        ]
-      }
+      ]
     },
     {
       "filePath": "./src/components/ino-tab-bar/ino-tab-bar.tsx",
-      "encapsulation": "none",
+      "fileName": "ino-tab-bar.tsx",
       "tag": "ino-tab-bar",
       "readme": "# ino-tab-bar\n\nTabs organize and allow navigation between groups of content that are related and at the same hierarchical level. The Tab Bar contains the Tab Scroller and Tab components. It functions as a wrapper around the material [Tab Bar](https://github.com/material-components/material-components-web/tree/master/packages/mdc-tab-bar) component.\n\n### Usage\n\nThe component can be used as follows:\n\n```js\ndocument\n  .querySelector('ino-tab-bar')\n  .addEventListener('activeTabChange', (e) =>\n    console.log(`The index of the new tab is: ${e.detail}`),\n  );\n```\n\n```jsx\n<ino-tab-bar\n  active-tab=\"<number>\"\n  onactivetabchange=\"handleActiveTabChange()\"\n>\n  <ino-tab ...></ino-tab>\n</ino-tab-bar>\n```\n\n### React\n\n#### Example #1 - Basic\n\n```js\nimport { Component } from 'react';\nimport { InoTab, InoTabBar } from '@inovex.de/elements/dist/react';\n\nclass MyComponent extends Component {\n  render() {\n    return (\n      <InoTabBar inoActiveTab={2}>\n        <InoTab inoLabel=\"Tab #1\" />\n        <InoTab inoLabel=\"Tab #2\" />\n        <InoTab inoLabel=\"Tab #3\" />\n      </InoTabBar>\n    );\n  }\n}\n```\n\n#### Example #2 - With Types\n\n```js\nimport React, { Component } from 'react';\nimport { InoTab, InoTabBar } from '@inovex.de/elements/dist/react';\nimport { Components } from '@inovex.de/elements/dist/types/components';\n\nconst TabBar: React.FunctionComponent<Components.InoTabBarAttributes> = (\n  props,\n) => {\n  const { inoActiveTab } = props;\n\n  return <InoTabBar inoActiveTab={inoActiveTab}>{props.children}</InoTabBar>;\n};\n\nclass MyComponent extends Component {\n  render() {\n    return (\n      <TabBar inoActiveTab={2}>\n        <InoTab inoLabel=\"Tab #1\" />\n        <InoTab inoLabel=\"Tab #2\" />\n        <InoTab inoLabel=\"Tab #3\" />\n      </TabBar>\n    );\n  }\n}\n```\n\n## Additional Hints\n\n### Control flow\n\nThe tab bar has a controlled (unmanaged) attribute `active-tab`. For this reason, the tab doesn't change on user interactions but on updates of `active-tab`. Listen to `activeTabChange`, sync it with your local state and pass the new index to the component again to activate the tab.\n\n```jsx\n<ino-tab-bar\n  active-tab={this.state.index}\n  activeTabChange={(e) => (this.state.index = e.detail)}\n/>\n```\n",
+      "usage": {},
       "docs": "Tabs organize and allow navigation between groups of content that are related and at the same hierarchical level. The Tab Bar contains the Tab Scroller and Tab components. It functions as a wrapper around the material [Tab Bar](https://github.com/material-components/material-components-web/tree/master/packages/mdc-tab-bar) component.",
       "docsTags": [
         {
@@ -7587,7 +7631,10 @@
           "text": "default - One or more `ino-tab`"
         }
       ],
-      "usage": {},
+      "encapsulation": "none",
+      "dependents": [],
+      "dependencies": [],
+      "dependencyGraph": {},
       "props": [
         {
           "name": "activeTab",
@@ -7636,13 +7683,6 @@
           "docsTags": []
         }
       ],
-      "listeners": [
-        {
-          "event": "interacted",
-          "capture": false,
-          "passive": false
-        }
-      ],
       "styles": [],
       "slots": [
         {
@@ -7651,15 +7691,20 @@
         }
       ],
       "parts": [],
-      "dependents": [],
-      "dependencies": [],
-      "dependencyGraph": {}
+      "listeners": [
+        {
+          "event": "interacted",
+          "capture": false,
+          "passive": false
+        }
+      ]
     },
     {
       "filePath": "./src/components/ino-table/ino-table.tsx",
-      "encapsulation": "none",
+      "fileName": "ino-table.tsx",
       "tag": "ino-table",
       "readme": "# ino-table\nThe ino-table is a custom table used to display sets of data across multiple columns.\nIt currently supports different states (selected, active), sorting and loading indication.\n\n> The component is based on the [mdc-data-table](https://github.com/material-components/material-components-web/tree/master/packages/mdc-data-table).\n\n## Usage\nThe table itself is a wrapper component around native `tr` and `td`. It renders a native `table` element itself and provides the styling for rows and column cell. As a side note it should be said, that having separate `ino-table-row` and `ino-table-header-cell` components would be the more consistent way with respect to the other components (for instance select or radio buttons). However, in large tables, rendering thousands of elements would be a massive overhead for mainly styling purposes.\n\nNonetheless, a separate `ino-table-header-cell` element contains all the sorting and searching behaviour you may need to make more your tables more intelligent.\n\n\n### Web Component\n\n```html\n<ino-table>\n  <tr slot=\"header-row\">\n    <td>Column A</td>\n    <td>Column B</td>\n  </tr>\n  <tr>\n    <td>Cell A1</td>\n    <td>Cell B1</td>\n  </tr>\n  <tr>\n    <td>Cell A2</td>\n    <td>Cell B2</td>\n  </tr>\n</ino-table>\n```\n\n### React\n\n```jsx\nimport React from 'react';\nimport { Component } from 'react';\nimport { InoTable, InoButton } from '@inovex/elements-react';\n\nclass MyComponent extends Component {\n\n  state = { selected: false };\n\n  handleEvent = () => this.setState(state => ({ selected: !state.selected }));\n\n  render() {\n    return (\n      <InoTable>\n        <tr className={ this.state.selected ?? 'ino-table__row--selected' }>\n          <td>\n            <InoButton onClick={this.handleEvent()}>Click Me</InoButton>\n          </td>\n        </tr>\n      </InoTable>\n    );\n  }\n}\n```\n\n## States\nThe table supports the following states:\n\n### Loading indication\nIn order to show the user that data is being loaded and to prohibit any user interaction, set `loading=\"true\"` on the `ino-table`.\nAdditionally, one can display a `<ino-progress-bar>` as follows:\n\n```html\n<ino-progress-bar slot=\"loading-indicator\" active indeterminate></ino-progress-bar>\n```\n\nProvide the progress bar as child of the `ino-table` in order render the slot `loading-indicator` at the desired position. Also note the debounce time of 500ms in the example above. While the progress-bar is only shown after a loading time of more than 500ms, the table is immediately disabled for any user interaction.\n\n> **Note** The table's `loading` and the progress indicator's `active` attribute are **independent**. You are responsible by yourself to keep their values in sync.\n\n## Sorting\nThe table provides the general setup for sorting. For full flexibility, the table does not actually perform the sorting by itself but notifies you that the user wants to sort for a column and direction. As a reaction, you may want to sort for the column and direction and update the respective properties/attributes on the `ino-table` element.\n\nFirst, set the sorted column, provide the `sort-column-id` and `sort-direction` attributes/properties on `ino-table`. In order to receive updates as soon as the sorting direction or column changes, use the `sortChange` event which contains the `columnId` and the target `sortDirection`.\n\n\n**Example:**\n\n```js\nconst sortChangeHandler = e => {\n  const inoTable = e.target as Components.InoTable;\n  const { columnId, sortDirection } = e.detail;\n\n  // Implement sorting algorithm here ...\n\n  inoTable.sortColumnId = columnId;\n  inoTable.sortDirection = sortDirection;\n};\ndocument.addEventListener('sortChange', sortChangeHandler);\n```\n\n```html\n<ino-table sort-column-id=\"column-a\" sort-direction=\"asc\">\n  <tr>\n    <ino-table-header-cell column-id=\"column-a\">Column A</ino-table-header-cell>\n    <ino-table-header-cell column-id=\"column-b\">Column B</ino-table-header-cell>\n  </tr>\n  <tr>\n    <td>Cell A1</td>\n    <td>Cell B1</td>\n  </tr>\n  <tr>\n    <td>Cell A2</td>\n    <td>Cell B2</td>\n  </tr>\n</ino-table>\n```\n\n## Rows and Cells\n\n### Table row\nFor table rows use the native `tr` elements. Use the `slot=\"header-row\"` in order to render the row as header within the `table > thead`. The default slot of the `ino-table` is treated as table content containing multiple `tr` elements. For default styling, there is no class needed. However, the following state classes are available:\n\n| State              | Usage                                        | Description                                                                       |\n|--------------------|----------------------------------------------|-----------------------------------------------------------------------------------|\n| Selected table row | `<tr class=\"ino-table__row--selected\"></tr>` | Indicates that the user selected a row.                                           |\n| Selected table row | `<tr class=\"ino-table__row--active\"></tr>`   | Indicates that the user activates a row (for instance to show detail information) |\n\nFurthermore, the `--ino-table-row-height` css variables allows you to increase or decrease the density of rows. This may be useful to provide the user customization option.\n\n\n### Table cell\nFor table cells `td`, `th` or, if needed, `ino-table-header-cell` elements. All table cells retrieve their styling options from the wrapping `ino-table` element, so you don't need to set any classes by default. However, you may want to use the following classes to provide customization options:\n\n| Name                | Usage                                         | Description                                                                                                 |\n|---------------------|-----------------------------------------------|-------------------------------------------------------------------------------------------------------------|\n| Table cell selector | `<td class=\"ino-table__cell--checkbox\"></td>` | Indicates that a table cell contains a checkbox which to select the current row (body) or all rows (header) |\n| Table cell numeric  | `<td class=\"ino-table__cell--numeric\"></td>`  | Indicates that the value is numeric (Mainly sets `text-align: right`).                                      |\n\n",
+      "usage": {},
       "docs": "The ino-table is a custom table used to display sets of data across multiple columns.\nIt currently supports different states (selected, active), sorting and loading indication.\n\n> The component is based on the [mdc-data-table](https://github.com/material-components/material-components-web/tree/master/packages/mdc-data-table).",
       "docsTags": [
         {
@@ -7675,7 +7720,10 @@
           "text": "loading-indicator - `<ino-progess-bar>` element used for an additional loading state."
         }
       ],
-      "usage": {},
+      "encapsulation": "none",
+      "dependents": [],
+      "dependencies": [],
+      "dependencyGraph": {},
       "props": [
         {
           "name": "loading",
@@ -7781,13 +7829,6 @@
           "docsTags": []
         }
       ],
-      "listeners": [
-        {
-          "event": "sortDirectionChange",
-          "capture": false,
-          "passive": false
-        }
-      ],
       "styles": [
         {
           "name": "--ino-table-row-height",
@@ -7810,15 +7851,20 @@
         }
       ],
       "parts": [],
-      "dependents": [],
-      "dependencies": [],
-      "dependencyGraph": {}
+      "listeners": [
+        {
+          "event": "sortDirectionChange",
+          "capture": false,
+          "passive": false
+        }
+      ]
     },
     {
       "filePath": "./src/components/ino-table-header-cell/ino-table-header-cell.tsx",
-      "encapsulation": "none",
+      "fileName": "ino-table-header-cell.tsx",
       "tag": "ino-table-header-cell",
       "readme": "# ino-table-header-cell\n\nThe `ino-table-header-cell` is a particular header cell to provide search and column sort behaviour on `ino-table`'s.\n\n## Usage\n\nThe component can be used as follows:\n\n```html\n<ino-table-header-cell\n  column-id=\"<string>\"\n  label=\"<string>\"\n  search-icon=\"<string>\"\n  not-sortable=\"<boolean>\"\n  sort-direction=\"<string>\"\n  sort-start=\"asc|desc\"\n></ino-table-header-cell>\n```\n\n## Sorting\n\nSet the `sortable` attribute/property on this column. The feature itself does not provide a sorting algorithm itself but notifies you whenever the user wants to sort\nthe column in a specific direction. The `sort-direction` shows the current sort direction, the `sort-start` changes the default sort direction.\n\nThe element emits a `sortDirectionChange` event which you can handle to implement the sorting behaviour. In most cases, however, it is recommended\nlet the `ino-table` handle it. Otherwise, you have to implement the logic to reset other columns in the table yourself (which may be useful when you want to sort\nfor multiple columns).\n\nFor the recommended approach, set the `column-id` such that the `ino-table` knows the identity of this column. For more details, see the documentation of `ino-table`.\n\n```html\n<tr slot=\"header-row\">\n  <ino-table-header-cell\n    label=\"1\"\n    column-id=\"column-name\"\n    sortable\n    sort-direction=\"asc\"\n  ></ino-table-header-cell>\n  <ino-table-header-cell label=\"Cell content\"></ino-table-header-cell>\n</tr>\n```\n\n## Searching\n\nIn order to add a floating column search as popover, add any desired form element as child of this component. The feature itself does not provide a search (or filter) algorithm itself but allows you to render search fields, selection or datepicker within a `ino-popover`. Based on the input, you may want to trigger a search in the backend or filter your elements locally.\n\nThe `search-icon` allows you to set an alternative to the default `search`, which may be useful for selections (`list`) or datepickers (`calender`).The slot contains the search input within the popover. In order to indicate to the user that a closed popover search input contains value, i.e. has been searched, set the `searched` property on the table-header-cell.\n\nUse the `data-ino-focus` on popover elements to focus them on load. Currently, `ino-input`, `ino-textarea` and `ino-datepicker` are supported.\n\n> Note: During initial rendering, the component checks for child elements and decides its searchability. However, if you need to change the search behaviour after initial rendering (for instance lazy load the input elements), use the `setSortable` method to update the behaviour.\n\n**Example:**\n\n```html\n<ino-table>\n  <tr slot=\"header-row\">\n    <ino-table-header-cell label=\"Simple text field\">\n      <ino-input placeholder=\"Search for XY...\" data-ino-focus>\n        <ino-icon\n          clickable\n          slot=\"ino-icon-trailing\"\n          icon=\"close--dense\"\n        ></ino-icon>\n      </ino-input>\n    </ino-table-header-cell>\n\n    <ino-table-header-cell\n      label=\"Column Selection Search\"\n      search-icon=\"list\"\n    >\n      <ino-list>\n        <ino-list-item text=\"Option 1\"\n          ><ino-checkbox\n            slot=\"ino-list-item-leading\"\n            selection\n          ></ino-checkbox\n        ></ino-list-item>\n        <ino-list-item-divider inset></ino-list-item-divider>\n        <ino-list-item text=\"Option 2\"\n          ><ino-checkbox\n            slot=\"ino-list-item-leading\"\n            selection\n          ></ino-checkbox\n        ></ino-list-item>\n        <ino-list-item-divider inset></ino-list-item-divider>\n        <ino-list-item text=\"Option 3\"\n          ><ino-checkbox\n            slot=\"ino-list-item-leading\"\n            selection\n          ></ino-checkbox\n        ></ino-list-item>\n        <ino-list-item-divider inset></ino-list-item-divider>\n        <ino-list-item text=\"Option 4\"\n          ><ino-checkbox\n            slot=\"ino-list-item-leading\"\n            selection\n          ></ino-checkbox\n        ></ino-list-item>\n        <ino-list-item-divider inset></ino-list-item-divider>\n      </ino-list>\n    </ino-table-header-cell>\n  </tr>\n</ino-table>\n```\n",
+      "usage": {},
       "docs": "The `ino-table-header-cell` is a particular header cell to provide search and column sort behaviour on `ino-table`'s.",
       "docsTags": [
         {
@@ -7826,7 +7872,23 @@
           "text": "default - The search content (input field, list) within the popover."
         }
       ],
-      "usage": {},
+      "encapsulation": "none",
+      "dependents": [],
+      "dependencies": [
+        "ino-popover",
+        "ino-icon",
+        "ino-icon-button"
+      ],
+      "dependencyGraph": {
+        "ino-table-header-cell": [
+          "ino-popover",
+          "ino-icon",
+          "ino-icon-button"
+        ],
+        "ino-icon-button": [
+          "ino-icon"
+        ]
+      },
       "props": [
         {
           "name": "autofocus",
@@ -8032,7 +8094,6 @@
           "docsTags": []
         }
       ],
-      "listeners": [],
       "styles": [],
       "slots": [
         {
@@ -8041,31 +8102,31 @@
         }
       ],
       "parts": [],
-      "dependents": [],
-      "dependencies": [
-        "ino-popover",
-        "ino-icon",
-        "ino-icon-button"
-      ],
-      "dependencyGraph": {
-        "ino-table-header-cell": [
-          "ino-popover",
-          "ino-icon",
-          "ino-icon-button"
-        ],
-        "ino-icon-button": [
-          "ino-icon"
-        ]
-      }
+      "listeners": []
     },
     {
       "filePath": "./src/components/ino-textarea/ino-textarea.tsx",
-      "encapsulation": "none",
+      "fileName": "ino-textarea.tsx",
       "tag": "ino-textarea",
       "readme": "# ino-textarea\n\nA textarea component with styles. It uses a material [textfield](https://github.com/material-components/material-components-web/tree/master/packages/mdc-textfield) component for its styling.\n\n> **Note:** The textarea is always styled in an outlined manner. If you need to use a textarea in combination with other form inputs (`ino-input`), use their respective outline style.\n\n### Usage\n\nThe component can be used as follows:\n\n```js\ndocument\n  .querySelector('ino-textarea')\n  .addEventListener('valueChange', (e) =>\n    alert(`The new textarea value is ${e.detail}`),\n  );\n```\n\n```html\n<ino-textarea\n  autofocus\n  cols=\"<number>\"\n  disabled\n  maxlength=\"<number>\"\n  minlength=\"<number>\"\n  name=\"<string>\"\n  placeholder=\"<string>\"\n  required\n  rows=\"<number>\"\n  value=\"<string>\"\n  autogrow\n  label=\"<string>\"\n>\n</ino-textarea>\n```\n\n### React\n\n#### Example #1 - Basic\n\n```js\nimport { Component } from 'react';\nimport { InoTextarea } from '@inovex.de/elements/dist/react';\n\nclass MyComponent extends Component {\n  render() {\n    return (\n      <InoTextarea autogrow>\n        Here's some text. And the textarea will grow when you enter more...\n      </InoTextarea>\n    );\n  }\n}\n```\n\n#### Example #2 - With Types\n\n```js\nimport React, { Component } from 'react';\nimport { InoTextarea } from '@inovex.de/elements/dist/react';\nimport { Components } from '@inovex.de/elements/dist/types/components';\n\nconst Textarea: React.FunctionComponent<Components.InoTextareaAttributes> = (\n  props,\n) => {\n  const { autogrow } = props;\n\n  return <InoTextarea autogrow={autogrow}>{props.children}</InoTextarea>;\n};\n\nclass MyComponent extends Component {\n  render() {\n    return (\n      <Textarea autogrow>\n        Here's some text. And the textarea will grow when you enter more...\n      </Textarea>\n    );\n  }\n}\n```\n\n## Additional Hints\n\n**Labels**: The component shows a floating label containing the value of `label`.\n\n### Control flow\n\nThe textarea has a controlled (unmanaged) attribute `value`. For this reason, the value doesn't change on user interaction but on updates of `value`. Listen to `valueChange`, sync it with your local state and pass the new value to the component again to change value of input.\n\n```js\ndocument.querySelector('ino-textarea').addEventListener('valueChanges', (e) => {\n  // ...\n});\n```\n\n```html\n<ino-textarea\n  value={this.state.value}\n  valueChange={e => this.state.value = e.detail}>\n</ino-textarea>\n```\n\n### Event Behaviour\n\nThe component is based on a native input with additional features. Thus, the component bubbles events triggered by the native [HTMLTextareaElement](https://developer.mozilla.org/en-US/docs/Web/API/HTMLTextAreaElement) like `keyup`. The native `input` and `change` event is not bubbled because the value will only change when the value attribute changes.\n",
+      "usage": {},
       "docs": "A textarea component with styles. It uses a material [textfield](https://github.com/material-components/material-components-web/tree/master/packages/mdc-textfield) component for its styling.\n\n> **Note:** The textarea is always styled in an outlined manner. If you need to use a textarea in combination with other form inputs (`ino-input`), use their respective outline style.",
       "docsTags": [],
-      "usage": {},
+      "encapsulation": "none",
+      "dependents": [
+        "ino-markdown-editor"
+      ],
+      "dependencies": [
+        "ino-label"
+      ],
+      "dependencyGraph": {
+        "ino-textarea": [
+          "ino-label"
+        ],
+        "ino-markdown-editor": [
+          "ino-textarea"
+        ]
+      },
       "props": [
         {
           "name": "autoFocus",
@@ -8354,18 +8415,6 @@
           "docsTags": []
         }
       ],
-      "listeners": [
-        {
-          "event": "change",
-          "capture": false,
-          "passive": false
-        },
-        {
-          "event": "input",
-          "capture": false,
-          "passive": false
-        }
-      ],
       "styles": [
         {
           "name": "--ino-textarea-caret-color",
@@ -8385,29 +8434,37 @@
       ],
       "slots": [],
       "parts": [],
-      "dependents": [
-        "ino-markdown-editor"
-      ],
-      "dependencies": [
-        "ino-label"
-      ],
-      "dependencyGraph": {
-        "ino-textarea": [
-          "ino-label"
-        ],
-        "ino-markdown-editor": [
-          "ino-textarea"
-        ]
-      }
+      "listeners": [
+        {
+          "event": "change",
+          "capture": false,
+          "passive": false
+        },
+        {
+          "event": "input",
+          "capture": false,
+          "passive": false
+        }
+      ]
     },
     {
       "filePath": "./src/components/ino-tooltip/ino-tooltip.tsx",
-      "encapsulation": "none",
+      "fileName": "ino-tooltip.tsx",
       "tag": "ino-tooltip",
       "readme": "# ino-tooltip\n\nA tooltip component that displays text when users hover over, focus on, or tap an element.\n\n> Note: A tooltip can only display plain text. For more complex dialogs, see the [Popover](https://elements.inovex.de/dist/latest/storybook/?path=/story/notification-ino-popover--default-usage) component.\n\n### Usage\n\nThe component can be used as follows:\n\n```html\n<ino-tooltip\n  for=\"<string>\"\n  label=\"<string>\"\n  placement=\"<string>\"\n  trigger=\"<string>\"\n>\n  Any desired HTML\n</ino-tooltip>\n```\n\n### React\n\n#### Example #1 - Basic\n\n```js\nimport { Component } from 'react';\nimport { InoButton, InoTooltip } from '@inovex.de/elements/dist/react';\n\nclass MyComponent extends Component {\n  render() {\n    return (\n      <InoButton id=\"tooltip-button\">Hover me to see the Tooltip!</InoButton>\n      <InoTooltip inoFor=\"tooltip-button\" inoLabel=\"This is the tooltip!\" inoPlacement=\"top\" inoTrigger=\"hover\" />\n    );\n  }\n}\n```\n\n#### Example #2 - With Types\n\n```js\nimport React, { Component } from 'react';\nimport { InoButton, InoTooltip } from '@inovex.de/elements/dist/react';\nimport { Components } from '@inovex.de/elements/dist/types/components';\n\nconst Tooltip: React.FunctionComponent<Components.InoTooltipAttributes> = props => {\n  const { inoPlacement, inoTrigger, inoFor, inoLabel } = props;\n\n  return <InoTooltip inoFor={inoFor} inoLabel={inoLabel} inoPlacement={inoPlacement} inoTrigger={inoTrigger}>{props.children}</InoTooltip>\n};\n\nclass MyComponent extends Component {\n  render() {\n    return (\n      <InoButton id=\"tooltip-button\">Hover me to see the Tooltip!</InoButton>\n      <Tooltip inoFor=\"tooltip-button\" inoLabel=\"This is the tooltip!\" inoPlacement=\"top\" inoTrigger=\"hover\" />\n    );\n  }\n}\n```\n\n## Additional Hints\n",
+      "usage": {},
       "docs": "A tooltip component that displays text when users hover over, focus on, or tap an element.\n\n> Note: A tooltip can only display plain text. For more complex dialogs, see the [Popover](https://elements.inovex.de/dist/latest/storybook/?path=/story/notification-ino-popover--default-usage) component.",
       "docsTags": [],
-      "usage": {},
+      "encapsulation": "none",
+      "dependents": [
+        "ino-fab"
+      ],
+      "dependencies": [],
+      "dependencyGraph": {
+        "ino-fab": [
+          "ino-tooltip"
+        ]
+      },
       "props": [
         {
           "name": "colorScheme",
@@ -8634,19 +8691,10 @@
         }
       ],
       "events": [],
-      "listeners": [],
       "styles": [],
       "slots": [],
       "parts": [],
-      "dependents": [
-        "ino-fab"
-      ],
-      "dependencies": [],
-      "dependencyGraph": {
-        "ino-fab": [
-          "ino-tooltip"
-        ]
-      }
+      "listeners": []
     }
   ]
 }


### PR DESCRIPTION
## Proposed Changes

- The core package generates a JSON-File with each build (`packages/storybook/elements-stencil-docs.json`) describing all components and properties
- This file includes a `timestamp` of its generation that **always** leads to merge conflicts
- I wrote a custom output target that deletes the `timestamp` (and other irrelevant props) before writing to the file
