### PR TITLE
chore(elements): update autogenerated README, docs, and component.d.ts

### DIFF
--- a/packages/elements/src/components.d.ts
+++ b/packages/elements/src/components.d.ts
@@ -824,7 +824,7 @@ export namespace Components {
     }
     interface InoNavDrawer {
         /**
-          * The aria-labels used for content and fotter nav elements. https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/navigation_role.
+          * The aria-labels used for content and footer nav elements. https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/navigation_role.
          */
         "a11yLabels"?: NavDrawerLabels;
         /**
@@ -2696,7 +2696,7 @@ declare namespace LocalJSX {
     }
     interface InoNavDrawer {
         /**
-          * The aria-labels used for content and fotter nav elements. https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/navigation_role.
+          * The aria-labels used for content and footer nav elements. https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/navigation_role.
          */
         "a11yLabels"?: NavDrawerLabels;
         /**

--- a/packages/elements/src/components/ino-icon-button/readme.md
+++ b/packages/elements/src/components/ino-icon-button/readme.md
@@ -148,6 +148,20 @@ The component bubbles the native `click`-Event to the user.
 | `"default"` | `<ino-icon>` |
 
 
+## CSS Custom Properties
+
+| Name                                          | Description                                    |
+| --------------------------------------------- | ---------------------------------------------- |
+| `--ino-icon-button-background-active-color`   | base color of the active background            |
+| `--ino-icon-button-background-color`          | default color of the background                |
+| `--ino-icon-button-background-disabled-color` | base color of the background in disabled state |
+| `--ino-icon-button-icon-active-color`         | color of the active icon itself                |
+| `--ino-icon-button-icon-color`                | default color of the icon itself               |
+| `--ino-icon-button-icon-disabled-color`       | color of the icon itself in disabled state     |
+| `--ino-icon-button-icon-size`                 | size of the icon itself                        |
+| `--ino-icon-button-size`                      | size of the entire button                      |
+
+
 ## Dependencies
 
 ### Used by

--- a/packages/elements/src/components/ino-list-item/readme.md
+++ b/packages/elements/src/components/ino-list-item/readme.md
@@ -73,6 +73,22 @@ document
 | `"trailing"`  | For the element to be appended                     |
 
 
+## CSS Custom Properties
+
+| Name                                                 | Description                                           |
+| ---------------------------------------------------- | ----------------------------------------------------- |
+| `--ino-list-item-deselected-background-color`        | Background color of a deselected list item            |
+| `--ino-list-item-deselected-background-color-active` | Background color of a deselected list item if active  |
+| `--ino-list-item-deselected-background-color-focus`  | Background color of a deselected list item if focused |
+| `--ino-list-item-deselected-background-color-hover`  | Background color of a deselected list item on hover   |
+| `--ino-list-item-deselected-color`                   | Text color of a deselected list item                  |
+| `--ino-list-item-selected-background-color`          | Background color of a selected list item              |
+| `--ino-list-item-selected-background-color-active`   | Background color of a selected list item if active    |
+| `--ino-list-item-selected-background-color-focus`    | Background color of a selected list item if focused   |
+| `--ino-list-item-selected-background-color-hover`    | Background color of a selected list item on hover     |
+| `--ino-list-item-selected-color`                     | Text color of a selected list item                    |
+
+
 ## Dependencies
 
 ### Used by

--- a/packages/elements/src/components/ino-nav-drawer/readme.md
+++ b/packages/elements/src/components/ino-nav-drawer/readme.md
@@ -120,7 +120,7 @@ class MyComponent extends Component {
 
 | Property     | Attribute | Description                                                                                                                                      | Type                                                      | Default                                                                                                     |
 | ------------ | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------ | --------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
-| `a11yLabels` | --        | The aria-labels used for content and fotter nav elements. https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/navigation_role. | `{ content: string; footer: string; toggleBtn: string; }` | `{     content: 'Main Navigation',     footer: 'Footer Navigation',     toggleBtn: 'Toggle Navigation'   }` |
+| `a11yLabels` | --        | The aria-labels used for content and footer nav elements. https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/navigation_role. | `{ content: string; footer: string; toggleBtn: string; }` | `{     content: 'Main Navigation',     footer: 'Footer Navigation',     toggleBtn: 'Toggle Navigation'   }` |
 | `anchor`     | `anchor`  | Side from which the drawer will appear. Possible values: `left` (default), `right`.                                                              | `"left" \| "right"`                                       | `'left'`                                                                                                    |
 | `open`       | `open`    | Marks this element as open. (**unmanaged**)                                                                                                      | `boolean`                                                 | `false`                                                                                                     |
 | `variant`    | `variant` | The variant to use for the drawer Possible values: `docked` (default), `dismissible`, `modal`.                                                   | `"dismissible" \| "docked" \| "modal"`                    | `'docked'`                                                                                                  |
@@ -143,6 +143,19 @@ class MyComponent extends Component {
 | `"header"`   | For a custom header on top of the navigation bar                                        |
 | `"logo"`     | For the logo on top of the navigation bar (cannot be used with the `header` slot)       |
 | `"subtitle"` | For the element just below the logo (cannot be used with the `header` slot)             |
+
+
+## CSS Custom Properties
+
+| Name                                   | Description                                             |
+| -------------------------------------- | ------------------------------------------------------- |
+| `--ino-nav-drawer-background`          | Background of the drawer.                               |
+| `--ino-nav-drawer-height`              | Height of the drawer.                                   |
+| `--ino-nav-drawer-text-color`          | Color of text inside the drawer.                        |
+| `--ino-nav-drawer-timing-function`     | Timing function of the slide animation of the drawer.   |
+| `--ino-nav-drawer-transition-duration` | Duration of the slide animation of the drawer.          |
+| `--ino-nav-drawer-width-closed`        | Docked variant only! The width of the collapsed drawer. |
+| `--ino-nav-drawer-width-open`          | The width of the open drawer.                           |
 
 
 ## Dependencies

--- a/packages/elements/src/components/ino-nav-item/readme.md
+++ b/packages/elements/src/components/ino-nav-item/readme.md
@@ -49,6 +49,16 @@ document
 | `"default"` | Any element |
 
 
+## CSS Custom Properties
+
+| Name                                     | Description                                   |
+| ---------------------------------------- | --------------------------------------------- |
+| `--ino-nav-item-background-color`        | Inactive color of the background of one item. |
+| `--ino-nav-item-background-color-active` | Active color of the background of one item.   |
+| `--ino-nav-item-color`                   | Inactive color of icon.                       |
+| `--ino-nav-item-color-active`            | Active color of icon.                         |
+
+
 ## Dependencies
 
 ### Depends on

--- a/packages/storybook/elements-stencil-docs.json
+++ b/packages/storybook/elements-stencil-docs.json
@@ -3077,7 +3077,48 @@
           "docsTags": []
         }
       ],
-      "styles": [],
+      "styles": [
+        {
+          "name": "--ino-icon-button-background-active-color",
+          "annotation": "prop",
+          "docs": "base color of the active background"
+        },
+        {
+          "name": "--ino-icon-button-background-color",
+          "annotation": "prop",
+          "docs": "default color of the background"
+        },
+        {
+          "name": "--ino-icon-button-background-disabled-color",
+          "annotation": "prop",
+          "docs": "base color of the background in disabled state"
+        },
+        {
+          "name": "--ino-icon-button-icon-active-color",
+          "annotation": "prop",
+          "docs": "color of the active icon itself"
+        },
+        {
+          "name": "--ino-icon-button-icon-color",
+          "annotation": "prop",
+          "docs": "default color of the icon itself"
+        },
+        {
+          "name": "--ino-icon-button-icon-disabled-color",
+          "annotation": "prop",
+          "docs": "color of the icon itself in disabled state"
+        },
+        {
+          "name": "--ino-icon-button-icon-size",
+          "annotation": "prop",
+          "docs": "size of the icon itself"
+        },
+        {
+          "name": "--ino-icon-button-size",
+          "annotation": "prop",
+          "docs": "size of the entire button"
+        }
+      ],
       "slots": [
         {
           "name": "default",
@@ -4633,7 +4674,58 @@
           "docsTags": []
         }
       ],
-      "styles": [],
+      "styles": [
+        {
+          "name": "--ino-list-item-deselected-background-color",
+          "annotation": "prop",
+          "docs": "Background color of a deselected list item"
+        },
+        {
+          "name": "--ino-list-item-deselected-background-color-active",
+          "annotation": "prop",
+          "docs": "Background color of a deselected list item if active"
+        },
+        {
+          "name": "--ino-list-item-deselected-background-color-focus",
+          "annotation": "prop",
+          "docs": "Background color of a deselected list item if focused"
+        },
+        {
+          "name": "--ino-list-item-deselected-background-color-hover",
+          "annotation": "prop",
+          "docs": "Background color of a deselected list item on hover"
+        },
+        {
+          "name": "--ino-list-item-deselected-color",
+          "annotation": "prop",
+          "docs": "Text color of a deselected list item"
+        },
+        {
+          "name": "--ino-list-item-selected-background-color",
+          "annotation": "prop",
+          "docs": "Background color of a selected list item"
+        },
+        {
+          "name": "--ino-list-item-selected-background-color-active",
+          "annotation": "prop",
+          "docs": "Background color of a selected list item if active"
+        },
+        {
+          "name": "--ino-list-item-selected-background-color-focus",
+          "annotation": "prop",
+          "docs": "Background color of a selected list item if focused"
+        },
+        {
+          "name": "--ino-list-item-selected-background-color-hover",
+          "annotation": "prop",
+          "docs": "Background color of a selected list item on hover"
+        },
+        {
+          "name": "--ino-list-item-selected-color",
+          "annotation": "prop",
+          "docs": "Text color of a selected list item"
+        }
+      ],
       "slots": [
         {
           "name": "leading",
@@ -4946,7 +5038,7 @@
           "type": "{ content: string; footer: string; toggleBtn: string; }",
           "mutable": false,
           "reflectToAttr": false,
-          "docs": "The aria-labels used for content and fotter nav elements.\nhttps://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/navigation_role.",
+          "docs": "The aria-labels used for content and footer nav elements.\nhttps://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/navigation_role.",
           "docsTags": [],
           "default": "{\n    content: 'Main Navigation',\n    footer: 'Footer Navigation',\n    toggleBtn: 'Toggle Navigation'\n  }",
           "values": [
@@ -5035,7 +5127,43 @@
           "docsTags": []
         }
       ],
-      "styles": [],
+      "styles": [
+        {
+          "name": "--ino-nav-drawer-background",
+          "annotation": "prop",
+          "docs": "Background of the drawer."
+        },
+        {
+          "name": "--ino-nav-drawer-height",
+          "annotation": "prop",
+          "docs": "Height of the drawer."
+        },
+        {
+          "name": "--ino-nav-drawer-text-color",
+          "annotation": "prop",
+          "docs": "Color of text inside the drawer."
+        },
+        {
+          "name": "--ino-nav-drawer-timing-function",
+          "annotation": "prop",
+          "docs": "Timing function of the slide animation of the drawer."
+        },
+        {
+          "name": "--ino-nav-drawer-transition-duration",
+          "annotation": "prop",
+          "docs": "Duration of the slide animation of the drawer."
+        },
+        {
+          "name": "--ino-nav-drawer-width-closed",
+          "annotation": "prop",
+          "docs": "Docked variant only! The width of the collapsed drawer."
+        },
+        {
+          "name": "--ino-nav-drawer-width-open",
+          "annotation": "prop",
+          "docs": "The width of the open drawer."
+        }
+      ],
       "slots": [
         {
           "name": "app",
@@ -5164,7 +5292,28 @@
       ],
       "methods": [],
       "events": [],
-      "styles": [],
+      "styles": [
+        {
+          "name": "--ino-nav-item-background-color",
+          "annotation": "prop",
+          "docs": "Inactive color of the background of one item."
+        },
+        {
+          "name": "--ino-nav-item-background-color-active",
+          "annotation": "prop",
+          "docs": "Active color of the background of one item."
+        },
+        {
+          "name": "--ino-nav-item-color",
+          "annotation": "prop",
+          "docs": "Inactive color of icon."
+        },
+        {
+          "name": "--ino-nav-item-color-active",
+          "annotation": "prop",
+          "docs": "Active color of icon."
+        }
+      ],
       "slots": [
         {
           "name": "default",


### PR DESCRIPTION
Closes no linked issue

## Proposed Changes
I've observed that our `element:start` command automatically updates several files: README, docs, and component.d.ts. The component.d.ts is auto-generated by the Stencil compiler for type information. Other updates include fixed typos and custom CSS selectors.