### PR TITLE
ci: optimize unicorn deployment

### DIFF
--- a/.github/workflows/deploy-unicorn.yml
+++ b/.github/workflows/deploy-unicorn.yml
@@ -9,51 +9,84 @@ on:
     branches-ignore: [master]
 
 jobs:
-  check-changes:
+  changeDetection:
     runs-on: ubuntu-latest
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     outputs:
-      hasChanges: ${{ steps.dir-check.outputs.hasChanges }}
+      hasChanges: ${{ steps.evaluation.outputs.hasChanges }}
     steps:
       - uses: actions/checkout@v3
         with:
-          fetch-depth: 2
-      - name: Set default output
-        run: echo "::set-output name=hasChanges::false"
+          ref: ${{ github.event.workflow_run.head_branch }}
+          fetch-depth: 0
+
+      # Cache handling to determine the last commit id of unicorn deployment
+      # 1. Load cache file
+      # 2. Read SHA from file
+      # 3. Check if commit SHA has changed
+      # 4. Update cache if necessary
+      - name: Get last commit info file from cache
+        id: cache
+        uses: actions/cache@v3
+        with:
+          path: last_commit_sha.txt
+          key: last-commit-${{ github.event.workflow_run.head_branch }}-${{ github.run_id }}
+          restore-keys: last-commit-${{ github.event.workflow_run.head_branch }}
+      - name: Provide fallback SHA
+        run: echo "sha=${{ github.sha }}" >> $GITHUB_OUTPUT
+      - name: Read commit sha from file
+        id: last-commit
+        if: steps.cache.outputs.cache-hit == 'true'
+        run: echo "sha=$(cat last_commit_sha.txt)" >> $GITHUB_OUTPUT
+      - name: Save commit SHA to cache
+        if: steps.cache.outputs.cache-hit != 'true' || steps.last-commit.outputs.sha != github.event.workflow_run.head_sha
+        run: echo "${{ github.event.workflow_run.head_sha }}" > last_commit_sha.txt
+
       - name: Get changed files
-        id: changed-dirs
+        id: changed-files
         uses: tj-actions/changed-files@v32
         with:
-          dir_names: true
+          base_sha: ${{ steps.last-commit.outputs.sha }}
+          sha: ${{ github.event.workflow_run.head_sha }}
+          files: |
+            packages/elements
+            packages/storybook
+      - name: Print all changed files
+        run: |
+          for file in ${{ steps.changed-files.outputs.all_changed_and_modified_files }}; do
+            echo "$file"
+          done
       - name: Check if storybook or elements was changed
-        id: dir-check
-        if: contains(join(steps.changed-dirs.outputs.all_changed_and_modified_files), 'packages/elements') ||
-          contains(join(steps.changed-dirs.outputs.all_changed_and_modified_files), 'packages/storybook')
-        run: echo "::set-output name=hasChanges::true"
+        id: evaluation
+        if: steps.changed-files.outputs.all_changed_and_modified_files != ''
+        run: echo "hasChanges=true" >> $GITHUB_OUTPUT
 
   deploy-unicorn:
     runs-on: ubuntu-latest
-    if: ${{ needs.check-changes.outputs.hasChanges == 'true' }}
-    needs: check-changes
+    if: ${{ needs.changeDetection.outputs.hasChanges == 'true' }}
+    needs: changeDetection
     environment:
       name: github-pages
       url: ${{ steps.set_env_id.outputs.url }}
     steps:
-    - name: Download Storybook artifact
-      uses: dawidd6/action-download-artifact@v2
-      with:
-        workflow: ${{ github.event.workflow_run.workflow_id }}
-        name: storybook
-        path: storybook-dist
+      - uses: actions/checkout@v3
+        with:
+          ref: gh-pages
+      - name: Download Storybook artifact
+        uses: dawidd6/action-download-artifact@v2
+        with:
+          workflow: ${{ github.event.workflow_run.workflow_id }}
+          name: storybook
+          path: storybook-dist
 
-    - name: Set environment url
-      id: set_env_id
-      run: echo "::set-output name=url::https://elements.inovex.de/unicorn/${{ github.event.workflow_run.head_branch  }}"
+      - name: Set environment url
+        id: set_env_id
+        run: echo "url=https://elements.inovex.de/unicorn/${{ github.event.workflow_run.head_branch }}" >> $GITHUB_OUTPUT
 
