### PR TITLE
ci: add action to deploy elements-angular-example project

### DIFF
--- a/.github/workflows/deploy-angular-example.yml
+++ b/.github/workflows/deploy-angular-example.yml
@@ -1,0 +1,63 @@
+name: Deploy angular example
+
+on:
+  workflow_dispatch:
+
+jobs:
+  install:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ./.github/workflows/install
+
+  test:
+    runs-on: ubuntu-latest
+    needs:
+      - install
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ./.github/workflows/install
+      - run: yarn lint
+      - run: yarn test
+
+  build:
+    runs-on: ubuntu-latest
+    needs:
+      - install
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ./.github/workflows/install
+      - run: yarn build
+
+      - name: Upload Example Project Artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: elements-angular-example
+          path:
+            packages/elements-angular-example/dist/
+
+  deploy-elements-angular-example:
+    runs-on: ubuntu-latest
+    needs:
+      - test
+      - build
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: gh-pages
+
+      - uses: actions/download-artifact@v2
+        with:
+          name: elements-angular-example
+          path: ./artifact
+
+      - name: Deploy Angular example project to Github Pages 🚀
+        uses: JamesIves/github-pages-deploy-action@4.1.7
+        with:
+          branch: gh-pages # The branch the action should deploy to.
+          folder: ./artifact # The folder the action should deploy.
+          target-folder: ./example-projects/angular # The folder the action will deploy to.
+          commit-message: Deploying elements-angular-example
+          clean-exclude: |
+            version
+            unicorn


### PR DESCRIPTION
A new git-workflow needs to be deployed to the master in order to be installed as a git action.

This action will deploy the angular-example-project to gh-pages.