### PR TITLE
refactor(landingpage): alternative footer design variant

### DIFF
--- a/packages/landingpage/components/layout.tsx
+++ b/packages/landingpage/components/layout.tsx
@@ -19,8 +19,8 @@ export default function Layout({ children }: { children: ReactNode }) {
       <Header />
       <div className={styles.body}>
         <main className={styles.main}>{children}</main>
-        {!isFooterHidden && <Footer />}
       </div>
+      {!isFooterHidden && <Footer />}
     </div>
   );
 }

--- a/packages/landingpage/components/layout/attributions.module.scss
+++ b/packages/landingpage/components/layout/attributions.module.scss
@@ -17,5 +17,5 @@
   display: flex;
   align-items: center;
   column-gap: 10px;
-  color: var(--inovex-elements-n-10) !important;
+  color: white !important;
 }

--- a/packages/landingpage/components/layout/attributions.module.scss
+++ b/packages/landingpage/components/layout/attributions.module.scss
@@ -4,6 +4,8 @@
   justify-content: space-between;
   border-top: 1px solid var(--inovex-elements-n-3);
   padding-top: 1rem;
+  padding-bottom: 0.5rem;
+  flex-wrap: wrap;
 }
 
 .company {
@@ -15,5 +17,5 @@
   display: flex;
   align-items: center;
   column-gap: 10px;
-  color: var(--inovex-elements-n-8) !important;
+  color: var(--inovex-elements-n-10) !important;
 }

--- a/packages/landingpage/components/layout/attributions.module.scss
+++ b/packages/landingpage/components/layout/attributions.module.scss
@@ -2,6 +2,8 @@
   width: 100%;
   display: flex;
   justify-content: space-between;
+  border-top: 1px solid var(--inovex-elements-n-3);
+  padding-top: 1rem;
 }
 
 .company {
@@ -13,5 +15,5 @@
   display: flex;
   align-items: center;
   column-gap: 10px;
-  color: var(--inovex-elements-n-7) !important;
+  color: var(--inovex-elements-n-8) !important;
 }

--- a/packages/landingpage/components/layout/footer/desktop/footer.desktop.module.scss
+++ b/packages/landingpage/components/layout/footer/desktop/footer.desktop.module.scss
@@ -1,0 +1,37 @@
+.sublinks {
+    display: grid;
+    grid-template-columns: repeat(5, 1fr);
+    column-gap: 6rem;
+    row-gap: 2rem;
+    padding: 3rem 0;
+  
+    @media only screen and (max-width: 1200px) {
+      grid-template-columns: repeat(4, 1fr);
+    }
+  
+    @media only screen and (max-width: 800px) {
+      grid-template-columns: repeat(2, 1fr);
+    }
+  
+    @media only screen and (max-width: 500px) {
+      grid-template-columns: 1fr;
+    }
+  }
+  
+  .col {
+    display: flex;
+    flex-direction: column;
+    row-gap: 0.5rem;
+    .mainRouteName {
+      color: var(--inovex-elements-n-10);
+      font-size: 1.2rem;
+      padding-bottom: 1rem;
+      white-space: nowrap;
+    }
+  
+    .subRouteName {
+      color: var(--inovex-elements-n-9);
+      font-size: smaller;
+    }
+  }
+  

--- a/packages/landingpage/components/layout/footer/desktop/footer.desktop.module.scss
+++ b/packages/landingpage/components/layout/footer/desktop/footer.desktop.module.scss
@@ -9,12 +9,8 @@
       grid-template-columns: repeat(4, 1fr);
     }
   
-    @media only screen and (max-width: 800px) {
+    @media only screen and (max-width: 850px) {
       grid-template-columns: repeat(2, 1fr);
-    }
-  
-    @media only screen and (max-width: 500px) {
-      grid-template-columns: 1fr;
     }
   }
   