-    - name: Deploy to Github Pages 🚀
-      uses: JamesIves/github-pages-deploy-action@4
-      with:
-        folder: ./storybook-dist
-        target-folder: unicorn/${{ github.event.workflow_run.head_branch  }}
-        commit-message: Deploying unicorn ${{ github.event.workflow_run.head_branch  }} 🦄
-        force: true
+      - name: Deploy to Github Pages 🚀
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          folder: ./storybook-dist
+          target-folder: unicorn/${{ github.event.workflow_run.head_branch  }}
+          commit-message: Deploying unicorn ${{ github.event.workflow_run.head_branch  }} 🦄
+          force: true

--- a/.github/workflows/deploy-unicorn.yml
+++ b/.github/workflows/deploy-unicorn.yml
@@ -1,61 +1,59 @@
 name: Deploy Unicorn
 
-## Manual workflow to build & deploy the storybook in a branch to github pages.
 ## The unicorn is public available at elements.inovex.de/unicorn/<BRANCH-NAME>.
 
 on:
-  workflow_dispatch:
+  workflow_run:
+    workflows: ["Test & Build"]
+    types: [completed]
+    branches-ignore: [master]
 
 jobs:
-  test:
+  check-changes:
     runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    outputs:
+      hasChanges: ${{ steps.dir-check.outputs.hasChanges }}
     steps:
       - uses: actions/checkout@v3
-      - uses: ./.github/workflows/dependencies-install
-      - run: yarn lint
-      - run: yarn test
-
-  build:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v3
-    - uses: ./.github/workflows/dependencies-install
-    - run: yarn build
-    - uses: ./.github/workflows/artifacts-upload
-      with:
-        upload-storybook-artifact: true
+        with:
+          fetch-depth: 2
+      - name: Set default output
+        run: echo "::set-output name=hasChanges::false"
+      - name: Get changed files
+        id: changed-dirs
+        uses: tj-actions/changed-files@v32
+        with:
+          dir_names: true
+      - name: Check if storybook or elements was changed
+        id: dir-check
+        if: contains(steps.changed-dirs.outputs.all_changed_and_modified_files, 'elements') &&
+          contains(steps.changed-dirs.outputs.all_changed_and_modified_files, 'storybook')
+        run: echo "::set-output name=hasChanges::true"
 
   deploy-unicorn:
     runs-on: ubuntu-latest
+    if: ${{ needs.check-changes.outputs.hasChanges == 'true' }}
+    needs: check-changes
     environment:
       name: github-pages
       url: ${{ steps.set_env_id.outputs.url }}
-
-    needs:
-      - test
-      - build
     steps:
-      - uses: actions/checkout@v3
-        name: Checkout to gh-pages branch
-        with:
-          ref: gh-pages
-      - uses: rlespinasse/github-slug-action@v3.x
+    - name: Download Storybook artifact
+      uses: dawidd6/action-download-artifact@v2
+      with:
+        workflow: ${{ github.event.workflow_run.workflow_id }}
+        name: storybook
+        path: storybook-dist
 
-      - uses: actions/download-artifact@v2
-        name: Download Storybook Artifact
-        with:
-          name: storybook
-          path: artifact
+    - name: Set environment url
+      id: set_env_id
+      run: echo "::set-output name=url::https://elements.inovex.de/unicorn/${{ github.event.workflow_run.head_branch  }}"
 
-      - run: echo "::set-output name=url::https://elements.inovex.de/unicorn/${{ env.GITHUB_REF_NAME_SLUG }}"
-        name: Set environment url
-        id: set_env_id
-
-      - name: Deploy to Github Pages 🚀
-        uses: JamesIves/github-pages-deploy-action@4.1.7
-        with:
-          branch: gh-pages
-          folder: ./artifact
-          target-folder: unicorn/${{ env.GITHUB_REF_NAME_SLUG }}
-          commit-message: Deploying unicorn ${{ env.GITHUB_REF_NAME_SLUG }} 🦄
-
+    - name: Deploy to Github Pages 🚀
+      uses: JamesIves/github-pages-deploy-action@4
+      with:
+        folder: ./storybook-dist
+        target-folder: unicorn/${{ github.event.workflow_run.head_branch  }}
+        commit-message: Deploying unicorn ${{ github.event.workflow_run.head_branch  }} 🦄
+        force: true

--- a/.github/workflows/deploy-unicorn.yml
+++ b/.github/workflows/deploy-unicorn.yml
@@ -27,8 +27,8 @@ jobs:
           dir_names: true
       - name: Check if storybook or elements was changed
         id: dir-check
-        if: contains(steps.changed-dirs.outputs.all_changed_and_modified_files, 'elements') &&
-          contains(steps.changed-dirs.outputs.all_changed_and_modified_files, 'storybook')
+        if: contains(join(steps.changed-dirs.outputs.all_changed_and_modified_files), 'packages/elements') ||
+          contains(join(steps.changed-dirs.outputs.all_changed_and_modified_files), 'packages/storybook')
         run: echo "::set-output name=hasChanges::true"
 
   deploy-unicorn:

