### PR TITLE
fix(elements|ino-icon-button): remove hardcoded css variables

### DIFF
--- a/packages/elements/src/components/ino-icon-button/ino-icon-button.scss
+++ b/packages/elements/src/components/ino-icon-button/ino-icon-button.scss
@@ -18,15 +18,15 @@ ino-icon-button {
 
   $button-size: var(--ino-icon-button-size, 48px);
   $icon-size: var(--ino-icon-button-icon-size, 24px);
-  $icon-color: var(--ino-icon-button-icon-color, theme.color(dark));
+  $icon-color: var(--ino-icon-button-icon-color, theme.color(primary));
   $background-color: var(--ino-icon-button-background-color, transparent);
   $icon-active-color: var(
       --ino-icon-button-icon-active-color,
-      theme.color(dark)
+      theme.color(primary)
   );
   $background-active-color: var(
       --ino-icon-button-background-active-color,
-      theme.color(dark)
+      theme.color(primary)
   );
 
   ino-icon {
@@ -56,11 +56,6 @@ ino-icon-button {
       }
     }
   }
-
-
-  --ino-icon-button-icon-color: #{theme.color(primary)};
-  --ino-icon-button-icon-active-color: #{theme.color(primary)};
-  --ino-icon-button-background-active-color: #{theme.color(primary)};
 
   &.ino-icon-button--filled {
     --ino-icon-button-icon-color: #{theme.color(primary, contrast)};


### PR DESCRIPTION
In the refactoring #736, the `--ino-icon-button-icon-color` have been hardcoded on the element root level. This might not be a problem using the element directly. However, inside the shadow DOM (for example `ino-nav-drawer`), one cannot override the properties anymore because the `ino-icon-button` styles itself are not accessible.

Thus, the css vars should only provide a default value and not be hardcoded :) 