### PR TITLE
refactor(ino-tab-bar): accessible ino-tab-bar

### DIFF
--- a/packages/elements-angular/src/generated/components.ts
+++ b/packages/elements-angular/src/generated/components.ts
@@ -1159,14 +1159,14 @@ export declare interface InoSwitch extends Components.InoSwitch {
 
 
 @ProxyCmp({
-  inputs: ['icon', 'indicatorContentWidth', 'label', 'stacked']
+  inputs: ['icon', 'indicatorContentWidth', 'label', 'panelId', 'stacked']
 })
 @Component({
   selector: 'ino-tab',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
-  inputs: ['icon', 'indicatorContentWidth', 'label', 'stacked'],
+  inputs: ['icon', 'indicatorContentWidth', 'label', 'panelId', 'stacked'],
 })
 export class InoTab {
   protected el: HTMLElement;

--- a/packages/elements-vue/src/proxies.ts
+++ b/packages/elements-vue/src/proxies.ts
@@ -494,6 +494,7 @@ export const InoSwitch = /*@__PURE__*/ defineContainer<JSX.InoSwitch, JSX.InoSwi
 export const InoTab = /*@__PURE__*/ defineContainer<JSX.InoTab>('ino-tab', undefined, [
   'icon',
   'label',
+  'panelId',
   'stacked',
   'indicatorContentWidth',
   'interacted'

--- a/packages/elements/src/components.d.ts
+++ b/packages/elements/src/components.d.ts
@@ -1247,6 +1247,10 @@ export namespace Components {
          */
         "label"?: string;
         /**
+          * The ID of the associated content panel. This prop is specifically used in conjunction with the `ino-tab-bar`. It links the tab to its content panel for accessibility, adhering to WAI-ARIA practices for the tabpanel role. See: https://w3c.github.io/aria/#tabpanel
+         */
+        "panelId"?: string;
+        /**
           * Indicates that the tab icon and label should flow vertically instead of horizontally.
          */
         "stacked": boolean;
@@ -3262,6 +3266,10 @@ declare namespace LocalJSX {
           * Emitted when the user interacts with the tab. This event is used by the ino-tab-bar.
          */
         "onInteracted"?: (event: InoTabCustomEvent<any>) => void;
+        /**
+          * The ID of the associated content panel. This prop is specifically used in conjunction with the `ino-tab-bar`. It links the tab to its content panel for accessibility, adhering to WAI-ARIA practices for the tabpanel role. See: https://w3c.github.io/aria/#tabpanel
+         */
+        "panelId"?: string;
         /**
           * Indicates that the tab icon and label should flow vertically instead of horizontally.
          */

--- a/packages/elements/src/components/ino-tab/ino-tab.tsx
+++ b/packages/elements/src/components/ino-tab/ino-tab.tsx
@@ -8,6 +8,7 @@ import {
   Prop,
   h,
   Listen,
+  Watch,
 } from '@stencil/core';
 import classNames from 'classnames';
 
@@ -32,6 +33,11 @@ export class Tab implements ComponentInterface {
   @Prop() label?: string;
 
   /**
+   * The ID of the associated content panel. This prop is specifically used in conjunction with the `ino-tab-bar`. It links the tab to its content panel for accessibility, adhering to WAI-ARIA practices for the tabpanel role. See: https://w3c.github.io/aria/#tabpanel
+   */
+  @Prop({ reflect: true }) panelId?: string = '';
+
+  /**
    * Indicates that the tab icon and label should flow vertically instead of horizontally.
    */
   @Prop() stacked = false;
@@ -47,10 +53,28 @@ export class Tab implements ComponentInterface {
    */
   @Event() interacted!: EventEmitter;
 
+  @Watch('panelID')
+  panelIdChanged(newValue: string) {
+    this.panelId = newValue;
+  }
+
   @Listen('MDCTab:interacted')
   interactionHandler(e) {
     e.stopPropagation();
     this.interacted.emit(this.el);
+  }
+  componentWillLoad() {
+    this.syncAttributeToProp();
+  }
+  /**
+   * Syncs 'panelID' attribute with the property for Storybook compatibility inside the ino-tab-bar story.
+   * ( <ino-tab panelID="panel-1" label="User" icon="user"></ino-tab> )
+   */
+  private syncAttributeToProp() {
+    const panelIdAttr = this.el.getAttribute('panelID');
+    if (panelIdAttr) {
+      this.panelId = panelIdAttr;
+    }
   }
 
   render() {

--- a/packages/elements/src/components/ino-tab/readme.md
+++ b/packages/elements/src/components/ino-tab/readme.md
@@ -74,12 +74,13 @@ class MyComponent extends Component {
 
 ## Properties
 
-| Property                | Attribute                 | Description                                                                                                                                    | Type      | Default     |
-| ----------------------- | ------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- | --------- | ----------- |
-| `icon`                  | `icon`                    | Indicates a leading icon in the tab.                                                                                                           | `string`  | `undefined` |
-| `indicatorContentWidth` | `indicator-content-width` | Indicates that the tab only expands to the width of its content.                                                                               | `boolean` | `false`     |
-| `label`                 | `label`                   | <span style="color:red">**[DEPRECATED]**</span> <br/><br/>[DEPRECATED] Please use the default slot instead. Indicates a label text in the tab. | `string`  | `undefined` |
-| `stacked`               | `stacked`                 | Indicates that the tab icon and label should flow vertically instead of horizontally.                                                          | `boolean` | `false`     |
+| Property                | Attribute                 | Description                                                                                                                                                                                                                                                            | Type      | Default     |
+| ----------------------- | ------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------- | ----------- |
+| `icon`                  | `icon`                    | Indicates a leading icon in the tab.                                                                                                                                                                                                                                   | `string`  | `undefined` |
+| `indicatorContentWidth` | `indicator-content-width` | Indicates that the tab only expands to the width of its content.                                                                                                                                                                                                       | `boolean` | `false`     |
+| `label`                 | `label`                   | <span style="color:red">**[DEPRECATED]**</span> <br/><br/>[DEPRECATED] Please use the default slot instead. Indicates a label text in the tab.                                                                                                                         | `string`  | `undefined` |
+| `panelId`               | `panel-id`                | The ID of the associated content panel. This prop is specifically used in conjunction with the `ino-tab-bar`. It links the tab to its content panel for accessibility, adhering to WAI-ARIA practices for the tabpanel role. See: https://w3c.github.io/aria/#tabpanel | `string`  | `''`        |
+| `stacked`               | `stacked`                 | Indicates that the tab icon and label should flow vertically instead of horizontally.                                                                                                                                                                                  | `boolean` | `false`     |
 
 
 ## Events

--- a/packages/storybook/elements-stencil-docs.json
+++ b/packages/storybook/elements-stencil-docs.json
@@ -9560,6 +9560,28 @@
           "required": false
         },
         {
+          "name": "panelId",
+          "type": "string",
+          "complexType": {
+            "original": "string",
+            "resolved": "string",
+            "references": {}
+          },
+          "mutable": false,
+          "attr": "panel-id",
+          "reflectToAttr": true,
+          "docs": "The ID of the associated content panel. This prop is specifically used in conjunction with the `ino-tab-bar`. It links the tab to its content panel for accessibility, adhering to WAI-ARIA practices for the tabpanel role. See: https://w3c.github.io/aria/#tabpanel",
+          "docsTags": [],
+          "default": "''",
+          "values": [
+            {
+              "type": "string"
+            }
+          ],
+          "optional": true,
+          "required": false
+        },
+        {
           "name": "stacked",
           "type": "boolean",
           "complexType": {

--- a/packages/storybook/src/stories/ino-tab-bar/ino-tab-bar.stories.ts
+++ b/packages/storybook/src/stories/ino-tab-bar/ino-tab-bar.stories.ts
@@ -6,21 +6,21 @@ import { html } from 'lit-html';
 import { decorateStoryWithClass } from '../utils';
 import './ino-tab-bar.scss';
 
-const eventHandler = (e) => e.target.setAttribute('active-tab', e.detail);
+const eventHandler = e => e.target.setAttribute('active-tab', e.detail);
 
 export default {
   title: `Structure/ino-tab-bar`,
   component: 'ino-tab-bar',
   decorators: [
-    (story) => decorateStoryWithClass(story, 'story-tab-bar'),
-    (story) => {
+    story => decorateStoryWithClass(story, 'story-tab-bar'),
+    story => {
       useEffect(() => {
         const tabBars = document.querySelectorAll('ino-tab-bar');
-        tabBars.forEach((t) =>
+        tabBars.forEach(t =>
           t.addEventListener('activeTabChange', eventHandler)
         );
         return () =>
-          tabBars.forEach((t) =>
+          tabBars.forEach(t =>
             t.removeEventListener('activeTabChange', eventHandler)
           );
       });
@@ -44,13 +44,18 @@ export default {
 const template = new TemplateGenerator<Components.InoTabBar>(
   'ino-tab-bar',
   args => html`
-  <ino-tab-bar id="customizable-tabbar" active-tab="${args.activeTab}" auto-focus="${args.autoFocus}">
-    <ino-tab label="User" icon="user"></ino-tab>
-    <ino-tab label="Messages" icon="message"></ino-tab>
-    <ino-tab label="Settings" icon="settings"></ino-tab>
-    <ino-tab label="Download" icon="download"></ino-tab>
-  </ino-tab-bar>
-`);
+    <ino-tab-bar
+      id="customizable-tabbar"
+      active-tab="${args.activeTab}"
+      auto-focus="${args.autoFocus}"
+    >
+      <ino-tab panelId="panel-1" label="User" icon="user"></ino-tab>
+      <ino-tab panelId="panel-2" label="Messages" icon="message"></ino-tab>
+      <ino-tab panelId="panel-3" label="Settings" icon="settings"></ino-tab>
+      <ino-tab panelId="panel-4" label="Download" icon="download"></ino-tab>
+    </ino-tab-bar>
+  `
+);
 
 export const Playground = template.generatePlaygroundStory();
 export const ActiveTab = template.generateStoryForProp('activeTab', 1);


### PR DESCRIPTION
Closes #1002 

### Note on Accessibility Implementations for Tab Panels

Our `ino-tab` and `ino-tab-bar` components focus on providing the tab and the tablist functionality. We do not control or provide the tab panels, as these are part of the user's content implementation. To support accessibility, I added a `panelId` property to the `ino-tab` component. This enables users to link each tab with its corresponding content panel for accessibility purposes, following WAI-ARIA practices. However, the actual implementation of tab panels and their accessibility attributes (`role="tabpanel"`, `aria-labelledby`, etc.) is under the user's control.