--- a/.github/workflows/deploy-unicorn.yml
+++ b/.github/workflows/deploy-unicorn.yml
@@ -26,27 +26,29 @@ jobs:
       # 3. Check if commit SHA has changed
       # 4. Update cache if necessary
       - name: Get last commit info file from cache
-        id: cache
+        id: sha-cache
         uses: actions/cache@v3
         with:
           path: last_commit_sha.txt
           key: last-commit-${{ github.event.workflow_run.head_branch }}-${{ github.run_id }}
           restore-keys: last-commit-${{ github.event.workflow_run.head_branch }}
-      - name: Provide fallback SHA
-        run: echo "sha=${{ github.sha }}" >> $GITHUB_OUTPUT
+      - uses: andstor/file-existence-action@v1
+        id: check-commit-file
+        with:
+          files: "last_commit_sha.txt"
       - name: Read commit sha from file
         id: last-commit
-        if: steps.cache.outputs.cache-hit == 'true'
+        if: steps.check-commit-file.outputs.files_exists
         run: echo "sha=$(cat last_commit_sha.txt)" >> $GITHUB_OUTPUT
       - name: Save commit SHA to cache
-        if: steps.cache.outputs.cache-hit != 'true' || steps.last-commit.outputs.sha != github.event.workflow_run.head_sha
+        if: steps.last-commit.outputs.sha != github.event.workflow_run.head_sha
         run: echo "${{ github.event.workflow_run.head_sha }}" > last_commit_sha.txt
 
       - name: Get changed files
         id: changed-files
         uses: tj-actions/changed-files@v32
         with:
-          base_sha: ${{ steps.last-commit.outputs.sha }}
+          base_sha: ${{ steps.last-commit.outputs.sha || github.sha }}
           sha: ${{ github.event.workflow_run.head_sha }}
           files: |
             packages/elements

--- a/.github/workflows/deploy-unicorn.yml
+++ b/.github/workflows/deploy-unicorn.yml
@@ -6,7 +6,6 @@ on:
   workflow_run:
     workflows: ["Test & Build"]
     types: [completed]
-    branches-ignore: [master]
 
 jobs:
   changeDetection:

--- a/.github/workflows/destroy-unicorn.yml
+++ b/.github/workflows/destroy-unicorn.yml
@@ -10,12 +10,12 @@ jobs:
     if: github.ref != 'refs/heads/master'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           ref: gh-pages
       - uses: rlespinasse/github-slug-action@v3.x
       - name: Delete Unicorn from github
-        uses: EndBug/add-and-commit@v7
+        uses: EndBug/add-and-commit@v9
         with:
           branch: gh-pages
           message: Destroying unicorn ${{ env.GITHUB_REF_NAME_SLUG }} 🦄

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,6 +24,13 @@ jobs:
     - run: npm config set scripts-prepend-node-path true
     - run: yarn build
 
+    # Build caches for unicorn deployment
+    - if: github.ref != 'refs/heads/master'
+      name: Upload all build artifacts
+      uses: ./.github/workflows/artifacts-upload
+      with:
+        upload-storybook-artifact: true
+
     # Build caches for (canary) release workflow
     - if: github.ref == 'refs/heads/master'
       name: Upload all build artifacts

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,14 +26,14 @@ jobs:
 
     # Build caches for unicorn deployment
     - if: github.ref != 'refs/heads/master'
-      name: Upload all build artifacts
+      name: Upload build artifacts for unicorn deployment
       uses: ./.github/workflows/artifacts-upload
       with:
         upload-storybook-artifact: true
 
     # Build caches for (canary) release workflow
     - if: github.ref == 'refs/heads/master'
-      name: Upload all build artifacts
+      name: Upload build artifacts for canary release
       uses: ./.github/workflows/artifacts-upload
       with:
         upload-core-artifacts: true


### PR DESCRIPTION
Closes #722

## Proposed Changes

- [x] The pipeline should only trigger on elements or storybook package changes (e.g. check the scope of the pull request title?)
- [x] The pipeline should only run if build/test was successful
- [x] We should drop the build/test step because it's guaranteed to run beforehand. Instead, we should download the elements and storybook artifact from the previous step
- [x] Outdated unicorns should be destroyed automatically

<!--
## Things to check

- [ ] Does the change need to be documented?
- [ ] Does any existing example code needs to be updated?
- [ ] Is the change properly tested?
- [ ] Is it helpful to provide another example to demonstrate the new feature?
- [ ] Are there other code lines that need to be modified?
-->
