### PR TITLE
feat(elements|ino-icon-button): use slotted icons

### DIFF
--- a/packages/elements/src/components.d.ts
+++ b/packages/elements/src/components.d.ts
@@ -486,6 +486,7 @@ export namespace Components {
         "filled"?: boolean;
         /**
           * The name of the icon of this element.
+          * @deprecated This property is deprecated and will be removed with the next major release. Instead, use the `icon-leading` slot.
          */
         "icon"?: string;
         /**
@@ -2194,6 +2195,7 @@ declare namespace LocalJSX {
         "filled"?: boolean;
         /**
           * The name of the icon of this element.
+          * @deprecated This property is deprecated and will be removed with the next major release. Instead, use the `icon-leading` slot.
          */
         "icon"?: string;
         /**

--- a/packages/elements/src/components/ino-icon-button/ino-icon-button.tsx
+++ b/packages/elements/src/components/ino-icon-button/ino-icon-button.tsx
@@ -12,9 +12,13 @@ import {
   Watch,
 } from '@stencil/core';
 import classNames from 'classnames';
+import { hasSlotContent } from '../../util/component-utils';
 
 import { ColorScheme, ButtonType } from '../types';
 
+/**
+ * @slot icon-leading - For the icon to be prepended
+ */
 @Component({
   tag: 'ino-icon-button',
   styleUrl: 'ino-icon-button.scss',
@@ -65,7 +69,8 @@ export class IconButton implements ComponentInterface {
 
   /**
    * The name of the icon of this element.
-   */
+   * @deprecated This property is deprecated and will be removed with the next major release. Instead, use the `icon-leading` slot.
+    */
   @Prop() icon?: string;
 
   /**
@@ -88,6 +93,13 @@ export class IconButton implements ComponentInterface {
       e.stopPropagation();
     } else {
       this.clickEl.emit();
+    }
+
+
+    if (this.icon) {
+      console.warn(
+        `Property 'icon' is deprecated and will be removed with the next major release. Instead, use the icon-leading slot.`
+      );
     }
   }
 
@@ -124,6 +136,8 @@ export class IconButton implements ComponentInterface {
       'mdc-icon-button': true,
       'mdc-ripple-upgraded--background-focused': this.activated,
     });
+    
+    const iconSlotHasContent = hasSlotContent(this.el, 'icon-leading');
 
     return (
       <Host class={hostClasses}>
@@ -134,7 +148,8 @@ export class IconButton implements ComponentInterface {
           type={this.type}
         >
           <div class="mdc-icon-button__ripple"/>
-          <ino-icon icon={this.icon} class="mdc-icon-button__icon" />
+          {this.icon && !iconSlotHasContent && <ino-icon icon={this.icon} class="mdc-icon-button__icon" /> }
+          {iconSlotHasContent && <slot name="icon-leading" />}
         </button>
       </Host>
     );

--- a/packages/elements/src/components/ino-icon-button/readme.md
+++ b/packages/elements/src/components/ino-icon-button/readme.md
@@ -106,15 +106,15 @@ The component bubbles the native `click`-Event to the user.
 
 ## Properties
 
-| Property      | Attribute      | Description                                                                                                                                                                                           | Type                                                                                 | Default     |
-| ------------- | -------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ | ----------- |
-| `activated`   | `activated`    | Marks the icon button as activated.  Useful in cases where an external state controls the icon button activation. Makes the component **managed**.                                                    | `boolean`                                                                            | `undefined` |
-| `autoFocus`   | `autofocus`    | Sets the autofocus for this element.                                                                                                                                                                  | `boolean`                                                                            | `undefined` |
-| `colorScheme` | `color-scheme` | The name of the color scheme which is used to style the background and outline of this component. Possible values: `primary` (default),  `secondary`, `success`, `warning`, `error`, `light`, `dark`. | `"dark" \| "error" \| "light" \| "primary" \| "secondary" \| "success" \| "warning"` | `'primary'` |
-| `disabled`    | `disabled`     | Disables this element.                                                                                                                                                                                | `boolean`                                                                            | `undefined` |
-| `filled`      | `filled`       | Styles this element as filled icon button with the `ino-color-scheme` as background color.                                                                                                            | `boolean`                                                                            | `undefined` |
-| `icon`        | `icon`         | The name of the icon of this element.                                                                                                                                                                 | `string`                                                                             | `undefined` |
-| `type`        | `type`         | The type of this form.  Can either be `button`, `submit` or `reset`.                                                                                                                                  | `"button" \| "reset" \| "submit"`                                                    | `'button'`  |
+| Property      | Attribute      | Description                                                                                                                                                                                                       | Type                                                                                 | Default     |
+| ------------- | -------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ | ----------- |
+| `activated`   | `activated`    | Marks the icon button as activated.  Useful in cases where an external state controls the icon button activation. Makes the component **managed**.                                                                | `boolean`                                                                            | `undefined` |
+| `autoFocus`   | `autofocus`    | Sets the autofocus for this element.                                                                                                                                                                              | `boolean`                                                                            | `undefined` |
+| `colorScheme` | `color-scheme` | The name of the color scheme which is used to style the background and outline of this component. Possible values: `primary` (default),  `secondary`, `success`, `warning`, `error`, `light`, `dark`.             | `"dark" \| "error" \| "light" \| "primary" \| "secondary" \| "success" \| "warning"` | `'primary'` |
+| `disabled`    | `disabled`     | Disables this element.                                                                                                                                                                                            | `boolean`                                                                            | `undefined` |
+| `filled`      | `filled`       | Styles this element as filled icon button with the `ino-color-scheme` as background color.                                                                                                                        | `boolean`                                                                            | `undefined` |
+| `icon`        | `icon`         | <span style="color:red">**[DEPRECATED]**</span> This property is deprecated and will be removed with the next major release. Instead, use the `icon-leading` slot.<br/><br/>The name of the icon of this element. | `string`                                                                             | `undefined` |
+| `type`        | `type`         | The type of this form.  Can either be `button`, `submit` or `reset`.                                                                                                                                              | `"button" \| "reset" \| "submit"`                                                    | `'button'`  |
 
 
 ## Events
@@ -122,6 +122,13 @@ The component bubbles the native `click`-Event to the user.
 | Event     | Description                                                                                                        | Type               |
 | --------- | ------------------------------------------------------------------------------------------------------------------ | ------------------ |
 | `clickEl` | Event that emits as soon as the user clicks on the icon. The event only emits if the property `clickable` is true. | `CustomEvent<any>` |
+
+
+## Slots
+
+| Slot             | Description                  |
+| ---------------- | ---------------------------- |
+| `"icon-leading"` | For the icon to be prepended |
 
 
 ## CSS Custom Properties

--- a/packages/storybook/elements-stencil-docs.json
+++ b/packages/storybook/elements-stencil-docs.json
@@ -1,5 +1,5 @@
 {
-  "timestamp": "2022-04-28T13:58:01",
+  "timestamp": "2022-05-17T16:49:03",
   "compiler": {
     "name": "@stencil/core",
     "version": "2.14.0",
@@ -2945,7 +2945,12 @@
       "tag": "ino-icon-button",
       "readme": "# ino-icon-button\n\nA rounded button component that contains an icon. It functions as a wrapper around the material [icon-button](https://github.com/material-components/material-components-web/tree/master/packages/mdc-icon-button) component.\n\n### Usage\n\nThe component can be used as follows:\n\n```js\ndocument\n  .querySelector('ino-icon-button')\n  .addEventListener('click', (_) => alert('The icon button was clicked'));\n```\n\n```html\n<ino-icon-button\n  autofocus\n  disabled\n  activated=\"<boolean>\"\n  icon=\"<string>\"\n>\n</ino-icon-button>\n```\n\n### React\n\n#### Example #1 - Basic\n\n```js\nimport { Component } from 'react';\nimport { InoIconButton } from '@inovex.de/elements/dist/react';\n\nclass MyComponent extends Component {\n  handleClick = (e: any) => {\n    alert(`IconButton was clicked`);\n  };\n\n  render() {\n    return <InoIconButton icon=\"search\" onClick={handleClick} />;\n  }\n}\n```\n\n#### Example #2 - With Types\n\n```js\nimport React, { Component } from 'react';\nimport { InoIconButton } from '@inovex.de/elements/dist/react';\nimport { Components } from '@inovex.de/elements/dist/types/components';\n\nconst IconButton: React.FunctionComponent<Components.InoIconButtonAttributes> = (\n  props,\n) => {\n  const { inoIcon } = props;\n\n  const handleClick = (e: any) => {\n    alert(`IconButton was clicked`);\n  };\n\n  return (\n    <InoIconButton icon={inoIcon} onClick={handleClick}>\n      {props.children}\n    </InoIconButton>\n  );\n};\n\nclass MyComponent extends Component {\n  render() {\n    return <IconButton icon=\"search\" />;\n  }\n}\n```\n\n## Managed Icon Button\n\nButtons, and icon buttons as well, are unmanaged components which swap their state internally based on the interactions. However, in some cases, it may be useful to change this behavior and provide an external state.\n\nThis can be done by using the `activated` flag and further listing to the `click` event to change the state. _Example:_\n\n```js\nactivated = false;\n\ndocument.querySelector('ino-icon-button').addEventListener('click', (e) => {\n  const el = e.target;\n  activated = !activated;\n  activated\n    ? el.addAttribute('activated')\n    : el.removeAttribute('activated');\n});\n```\n\n```html\n<ino-icon-button icon=\"info\"></ino-icon-button>\n```\n\n## Additional Hints\n\n**Toggle Button**: To use the ino-icon-button as a toggle button the user can listen to the native `click`-Event and change the icon in the `icon`-Attribute.\n\n### Native Events\n\nThe component bubbles the native `click`-Event to the user.\n",
       "docs": "A rounded button component that contains an icon. It functions as a wrapper around the material [icon-button](https://github.com/material-components/material-components-web/tree/master/packages/mdc-icon-button) component.",
-      "docsTags": [],
+      "docsTags": [
+        {
+          "name": "slot",
+          "text": "icon-leading - For the icon to be prepended"
+        }
+      ],
       "usage": {},
       "props": [
         {
@@ -3061,7 +3066,13 @@
           "attr": "icon",
           "reflectToAttr": false,
           "docs": "The name of the icon of this element.",
-          "docsTags": [],
+          "docsTags": [
+            {
+              "name": "deprecated",
+              "text": "This property is deprecated and will be removed with the next major release. Instead, use the `icon-leading` slot."
+            }
+          ],
+          "deprecation": "This property is deprecated and will be removed with the next major release. Instead, use the `icon-leading` slot.",
           "values": [
             {
               "type": "string"
@@ -3148,7 +3159,12 @@
           "docs": "size of the entire button"
         }
       ],
-      "slots": [],
+      "slots": [
+        {
+          "name": "icon-leading",
+          "docs": "For the icon to be prepended"
+        }
+      ],
       "parts": [],
       "dependents": [
         "ino-carousel",

--- a/packages/storybook/src/stories/ino-icon-button/ino-icon-button.stories.ts
+++ b/packages/storybook/src/stories/ino-icon-button/ino-icon-button.stories.ts
@@ -24,11 +24,11 @@ export const Playground = (args) => {
       activated="${args.activated}"
       disabled="${args.disabled}"
       filled="${args.filled}"
-      icon="${args.icon}"
       type="${args.type}"
       autofocus="${args.autofocus}"
       color-scheme="${args.colorScheme}"
     >
+      <ino-icon slot="icon-leading" icon="${args.icon}" />
     </ino-icon-button>
   `;
 };
@@ -55,42 +55,47 @@ export const Filled = () => html`
       <div class="flex-child">
         <h4>Primary</h4>
         <ino-icon-button
-          icon="time"
           color-scheme="primary"
           filled
-        ></ino-icon-button>
+        >   
+          <ino-icon slot='icon-leading' icon='time'></ino-icon>
+        </ino-icon-button>
       </div>
       <div class="flex-child">
         <h4>Secondary</h4>
         <ino-icon-button
-          icon="time"
           color-scheme="secondary"
           filled
-        ></ino-icon-button>
+        >    
+         <ino-icon slot='icon-leading' icon='time'></ino-icon>
+        </ino-icon-button>
       </div>
       <div class="flex-child">
         <h4>Success</h4>
         <ino-icon-button
-          icon="time"
           color-scheme="success"
           filled
-        ></ino-icon-button>
+        >
+          <ino-icon slot='icon-leading' icon='time'></ino-icon>
+        </ino-icon-button>
       </div>
       <div class="flex-child">
         <h4>Warning</h4>
         <ino-icon-button
-          icon="time"
           color-scheme="warning"
           filled
-        ></ino-icon-button>
+        > 
+         <ino-icon slot='icon-leading' icon='time'></ino-icon>
+        </ino-icon-button>
       </div>
       <div class="flex-child">
         <h4>Error</h4>
         <ino-icon-button
-          icon="time"
           color-scheme="error"
           filled
-        ></ino-icon-button>
+        >
+          <ino-icon slot='icon-leading' icon='time'></ino-icon>
+        </ino-icon-button>
       </div>
     </div>
   </div>
@@ -103,21 +108,23 @@ export const States = () => html`
         <h4>Activated (Managed)</h4>
         <ino-icon-button
           class="managed"
-          icon="time"
           color-scheme="primary"
           activated
-        ></ino-icon-button>
+        >
+        <ino-icon slot='icon-leading' icon='time'></ino-icon>
+      </ino-icon-button>
       </div>
 
       <div class="flex-child">
         <h4>Activated (Managed, Filled)</h4>
         <ino-icon-button
           class="managed"
-          icon="time"
           color-scheme="primary"
           filled
           activated
-        ></ino-icon-button>
+        >
+        <ino-icon slot='icon-leading' icon='time'></ino-icon>
+      </ino-icon-button>
       </div>
     </div>
   </div>
@@ -131,8 +138,9 @@ export const Variations = () => html`
         <ino-icon-button
           filled
           color-scheme="primary"
-          icon="time"
-        ></ino-icon-button>
+        >
+        <ino-icon slot='icon-leading' icon='time'></ino-icon>
+      </ino-icon-button>
       </div>
       <div class="flex-child">
         <h4>CSS Variables</h4>
@@ -143,9 +151,9 @@ export const Variations = () => html`
           --ino-icon-button-icon-active-color: white;
           --ino-icon-button-background-active-color: pink;
         "
-          icon="time"
         >
-        </ino-icon-button>
+        <ino-icon slot='icon-leading' icon='time'></ino-icon>
+      </ino-icon-button>
       </div>
       <div class="flex-child">
         <h4>Managed + Changing colors</h4>
@@ -157,14 +165,16 @@ export const Variations = () => html`
           --ino-icon-button-icon-active-color: red;
           --ino-icon-button-background-active-color: red;
         "
-          icon="time"
           activated
         >
-        </ino-icon-button>
+        <ino-icon slot='icon-leading' icon='time'></ino-icon>
+      </ino-icon-button>
       </div>
     </div>
   </div>
 `;
+
+
 
 // import readme from '../../../../../elements/src/components/ino-icon-button/readme.md';
 // import { renderWithMermaid } from '../../../core/with-stencil-readme';


### PR DESCRIPTION
Closes #512 

## Proposed Changes

- Move api to use slotted icons
- Adjust Storybook
- Add deprecation warnings  

## Things to check

- [ ] Does the change need to be documented?
- [ ] Does any existing example code needs to be updated?
- [ ] Is the change properly tested?
- [ ] Is it helpful to provide another example to demonstrate the new feature?
- [ ] Are there other code lines that need to be modified?
