### PR TITLE
fix(landingpage): use GitHub token to fetch commits if available

### DIFF
--- a/.github/workflows/deploy-landingpage-new.yml
+++ b/.github/workflows/deploy-landingpage-new.yml
@@ -17,6 +17,8 @@ jobs:
         working-directory: packages/elements-react
       - name: Build landingpage-new
         run: yarn build
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         working-directory: packages/landingpage-new
       - name: Upload Artifact
         uses: actions/upload-artifact@v2

--- a/.github/workflows/deploy-landingpage.yml
+++ b/.github/workflows/deploy-landingpage.yml
@@ -18,6 +18,8 @@ jobs:
       - uses: actions/checkout@v2
       - uses: ./.github/workflows/dependencies-install
       - run: yarn build
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload Storybook Artifact
         uses: actions/upload-artifact@v2

--- a/.github/workflows/deploy-version.yml
+++ b/.github/workflows/deploy-version.yml
@@ -19,6 +19,8 @@ jobs:
       - uses: ./.github/workflows/dependencies-install
       - run: npm config set scripts-prepend-node-path true
       - run: yarn build
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Upload all build artifacts
         uses: ./.github/workflows/artifacts-upload
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,6 +23,8 @@ jobs:
     - uses: ./.github/workflows/dependencies-install
     - run: npm config set scripts-prepend-node-path true
     - run: yarn build
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     # Build caches for unicorn deployment
     - if: github.ref != 'refs/heads/master'

--- a/packages/landingpage-new/pages/about/index.tsx
+++ b/packages/landingpage-new/pages/about/index.tsx
@@ -4,9 +4,9 @@ import History from '../../components/about/history';
 import Activity from '../../components/about/activity';
 import { GetStaticProps } from 'next';
 import {
+  GithubCommitsPerMonth,
   GithubContributor,
   GithubParticipation,
-  GithubCommitsPerMonth,
 } from 'types/github';
 import Contributors from 'components/about/contributors/contributors';
 import { endOfWeek, format, startOfMonth, subWeeks } from 'date-fns';
@@ -15,7 +15,26 @@ const GITHUB_REPO_URL = 'https://api.github.com/repos/inovex/elements';
 const NUMBER_WEEKS_PER_YEAR = 52;
 
 async function getCommitPerMonth(): Promise<GithubCommitsPerMonth> {
-  const fetchResult = await fetch(GITHUB_REPO_URL + '/stats/participation');
+  const maybeGithubToken = process.env.GITHUB_TOKEN;
+  const requestInit: RequestInit = {};
+
+  if (maybeGithubToken) {
+    console.log(
+      'Found an Github Token in your environment. Using it to fetch commit info.'
+    );
+    requestInit.headers = new Headers({
+      authorization: `Bearer ${maybeGithubToken}`,
+    });
+  } else {
+    console.warn(
+      'An github token was not found in your environment. Trying to fetch commit info without a token. You might run into a rate limit.'
+    );
+  }
+
+  const fetchResult = await fetch(
+    GITHUB_REPO_URL + '/stats/participation',
+    requestInit
+  );
   const activities: GithubParticipation = await fetchResult.json();
 
   const lastDayOfCurrentWeek = endOfWeek(new Date());

--- a/packages/landingpage-new/pages/about/index.tsx
+++ b/packages/landingpage-new/pages/about/index.tsx
@@ -20,7 +20,7 @@ async function getCommitPerMonth(): Promise<GithubCommitsPerMonth> {
 
   if (maybeGithubToken) {
     console.log(
-      'Found an Github Token in your environment. Using it to fetch commit info.'
+      'Found a Github Token in your environment. Using it to fetch commit info.'
     );
     requestInit.headers = new Headers({
       authorization: `Bearer ${maybeGithubToken}`,


### PR DESCRIPTION
Closes #841 

- Our new landingpage pulls our latest activity via the official Github API
- This fetch happens locally with every reload in dev and once at build time in prod
- While it is possible to fetch the data without a token, we ran into rate limits when using the Github runners to build the app (presumably because the runner or its IP was already used for API calls)
- With this PR, our Github tokens will be used when running the build process via the Github pipeline 