### PR TITLE
feat(landingpage): add faq to landingage

### DIFF
--- a/packages/landingpage-new/components/home/faq-section/faq-section.module.scss
+++ b/packages/landingpage-new/components/home/faq-section/faq-section.module.scss
@@ -1,5 +1,10 @@
+.subheader{
+  color: #3a3b64;
+}
+
 .accordionWrapper {
-  .accordion {
+  padding-top: 55px;
+  .accordion:not(:last-child){
     margin-bottom: 8px;
   }
 }

--- a/packages/landingpage-new/components/home/faq-section/faq-section.module.scss
+++ b/packages/landingpage-new/components/home/faq-section/faq-section.module.scss
@@ -1,0 +1,5 @@
+.accordionWrapper {
+  .accordion {
+    margin-bottom: 8px;
+  }
+}

--- a/packages/landingpage-new/components/home/faq-section/faq-section.tsx
+++ b/packages/landingpage-new/components/home/faq-section/faq-section.tsx
@@ -1,7 +1,7 @@
 import styles from './faq-section.module.scss';
 import { InoAccordion } from '@elements';
 import classNames from 'classnames';
-import { useState } from 'react';
+import { useSet } from 'react-use';
 import useTranslation from 'utils/hooks/useTranslation';
 
 interface FaqItem {
@@ -14,20 +14,13 @@ export default function FaqSection() {
   const { t } = useTranslation();
   const faqs: FaqItem[] = t('faq.faqs');
 
-  const [expanded, setExpanded] = useState<{ [key: number]: boolean }>({});
-
-  const handleExpandedChange = (id: number) => {
-    setExpanded((prevExpanded) => ({
-      ...prevExpanded,
-      [id]: !prevExpanded[id],
-    }));
-  };
+  const [_, { has, toggle }] = useSet(new Set<number>());
 
   return (
     <>
       <div>
         <h1 className="header-d3">
-          <b>{t('faq.title_1')}</b>
+          <b>{t('faq.title')}</b>
         </h1>
         <div className={classNames(styles.subHeaderContainer, 'body-l')}>
           <p className={styles.subheader}>{t('faq.subheader')}</p>
@@ -38,8 +31,8 @@ export default function FaqSection() {
           <div className={styles.accordion} key={faq.id}>
             <InoAccordion
               accordionTitle={faq.title}
-              expanded={expanded[faq.id]}
-              onExpandedChange={() => handleExpandedChange(faq.id)}
+              expanded={has(faq.id)}
+              onExpandedChange={() => toggle(faq.id)}
             >
               <>{faq.content}</>
             </InoAccordion>

--- a/packages/landingpage-new/components/home/faq-section/faq-section.tsx
+++ b/packages/landingpage-new/components/home/faq-section/faq-section.tsx
@@ -33,21 +33,19 @@ export default function FaqSection() {
           <p className={styles.subheader}>{t('faq.subheader')}</p>
         </div>
       </div>
-      {faqs.length > 0 && ( // the faqs.length is of no use as there will always be faqs, the switching of the locale breaks the ino-accordion
-        <div className={styles.accordionWrapper}>
-          {faqs.map((faq) => (
-            <div className={styles.accordion} key={faq.id}>
-              <InoAccordion
-                accordionTitle={faq.title}
-                expanded={expanded[faq.id]}
-                onExpandedChange={() => handleExpandedChange(faq.id)}
-              >
-                {faq.content}
-              </InoAccordion>
-            </div>
-          ))}
-        </div>
-      )}
+      <div className={styles.accordionWrapper}>
+        {faqs.map((faq) => (
+          <div className={styles.accordion} key={faq.id}>
+            <InoAccordion
+              accordionTitle={faq.title}
+              expanded={expanded[faq.id]}
+              onExpandedChange={() => handleExpandedChange(faq.id)}
+            >
+              <>{faq.content}</>
+            </InoAccordion>
+          </div>
+        ))}
+      </div>
     </>
   );
 }

--- a/packages/landingpage-new/components/home/faq-section/faq-section.tsx
+++ b/packages/landingpage-new/components/home/faq-section/faq-section.tsx
@@ -1,0 +1,53 @@
+import styles from './faq-section.module.scss';
+import { InoAccordion } from '@elements';
+import classNames from 'classnames';
+import { useState } from 'react';
+import useTranslation from 'utils/hooks/useTranslation';
+
+interface FaqItem {
+  id: number;
+  title: string;
+  content: string;
+}
+
+export default function FaqSection() {
+  const { t } = useTranslation();
+  const faqs: FaqItem[] = t('faq.faqs');
+
+  const [expanded, setExpanded] = useState<{ [key: number]: boolean }>({});
+
+  const handleExpandedChange = (id: number) => {
+    setExpanded((prevExpanded) => ({
+      ...prevExpanded,
+      [id]: !prevExpanded[id],
+    }));
+  };
+
+  return (
+    <>
+      <div>
+        <h1 className="header-d3">
+          <b>{t('faq.title_1')}</b>
+        </h1>
+        <div className={classNames(styles.subHeaderContainer, 'body-l')}>
+          <p className={styles.subheader}>{t('faq.subheader')}</p>
+        </div>
+      </div>
+      {faqs.length > 0 && ( // the faqs.length is of no use as there will always be faqs, the switching of the locale breaks the ino-accordion
+        <div className={styles.accordionWrapper}>
+          {faqs.map((faq) => (
+            <div className={styles.accordion} key={faq.id}>
+              <InoAccordion
+                accordionTitle={faq.title}
+                expanded={expanded[faq.id]}
+                onExpandedChange={() => handleExpandedChange(faq.id)}
+              >
+                {faq.content}
+              </InoAccordion>
+            </div>
+          ))}
+        </div>
+      )}
+    </>
+  );
+}

--- a/packages/landingpage-new/pages/[lang]/index.tsx
+++ b/packages/landingpage-new/pages/[lang]/index.tsx
@@ -15,6 +15,7 @@ import Page from 'components/layout/page';
 import useTranslation from 'utils/hooks/useTranslation';
 import useDefaultLocale from '../../translations/useDefaultLocale';
 import { useMount } from 'react-use';
+import FaqSection from 'components/home/faq-section/faq-section';
 
 const Home: NextPage = () => {
   const redirectToDefaultLocale = useDefaultLocale();
@@ -33,6 +34,9 @@ const Home: NextPage = () => {
         </section>
         <section id={SubRoutes.HOME_COMPONENTS}>
           <ComponentSample></ComponentSample>
+        </section>
+        <section id={SubRoutes.HOME_FAQ}>
+        <FaqSection></FaqSection>
         </section>
         <section id={SubRoutes.HOME_CONTACT}>
           <Contact />

--- a/packages/landingpage-new/translations/locales/de/home.json
+++ b/packages/landingpage-new/translations/locales/de/home.json
@@ -30,8 +30,8 @@
     "button": "Ich bin ein Button"
   },
   "faq": {
-    "title_1": "FAQ",
-    "subheader": "Lorem Ipsum stuff german",
+    "title": "FAQ",
+    "subheader": "Hier finden Sie Antworten auf die am häufigsten gestellten Fragen rund um die Elements",
     "faqs": [
       {
         "id": 1,

--- a/packages/landingpage-new/translations/locales/de/home.json
+++ b/packages/landingpage-new/translations/locales/de/home.json
@@ -3,10 +3,8 @@
     "title_1": "die interoperable UI-Bibliothek",
     "title_2": "für jedes",
     "title_mark": "Framework",
-    "subtitle_1":
-      "Es ist herausfordernd, UI-Komponenten zu erstellen und zu pflegen. Fange nicht jedes Mal von vorne an, wenn Du ein neues Projekt erstellst. Erstelle Komponenten einmal und setze sie überall ein!",
-    "subtitle_2":
-      "Verwende gerne unsere Open-Source-Bibliothek für UI-Komponenten",
+    "subtitle_1": "Es ist herausfordernd, UI-Komponenten zu erstellen und zu pflegen. Fange nicht jedes Mal von vorne an, wenn Du ein neues Projekt erstellst. Erstelle Komponenten einmal und setze sie überall ein!",
+    "subtitle_2": "Verwende gerne unsere Open-Source-Bibliothek für UI-Komponenten",
     "getting_started": "Jetzt loslegen",
     "clipboard_success": "In die Zwischenablage kopiert ✓"
   },
@@ -30,6 +28,57 @@
     "subheader": "Hier einige Beispiele unserer Komponenten",
     "link": "zu allen Komponenten",
     "button": "Ich bin ein Button"
+  },
+  "faq": {
+    "title_1": "FAQ",
+    "subheader": "Lorem Ipsum stuff german",
+    "faqs": [
+      {
+        "id": 1,
+        "title": "Sind die Inovex-Elemente Open Source?",
+        "content": "Ja! Die Inovex Elements-Bibliothek ist Open Source und unter der MIT-Lizenz kostenlos verfügbar."
+      },
+      {
+        "id": 2,
+        "title": "Wie kann ich die Elemente verwenden?",
+        "content": "Sie können die Inovex Elements Web Components-Bibliothek in jedem Webprojekt verwenden, da sie auf Webkomponenten basieren, einem Framework-unabhängigen Standard. Um die Sache noch einfacher zu machen, bieten wir verschiedene Pakete für die gängigen Frameworks wie Angular, React und Vue an. Schauen Sie sich unsere Integrationsanleitungen an, um zu sehen, wie Sie sie im Detail verwenden können."
+      },
+      {
+        "id": 3,
+        "title": "Wo ist der beste Ort, um anzufangen, wenn ich neu bin?",
+        "content": "Schauen Sie sich unsere Getting Started-Seite an, die die Grundlagen erklärt und Sie durch Ihre ersten Schritte mit den Inovex Elements führt. Es bietet auch detaillierte Anweisungen, wie Sie die Inovex Elements in Ihre eigenen Projekte einbinden können."
+      },
+      {
+        "id": 4,
+        "title": "Gibt es Beispiele, in denen die Inovex-Elemente verwendet wurden?",
+        "content": "Die Inovex-Elemente werden hauptsächlich für unsere internen Web-Tools bei Inovex GmbH verwendet. Um ein Gefühl dafür zu bekommen, wie die Elemente aussehen und sich anfühlen, können Sie sich unsere Beispielprojekte ansehen."
+      },
+      {
+        "id": 5,
+        "title": "Wer steckt hinter den Inovex-Elementen?",
+        "content": "Die Inovex-Elemente werden von einem Team aus Software-Entwicklern und Designern bei Inovex, einem digitalen Innovationsunternehmen mit Sitz in Deutschland, verwaltet. Mit den Inovex-Elementen möchten wir eine Bibliothek von Webkomponenten anbieten, mit der Entwickler schnell und zeiteffizient großartige Benutzererlebnisse erstellen können."
+      },
+      {
+        "id": 6,
+        "title": "Wie melde ich ein Problem mit den Webkomponenten?",
+        "content": "Sie können ein Problem mit den Webkomponenten melden, indem Sie unser Kontaktformular verwenden oder ein Problem in unserem GitHub-Repository eröffnen. Bitte geben Sie so viele Informationen wie möglich an (z.B. betroffene Webkomponente, Browser-Version und Schritte zur Reproduktion des Problems), damit wir jedes Problem schnell untersuchen und lösen können."
+      },
+      {
+        "id": 7,
+        "title": "Welche Anforderungen haben die Inovex-Elemente?",
+        "content": "Es gibt keine Anforderungen, außer dass Ihre Anwendung eine Webanwendung sein muss. Die Inovex Elements-Bibliothek unterstützt die neueste Version aller gängigen Browser. Beachten Sie, dass unsere Komponenten derzeit für umfassende Desktop-Anwendungen optimiert sind."
+      },
+      {
+        "id": 8,
+        "title": "Warum werden die Material Webkomponenten in den inovex-Elements verwendet?",
+        "content": "Um das Rad nicht neu erfinden zu müssen, haben wir auf die Material Webkomponenten von Google aufgebaut, ein umfassendes Toolset der gängigsten UI-Elemente. So können wir uns auf unser Styling und unsere Spezialfunktionen konzentrieren, ohne Funktionalitäten implementieren zu müssen, die bereits bekannt und erprobt sind."
+      },
+      {
+        "id": 9,
+        "title": "Wie oft werden die inovex-Elements aktualisiert?",
+        "content": "Wir aktualisieren die inovex-Elements-Bibliothek regelmäßig, um sicherzustellen, dass unsere Benutzer das Beste aus unseren Komponenten herausholen können. Wir streben an, mindestens alle ein bis zwei Monate eine neue Version herauszugeben und werden unser Bestes tun, um sie auf dem neuesten Stand der Webkomponententechnologie zu halten."
+      }
+    ]
   },
   "contact": {
     "title_1": "kontaktieren",

--- a/packages/landingpage-new/translations/locales/en/home.json
+++ b/packages/landingpage-new/translations/locales/en/home.json
@@ -29,6 +29,56 @@
     "link": "Check out all components",
     "button": "I'm a Button"
   },
+  "faq": {
+    "title_1": "FAQ",
+    "subheader" : "Lorem Ipsum stuff english",
+    "faqs": [
+    {
+      "id": 1,
+      "title": "Are the inovex Elements open source?",
+      "content": "Yes! The inovex Elements library is open source and made available for free under the MIT license."
+    },
+    {
+      "id": 2,
+      "title": "How can I use the Elements?",
+      "content": "You can use the inovex Elements web components library in any web project because they are based on web components, a framework independent standard. To make things even easier, we provide different packages for the commonly used frameworks like Angular, React and Vue. Have a look at our integration guides to see how to use them in detail."
+    },
+    {
+      "id": 3,
+      "title": "Where is the best place to start if I am new?",
+      "content": "Have a look at our Getting Started page which explains the basics and guides you through your first steps with the inovex Elements. It also provides detailed instructions on how to include the inovex Elements in your own projects."
+    },
+    {
+      "id": 4,
+      "title": "Are there any examples where the inovex Elements have been used?",
+      "content": "The inovex Elements are primarily used for our internal web tools at inovex GmbH. To get a feeling on how the elements look and feel like, you can check out our example projects."
+    },
+    {
+      "id": 5,
+      "title": "Who is behind the inovex elements?",
+      "content": "The inovex elements is managed by a team of software developers and designers at inovex, a digital innovation company based in Germany. With the inovex elements, we want to offer a library of web components to enable developers to create great user experiences quickly and time-efficiently."
+    },
+    {
+      "id": 6,
+      "title": "How do I report a Problem with the web-components?",
+      "content": "You can report a problem with the web-components by writing using our contact form or by opening an issue in our GitHub repository. Please provide as much information as possible (e.g. affected web-component, browser version and steps to reproduce the issue), so that we can investigate and solve any issue quickly."
+    },
+    {
+      "id": 7,
+      "title": "What requirements do the inovex elements have?",
+      "content": "There are no requirements except that your application must be a web application. The inovex Elements library supports the latest version of all major browsers. Keep in mind that our components are currently optimized for comprehensive desktop applications."
+    },
+    {
+      "id": 8,
+      "title": "Why are the material web components used in the inovex Elements?",
+      "content": "To avoid reinventing the wheel, we built on top of Google’s Material Web Components, a comprehensive toolbox of the most common UI elements. This allows us to concentrate on our styling and special features without having to implement functionality that is already well-known and battle-tested."
+    },
+    {
+      "id": 9,
+      "title": "How often are the inovex Elements updated?",
+      "content": "We update the inovex Elements library regularly to ensure that our users are able to get the most out of our components. We aim to release a new version at least (one-/bi-monthly) and will try our best to keep it up-to-date with all the latest web-component technology."
+    }
+  ]},
   "contact": {
     "title_1": "contact",
     "title_2": "us",

--- a/packages/landingpage-new/translations/locales/en/home.json
+++ b/packages/landingpage-new/translations/locales/en/home.json
@@ -30,8 +30,8 @@
     "button": "I'm a Button"
   },
   "faq": {
-    "title_1": "FAQ",
-    "subheader" : "Lorem Ipsum stuff english",
+    "title": "FAQ",
+    "subheader" : "Here you can find answers to the most frequently asked questions about the Elements",
     "faqs": [
     {
       "id": 1,

--- a/packages/landingpage-new/utils/elementsWrapper.ts
+++ b/packages/landingpage-new/utils/elementsWrapper.ts
@@ -8,6 +8,7 @@ export const importElement = <Component extends keyof typeof Components>(element
   ssr: false 
 });
 
+export const InoAccordion = importElement('InoAccordion')
 export const InoButton = importElement('InoButton');
 export const InoChip = importElement('InoChip');
 export const InoTab = importElement('InoTab');


### PR DESCRIPTION
Closes #817

**Error Report**[FIXED]:

The ino-accordion component is not rendering properly after the locale switcher is changed or on the initial page load once we listen to the default locale in localeStorage, which calls [`useMount(redirectToDefaultLocale)`](url) in the` index.tsx `file. The text of the FAQ section is displayed as plain text, but the component that should display the text is not being rendered properly. This is causing an issue with the layout and functionality of the FAQ section.

https://user-images.githubusercontent.com/81302108/219409323-83af2ef3-1429-4296-8b79-54eca32c989a.mp4

As shown in the video it only happens for the ino-accordion component, inspecting the element it still renders as ino-carousel in the dev-tools. 


### Solution:

Giving the slot content Fragments(`<> Bla Bla</>`)