--- a/packages/landingpage/components/layout/footer/desktop/footer.desktop.module.scss
+++ b/packages/landingpage/components/layout/footer/desktop/footer.desktop.module.scss
@@ -1,33 +1,56 @@
 .sublinks {
-    display: grid;
-    grid-template-columns: repeat(5, 1fr);
-    column-gap: 6rem;
-    row-gap: 2rem;
-    padding: 3rem 0;
-  
-    @media only screen and (max-width: 1200px) {
-      grid-template-columns: repeat(4, 1fr);
-    }
-  
-    @media only screen and (max-width: 850px) {
-      grid-template-columns: repeat(2, 1fr);
+  display: grid;
+  grid-template-columns: repeat(5, 1fr);
+  column-gap: 6rem;
+  row-gap: 2rem;
+  padding: 3rem 0;
+
+  @media only screen and (max-width: 1200px) {
+    grid-template-columns: repeat(4, 1fr);
+  }
+
+  @media only screen and (max-width: 850px) {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+.col {
+  display: flex;
+  flex-direction: column;
+  row-gap: 0.5rem;
+
+  .mainRouteName,
+  .subRouteName {
+    color: white;
+
+    &:hover {
+      color: white; // cover up the default <LinkItem> hover color
     }
   }
-  
-  .col {
-    display: flex;
-    flex-direction: column;
-    row-gap: 0.5rem;
-    .mainRouteName {
-      color: var(--inovex-elements-n-10);
-      font-size: 1.2rem;
-      padding-bottom: 1rem;
-      white-space: nowrap;
+
+  .mainRouteName {
+    font-size: 1.2rem;
+    padding-bottom: 1rem;
+    white-space: nowrap;
+  }
+
+  .subRouteName {
+    position: relative;
+    overflow: hidden;
+
+    &::before {
+      content: '';
+      position: absolute;
+      bottom: -1px;
+      left: 0;
+      width: 0;
+      height: 2px;
+      background-color: white;
+      transition: width 0.2s;
     }
-  
-    .subRouteName {
-      color: var(--inovex-elements-n-9);
-      font-size: smaller;
+
+    &:hover::before {
+      width: 100%;
     }
   }
-  
+}

--- a/packages/landingpage/components/layout/footer/desktop/footer.desktop.tsx
+++ b/packages/landingpage/components/layout/footer/desktop/footer.desktop.tsx
@@ -1,0 +1,34 @@
+import styles from './footer.desktop.module.scss';
+import { Routes } from '../../../../utils/routes';
+import LinkItem from '../../linkItem';
+import useTranslation from 'utils/hooks/useTranslation';
+
+export default function FooterDesktop() {
+  const { t } = useTranslation();
+
+  return (
+    <div className={styles.sublinks}>
+      {Routes.map(({ key: mainRouteName, url: mainRouteUrl, subRoutes }) => (
+        <div key={mainRouteUrl} className={styles.col}>
+          <LinkItem
+            url={mainRouteUrl}
+            name={t(`common.navigation.${mainRouteName}.name`)}
+            className={styles.mainRouteName}
+            noMargin={true}
+          />
+          {subRoutes.map(({ key: subRouteName, url: subRouteUrl }) => (
+            <LinkItem
+              key={subRouteUrl}
+              url={subRouteUrl}
+              name={t(
+                `common.navigation.${mainRouteName}.subroutes.${subRouteName}.name`
+              )}
+              isDense={true}
+              className={styles.subRouteName}
+            />
+          ))}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/packages/landingpage/components/layout/footer/footer.module.scss
+++ b/packages/landingpage/components/layout/footer/footer.module.scss
@@ -2,8 +2,11 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  row-gap: 150px;
+  row-gap: 100px;
   margin-bottom: 120px;
+  background-color: var(--inovex-elements-n-1);
+  border-radius: 25px;
+  padding: 25px;
 
   @media only screen and (max-width: 700px) {
     row-gap: 4rem;
@@ -11,16 +14,14 @@
 }
 
 .sublinks {
-  width: 100%;
-  max-width: 1400px;
   display: flex;
-  justify-content: space-between;
+  justify-content: flex-start;
   flex-wrap: wrap;
   gap: 28px;
 
-  @media only screen and (max-width: 920px) {
+  @media only screen and (max-width: 970px) {
     &::after {
-      content: "";
+      content: '';
       flex: auto;
     }
   }
@@ -29,8 +30,17 @@
 .col {
   display: flex;
   flex-direction: column;
-  row-gap: 1.2rem;
+  row-gap: 1rem;
   min-width: 10rem;
+
+  .mainRouteName {
+    color: var(--inovex-elements-n-10);
+    font-size: 1.2rem;
+  }
+
+  .subRouteName {
+    color: var(--inovex-elements-n-9);
+  }
 }
 
 .empty {

--- a/packages/landingpage/components/layout/footer/footer.module.scss
+++ b/packages/landingpage/components/layout/footer/footer.module.scss
@@ -3,9 +3,7 @@
   flex-direction: column;
   align-items: center;
   row-gap: 100px;
-  margin-bottom: 120px;
-  background-color: var(--inovex-elements-n-1);
-  border-radius: 25px;
+  background: linear-gradient(180deg, var(--inovex-elements-p-6) 0%, var(--inovex-elements-p-8) 25%, var(--inovex-elements-p-10) 85%);
   padding: 25px;
 
   @media only screen and (max-width: 599px) {

--- a/packages/landingpage/components/layout/footer/footer.module.scss
+++ b/packages/landingpage/components/layout/footer/footer.module.scss
@@ -8,45 +8,8 @@
   border-radius: 25px;
   padding: 25px;
 
-  @media only screen and (max-width: 700px) {
-    row-gap: 4rem;
-  }
-}
-
-.sublinks {
-  display: flex;
-  justify-content: flex-start;
-  flex-wrap: wrap;
-  gap: 28px;
-
-  @media only screen and (max-width: 970px) {
-    &::after {
-      content: '';
-      flex: auto;
-    }
-  }
-}
-
-.col {
-  display: flex;
-  flex-direction: column;
-  row-gap: 1rem;
-  min-width: 10rem;
-
-  .mainRouteName {
-    color: var(--inovex-elements-n-10);
-    font-size: 1.2rem;
-  }
-
-  .subRouteName {
-    color: var(--inovex-elements-n-9);
-  }
-}
-
-.empty {
-  height: 0;
-
-  @media only screen and (max-width: 700px) {
-    display: none;
+  @media only screen and (max-width: 599px) {
+    align-items: stretch;
+    padding: 0;
   }
 }

--- a/packages/landingpage/components/layout/footer/footer.tsx
+++ b/packages/landingpage/components/layout/footer/footer.tsx
@@ -1,36 +1,15 @@
 import styles from './footer.module.scss';
-import { Routes } from '../../../utils/routes';
-import LinkItem from '../linkItem';
-import useTranslation from 'utils/hooks/useTranslation';
+import { useMedia } from 'react-use';
+import FooterDesktop from './desktop/footer.desktop';
+import FooterMobile from './mobile/footer.mobile';
 import Attributions from '../attributions';
 
 export default function Footer() {
-  const { t } = useTranslation();
+  const isWide = useMedia('(min-width: 600px)', true);
+
   return (
     <footer className={styles.footer}>
-      <div className={styles.sublinks}>
-        {Routes.map(({ key: mainRouteName, url: mainRouteUrl, subRoutes }) => (
-          <div key={mainRouteUrl} className={styles.col}>
-            <LinkItem
-              url={mainRouteUrl}
-              name={t(`common.navigation.${mainRouteName}.name`)}
-              className={styles.mainRouteName}
-              noMargin={true}
-            />
-            {subRoutes.map(({ key: subRouteName, url: subRouteUrl }) => (
-              <LinkItem
-                key={subRouteUrl}
-                url={subRouteUrl}
-                name={t(
-                  `common.navigation.${mainRouteName}.subroutes.${subRouteName}.name`
-                )}
-                isDense={true}
-                className={styles.subRouteName}
-              />
-            ))}
-          </div>
-        ))}
-      </div>
+      {isWide ? <FooterDesktop /> : <FooterMobile />}
       <Attributions />
     </footer>
   );

--- a/packages/landingpage/components/layout/footer/footer.tsx
+++ b/packages/landingpage/components/layout/footer/footer.tsx
@@ -14,6 +14,8 @@ export default function Footer() {
             <LinkItem
               url={mainRouteUrl}
               name={t(`common.navigation.${mainRouteName}.name`)}
+              className={styles.mainRouteName}
+              noMargin={true}
             />
             {subRoutes.map(({ key: subRouteName, url: subRouteUrl }) => (
               <LinkItem
@@ -23,6 +25,7 @@ export default function Footer() {
                   `common.navigation.${mainRouteName}.subroutes.${subRouteName}.name`
                 )}
                 isDense={true}
+                className={styles.subRouteName}
               />
             ))}
           </div>

--- a/packages/landingpage/components/layout/footer/mobile/footer.mobile.module.scss
+++ b/packages/landingpage/components/layout/footer/mobile/footer.mobile.module.scss
@@ -2,3 +2,7 @@
   color: var(--inovex-elements-n-10) !important;
   padding: 5px 0;
 }
+
+.ino-accordion__title  {
+  color: white !important;
+}

--- a/packages/landingpage/components/layout/footer/mobile/footer.mobile.module.scss
+++ b/packages/landingpage/components/layout/footer/mobile/footer.mobile.module.scss
@@ -1,0 +1,4 @@
+.accordion p {
+  color: var(--inovex-elements-n-10) !important;
+  padding: 5px 0;
+}

--- a/packages/landingpage/components/layout/footer/mobile/footer.mobile.tsx
+++ b/packages/landingpage/components/layout/footer/mobile/footer.mobile.tsx
@@ -1,0 +1,37 @@
+import styles from './footer.mobile.module.scss';
+import { Routes } from '../../../../utils/routes';
+import LinkItem from '../../linkItem';
+import useTranslation from 'utils/hooks/useTranslation';
+import { InoAccordion } from '@elements';
+import { useSet } from 'react-use';
+
+export default function FooterMobile() {
+  const [_, { has, toggle }] = useSet(new Set<string>());
+  const { t } = useTranslation();
+
+  return (
+    <div className={styles.accordionWrapper}>
+      {Routes.map(({ key: mainRouteName, url: mainRouteUrl, subRoutes }) => (
+        <div key={mainRouteUrl} className={styles.accordion}>
+          <InoAccordion
+            accordionTitle={t(`common.navigation.${mainRouteName}.name`)}
+            expanded={has(mainRouteUrl)}
+            onExpandedChange={() => toggle(mainRouteUrl)}
+          >
+            {subRoutes.map(({ key: subRouteName, url: subRouteUrl }) => (
+              <LinkItem
+                key={subRouteUrl}
+                url={subRouteUrl}
+                name={t(
+                  `common.navigation.${mainRouteName}.subroutes.${subRouteName}.name`
+                )}
+                isDense={true}
+                className={styles.subRouteName}
+              />
+            ))}
+          </InoAccordion>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/packages/landingpage/components/layout/linkItem.module.scss
+++ b/packages/landingpage/components/layout/linkItem.module.scss
@@ -2,6 +2,7 @@ p.link {
   cursor: pointer;
   color: var(--inovex-elements-n-6);
   overflow-wrap: break-word;
+  width: fit-content;
 
   &:hover {
     color: var(--inovex-elements-primary);

--- a/packages/landingpage/components/layout/linkItem.tsx
+++ b/packages/landingpage/components/layout/linkItem.tsx
@@ -9,6 +9,7 @@ type Props = {
   isActive?: boolean;
   isDense?: boolean;
   noMargin?: boolean;
+  className?: string;
 };
 
 export default function LinkItem({
@@ -17,6 +18,7 @@ export default function LinkItem({
   isActive = false,
   isDense = false,
   noMargin = false,
+  className,
 }: Props) {
   const { locale } = useTranslation();
 
@@ -28,7 +30,8 @@ export default function LinkItem({
           isActive && styles.linkActive,
           noMargin && styles.noMargin,
           isDense && styles.linkDense,
-          isDense ? 'title-m' : 'title-l'
+          isDense ? 'title-m' : 'title-l',
+          className
         )}
       >
         {name.toLowerCase()}


### PR DESCRIPTION
Closes no linked issue, is a variant of #1049 

## Proposed Changes

As we are still in the process of deciding on a suitable design for our footer, I've created a draft that spans the full width and resembles a traditional footer with a more clear separation of content using our primary colors. 

_Note: The mobile footer (utilizing ino-accordions) requires exposing custom CSS properties to adjust its colors, ensuring compatibility with this background color._


Preview:

https://github.com/inovex/elements/assets/81302108/2d0ce1a3-5400-4ad7-b74a-88721e212c31


