### PR TITLE
docs(storybook): collapse component roots by default

### DIFF
--- a/packages/storybook/config/manager.js
+++ b/packages/storybook/config/manager.js
@@ -5,4 +5,8 @@ import theme from './theme';
 addons.setConfig({
   panelPosition: 'bottom',
   theme,
+  sidebar: {
+    showRoots: true,
+    collapsedRoots: ['input', 'buttons', 'structure', 'graphic', 'notification'],
+  },
 });


### PR DESCRIPTION
Closes #727 
