### PR TITLE
fix(elements|ino-select): prevent the `valueChange` event from triggering initially and triggering twice

### DIFF
--- a/packages/elements/src/components/ino-carousel/ino-carousel.e2e.ts
+++ b/packages/elements/src/components/ino-carousel/ino-carousel.e2e.ts
@@ -39,7 +39,6 @@ describe('ino-carousel', () => {
 describe('InoCarousel', () => {
   let page: E2EPage;
   let inoCarousel: E2EElement;
-  let inoCarouselWrapper: E2EElement;
   let iconArrowRight: E2EElement;
   let iconArrowLeft: E2EElement;
 
@@ -53,7 +52,6 @@ describe('InoCarousel', () => {
     </ino-carousel>
     `);
     inoCarousel = await page.find('ino-carousel');
-    inoCarouselWrapper = await page.find('ino-carousel > div');
     iconArrowLeft = await page.find('.ino-carousel__left-arrow > ino-icon-button')
     iconArrowRight = await page.find('.ino-carousel__right-arrow > ino-icon-button')
   });
@@ -87,7 +85,7 @@ describe('InoCarousel', () => {
   it('should show last slide in carousel upon clicking left arrow icon if first slide is showing', async () => {
     inoCarousel.setAttribute('value', 'a');
     await page.waitForChanges()
-    
+
     const eventSpy = await page.spyOnEvent('valueChange');
     await simulateIconClick('Left');
     expect(eventSpy).toHaveReceivedEventDetail('c');

--- a/packages/elements/src/components/ino-option/ino-option.tsx
+++ b/packages/elements/src/components/ino-option/ino-option.tsx
@@ -56,6 +56,10 @@ export class InoOption {
     }
   }
 
+  componentDidLoad() {
+    if (this.value === undefined) console.error('[ino-option]: A value is required.');
+  }
+
   render() {
     const classSelect = classNames({
       'mdc-deprecated-list-item': true,

--- a/packages/elements/src/components/ino-select/ino-select.e2e.ts
+++ b/packages/elements/src/components/ino-select/ino-select.e2e.ts
@@ -3,7 +3,9 @@ import { setupPageWithContent } from '../../util/e2etests-setup';
 
 const INO_SELECT = `
   <ino-select>
-    <ino-option value="1" id="opt1">1</ino-option>
+    <ino-option value="HH">Hamburg</ino-option>
+    <ino-option value="M">Munich</ino-option>
+    <ino-option value="B">Berlin</ino-option>
   </ino-select>
 `;
 const INO_SELECT_SELECTOR = 'ino-select';
@@ -46,13 +48,27 @@ describe('InoSelect', () => {
   });
 
   describe('Events', () => {
-    it('should emit a valueChange event upon receiving a MDCSelect:change event', async () => {
+    it('should emit a valueChange event with correct details', async () => {
       const valueChangeEvent = await page.spyOnEvent('valueChange');
 
-      await inoSelectEl.triggerEvent('MDCSelect:change');
+      const inoOptionEl = await page.waitForSelector('ino-option > li'); // select the element
+      await inoOptionEl.evaluate((b: HTMLInoOptionElement) => b.click());
+
       await page.waitForChanges();
 
-      expect(valueChangeEvent).toHaveReceivedEvent();
+      expect(valueChangeEvent).toHaveReceivedEventDetail('HH');
+
+    });
+
+    it('should emit a valueChange event only one time', async () => {
+      const valueChangeEvent = await page.spyOnEvent('valueChange');
+
+      const inoOptionEl = await page.waitForSelector('ino-option > li'); // select the element
+      await inoOptionEl.evaluate((b: HTMLInoOptionElement) => b.click());
+
+      await page.waitForChanges();
+
+      expect(valueChangeEvent).toHaveReceivedEventTimes(1);
     });
 
     it('should receive submit event if select is required and value is set', async () => {

--- a/packages/elements/src/components/ino-select/ino-select.tsx
+++ b/packages/elements/src/components/ino-select/ino-select.tsx
@@ -175,7 +175,7 @@ export class Select implements ComponentInterface {
   @Listen('MDCSelect:change')
   handleInput(e) {
     e.preventDefault();
-    if (this.mdcSelectInstance && this.mdcSelectInstance.value !== undefined) {
+    if ((this.mdcSelectInstance && this.mdcSelectInstance.value !== undefined) && !(this.mdcSelectInstance.value === this.value)) {
       const value = this.mdcSelectInstance.value;
       this.valueChange.emit(value);
     }

--- a/packages/elements/src/components/ino-select/ino-select.tsx
+++ b/packages/elements/src/components/ino-select/ino-select.tsx
@@ -1,4 +1,4 @@
-import { MDCSelect } from '@material/select';
+import {MDCSelect, MDCSelectEventDetail} from '@material/select';
 import {
   Component,
   ComponentInterface,
@@ -173,11 +173,12 @@ export class Select implements ComponentInterface {
   }
 
   @Listen('MDCSelect:change')
-  handleInput(e) {
+  handleInput(e: CustomEvent<MDCSelectEventDetail>) {
     e.preventDefault();
-    if ((this.mdcSelectInstance && this.mdcSelectInstance.value !== undefined) && !(this.mdcSelectInstance.value === this.value)) {
-      const value = this.mdcSelectInstance.value;
-      this.valueChange.emit(value);
+    const detailValue = e.detail?.value;
+
+    if (detailValue !== this.value) {
+      this.valueChange.emit(detailValue);
     }
   }
 


### PR DESCRIPTION
Closes #729 