### PR TITLE
fix(elements|ino-icon-button): improve button styling in disabled state

### DIFF
--- a/packages/elements/src/components/ino-icon-button/ino-icon-button.scss
+++ b/packages/elements/src/components/ino-icon-button/ino-icon-button.scss
@@ -77,7 +77,19 @@ ino-icon-button {
     }
   }
 
-  button:disabled ino-icon {
-    --icon-color: #{theme.color(dark, light)};
+  // Disabled
+
+  .ino-icon-button--disabled.ino-icon-button-filled {
+    --ino-icon-button-background-color: #{theme.color(dark, light)};
+
+    ino-icon {
+      --ino-icon-button-icon-color: #fff;
+    }
+  }
+
+  .ino-icon-button--disabled:not(.ino-icon-button-filled) {
+    ino-icon {
+      --ino-icon-button-icon-color: #{theme.color(dark, light)};
+    }
   }
 }

--- a/packages/elements/src/components/ino-icon-button/ino-icon-button.scss
+++ b/packages/elements/src/components/ino-icon-button/ino-icon-button.scss
@@ -12,6 +12,8 @@ ino-icon-button {
     * @prop --ino-icon-button-background-color: default color of the background
     * @prop --ino-icon-button-icon-active-color: color of the active icon itself
     * @prop --ino-icon-button-background-active-color: base color of the active background
+    * @prop --ino-icon-button-icon-disabled-color: color of the icon itself in disabled state
+    * @prop --ino-icon-button-background-disabled-color: base color of the background in disabled state
   */
 
   $button-size: var(--ino-icon-button-size, 48px);
@@ -80,7 +82,10 @@ ino-icon-button {
   // Disabled
 
   .ino-icon-button--disabled.ino-icon-button-filled {
-    --ino-icon-button-background-color: #{theme.color(dark, light)};
+    --ino-icon-button-background-color: var(
+      --ino-icon-button-background-disabled-color,
+      #{theme.color(dark, light)}
+    );
 
     ino-icon {
       --ino-icon-button-icon-color: #fff;
@@ -89,7 +94,10 @@ ino-icon-button {
 
   .ino-icon-button--disabled:not(.ino-icon-button-filled) {
     ino-icon {
-      --ino-icon-button-icon-color: #{theme.color(dark, light)};
+      --ino-icon-button-icon-color: var(
+        --ino-icon-button-icon-disabled-color,
+        #{theme.color(dark, light)}
+      );
     }
   }
 }

--- a/packages/elements/src/components/ino-icon-button/ino-icon-button.tsx
+++ b/packages/elements/src/components/ino-icon-button/ino-icon-button.tsx
@@ -123,6 +123,8 @@ export class IconButton implements ComponentInterface {
     const iconButtonClasses = classNames({
       'mdc-icon-button': true,
       'mdc-ripple-upgraded--background-focused': this.activated,
+      'ino-icon-button-filled': this.filled,
+      'ino-icon-button--disabled': this.disabled,
     });
 
     return (

--- a/packages/elements/src/components/ino-icon-button/readme.md
+++ b/packages/elements/src/components/ino-icon-button/readme.md
@@ -126,14 +126,16 @@ The component bubbles the native `click`-Event to the user.
 
 ## CSS Custom Properties
 
-| Name                                        | Description                         |
-| ------------------------------------------- | ----------------------------------- |
-| `--ino-icon-button-background-active-color` | base color of the active background |
-| `--ino-icon-button-background-color`        | default color of the background     |
-| `--ino-icon-button-icon-active-color`       | color of the active icon itself     |
-| `--ino-icon-button-icon-color`              | default color of the icon itself    |
-| `--ino-icon-button-icon-size`               | size of the icon itself             |
-| `--ino-icon-button-size`                    | size of the entire button           |
+| Name                                          | Description                                    |
+| --------------------------------------------- | ---------------------------------------------- |
+| `--ino-icon-button-background-active-color`   | base color of the active background            |
+| `--ino-icon-button-background-color`          | default color of the background                |
+| `--ino-icon-button-background-disabled-color` | base color of the background in disabled state |
+| `--ino-icon-button-icon-active-color`         | color of the active icon itself                |
+| `--ino-icon-button-icon-color`                | default color of the icon itself               |
+| `--ino-icon-button-icon-disabled-color`       | color of the icon itself in disabled state     |
+| `--ino-icon-button-icon-size`                 | size of the icon itself                        |
+| `--ino-icon-button-size`                      | size of the entire button                      |
 
 
 ## Dependencies

--- a/packages/storybook/src/stories/ino-icon-button/ino-icon-button.stories.ts
+++ b/packages/storybook/src/stories/ino-icon-button/ino-icon-button.stories.ts
@@ -119,6 +119,25 @@ export const States = () => html`
           activated
         ></ino-icon-button>
       </div>
+
+      <div class="flex-child">
+        <h4>Disabled</h4>
+        <ino-icon-button
+          icon="time"
+          color-scheme="primary"
+          disabled
+        ></ino-icon-button>
+      </div>
+
+      <div class="flex-child">
+        <h4>Disabled (filled)</h4>
+        <ino-icon-button
+          icon="time"
+          color-scheme="primary"
+          disabled
+          filled
+        ></ino-icon-button>
+      </div>
     </div>
   </div>
 `;

--- a/packages/storybook/src/stories/ino-icon-button/ino-icon-button.stories.ts
+++ b/packages/storybook/src/stories/ino-icon-button/ino-icon-button.stories.ts
@@ -185,6 +185,35 @@ export const Variations = () => html`
   </div>
 `;
 
+export const CSSProperties = (args) => {
+  return html`
+    <style>
+      .customizable-icon-button {
+        --ino-icon-button-background-disabled-color: ${args.inoIconButtonBackgroundDisabledColor};
+        --ino-icon-button-icon-disabled-color: ${args.inoIconButtonIconDisabledColor};
+      }
+    </style>
+    <ino-icon-button
+      class="customizable-icon-button"
+      disabled="${args.disabled}"
+      filled="${args.filled}"
+      color-scheme="primary"
+      icon="time"
+    >
+    </ino-icon-button>
+  `;
+};
+CSSProperties.args = {
+  disabled: 'true',
+  filled: 'true',
+  inoIconButtonBackgroundDisabledColor: '#EB002D',
+  inoIconButtonIconDisabledColor: '#820F35'
+};
+CSSProperties.argTypes = {
+  inoIconButtonBackgroundDisabledColor: { control: 'color' },
+  inoIconButtonIconDisabledColor: { control: 'color' }
+}
+
 // import readme from '../../../../../elements/src/components/ino-icon-button/readme.md';
 // import { renderWithMermaid } from '../../../core/with-stencil-readme';
 // export const Documentation = () => renderWithMermaid(readme);

--- a/packages/storybook/src/stories/ino-icon-button/ino-icon-button.stories.ts
+++ b/packages/storybook/src/stories/ino-icon-button/ino-icon-button.stories.ts
@@ -191,6 +191,12 @@ export const CSSProperties = (args) => {
       .customizable-icon-button {
         --ino-icon-button-background-disabled-color: ${args.inoIconButtonBackgroundDisabledColor};
         --ino-icon-button-icon-disabled-color: ${args.inoIconButtonIconDisabledColor};
+        --ino-icon-button-size: ${args.inoIconButtonSize};
+        --ino-icon-button-icon-size: ${args.inoIconButtonIconSize};
+        --ino-icon-button-icon-color: ${args.inoIconButtonIconColor};
+        --ino-icon-button-background-color: ${args.inoIconButtonBackgroundColor};
+        --ino-icon-button-icon-active-color: ${args.inoIconButtonIconActiveColor};
+        --ino-icon-button-background-active-color: ${args.inoIconButtonBackgroundActiveColor};
       }
     </style>
     <ino-icon-button
@@ -198,20 +204,52 @@ export const CSSProperties = (args) => {
       disabled="${args.disabled}"
       filled="${args.filled}"
       color-scheme="primary"
+      activated="${args.activated}"
       icon="time"
     >
     </ino-icon-button>
   `;
 };
 CSSProperties.args = {
-  disabled: 'true',
-  filled: 'true',
-  inoIconButtonBackgroundDisabledColor: '#EB002D',
-  inoIconButtonIconDisabledColor: '#820F35'
+  disabled: 'false',
+  filled: 'false',
+  activated: 'false',
+  inoIconButtonBackgroundDisabledColor: '#00B9EB',
+  inoIconButtonIconDisabledColor: '#D35D85',
+  inoIconButtonSize: '48px',
+  inoIconButtonIconSize: '24px',
+  inoIconButtonIconColor: '#820F35',
+  inoIconButtonBackgroundColor: 'transparent',
+  inoIconButtonIconActiveColor: '#820F35',
+  inoIconButtonBackgroundActiveColor: '#39DEE3',
 };
 CSSProperties.argTypes = {
   inoIconButtonBackgroundDisabledColor: { control: 'color' },
-  inoIconButtonIconDisabledColor: { control: 'color' }
+  inoIconButtonIconDisabledColor: { control: 'color' },
+  inoIconButtonIconColor: { control: 'color' },
+  inoIconButtonBackgroundColor: { control: 'color' },
+  inoIconButtonIconActiveColor: { control: 'color' },
+  inoIconButtonBackgroundActiveColor: { control: 'color' },
+  autofocus: {
+    table: {
+      disable: true
+    }
+  },
+  colorScheme: {
+    table: {
+      disable: true
+    }
+  },
+  icon: {
+    table: {
+      disable: true
+    }
+  },
+  type: {
+    table: {
+      disable: true
+    }
+  }
 }
 
 // import readme from '../../../../../elements/src/components/ino-icon-button/readme.md';


### PR DESCRIPTION
Closes #513 

## Proposed Changes

- specify styling for disabled state
- add CSS properties for button background and icon in disabled state
- add exemplary CSS properties story
