### PR TITLE
feat(elements): add light- & dark-mode configuration

### DIFF
--- a/packages/elements/src/components/ino-accordion/ino-accordion.scss
+++ b/packages/elements/src/components/ino-accordion/ino-accordion.scss
@@ -40,7 +40,7 @@ $animation-time: 200ms;
   }
 
   &--expanded {
-    background: theme.$p-1;
+    background: var(--inovex-elements-p-1); //Example for CSS variable usage
   }
 
   .ino-accordion__content-wrapper {

--- a/packages/elements/src/components/ino-accordion/ino-accordion.scss
+++ b/packages/elements/src/components/ino-accordion/ino-accordion.scss
@@ -6,6 +6,11 @@ $animation-time: 200ms;
 .ino-accordion {
   &:hover {
     background: theme.$p-1;
+    /*
+    TODO: Switch to CSS variables for light- & dark theme support.
+    Replace the above line with the following once the global styles.scss file has been updated with a dark-theme import:
+    background: var(--inovex-elements-p-1);
+    */
   }
   border-radius: 24px;
 

--- a/packages/elements/src/global/styles.scss
+++ b/packages/elements/src/global/styles.scss
@@ -144,13 +144,7 @@
 
 // Dark Theme Variables
 .inovex-elements-theme-dark {
-  --inovex-elements-white: #{dark-theme.$white};
-  --inovex-elements-black: #{dark-theme.$black};
-  --inovex-elements-transparent: #{dark-theme.$transparent};
-
-  // Neutrals dark theme colors
-  --inovex-elements-n-1: #{dark-theme.$n-1};
-  --inovex-elements-n-2: #{dark-theme.$n-2};
+  --inovex-elements-p-1: #48ec4a;
   // ...
 
   /*

--- a/packages/elements/src/global/styles.scss
+++ b/packages/elements/src/global/styles.scss
@@ -1,6 +1,9 @@
 @use '../components/base/typography-new';
 @use '../components/base/theme';
 @use '../components/base/new-theme' as new-theme;
+/*
+@use '../components/base/dark-theme' as dark-theme;
+*/
 
 .inovex-elements-typo {
   font-family: Lato, Verdana, sans-serif;
@@ -91,8 +94,8 @@
     @include typography-new.typo(body-s);
   }
 }
-
-.inovex-elements-theme {
+// Light Theme Variables (Default)
+.inovex-elements-theme/*-light*/ {
   --inovex-elements-white: #{new-theme.$white};
   --inovex-elements-black: #{new-theme.$black};
   --inovex-elements-transparent: #{new-theme.$transparent};
@@ -137,4 +140,30 @@
   --inovex-elements-error-light: #{new-theme.$error-light};
   --inovex-elements-warning: #{new-theme.$warning};
   --inovex-elements-warning-light: #{new-theme.$warning-light};
+}
+
+// Dark Theme Variables
+.inovex-elements-theme-dark {
+  --inovex-elements-white: #{dark-theme.$white};
+  --inovex-elements-black: #{dark-theme.$black};
+  --inovex-elements-transparent: #{dark-theme.$transparent};
+
+  // Neutrals dark theme colors
+  --inovex-elements-n-1: #{dark-theme.$n-1};
+  --inovex-elements-n-2: #{dark-theme.$n-2};
+  // ...
+
+  /*
+  TODO:
+  Continue defining dark theme colors for other categories.
+  */
+
+  /* Theme Switching Documentation
+   * -----------------------------
+   * The elements package is designed to be theme-aware, supporting light and dark themes.
+   * The actual theme switching should be implemented in the application using this library (our next.js landingpage or storybook).
+   * The application can switch themes at runtime by toggling between the 
+   * '.inovex-elements-theme-light' and '.inovex-elements-theme-dark' classes on a high-level element (like 'body').
+   * This allows for dynamic theme changes without the need to reload or recompile the application.
+   */
 }

--- a/packages/landingpage/components/layout.tsx
+++ b/packages/landingpage/components/layout.tsx
@@ -4,12 +4,14 @@ import styles from './layout.module.scss';
 import Footer from './layout/footer/footer';
 import Header from './layout/header/header';
 import { UiContext, UiContextType } from '../utils/context/UiContext';
+import { useTheme } from '../utils/context/ThemeContext';
 
 export default function Layout({ children }: { children: ReactNode }) {
   const { isFooterHidden } = useContext(UiContext) as UiContextType;
+  const { theme } = useTheme();
 
   return (
-    <div className="inovex-elements-typo inovex-elements-theme">
+    <div className={`inovex-elements-typo ${theme}`}>
       <Head>
         <meta
           name="viewport"

--- a/packages/landingpage/components/layout/header/desktop/navbar.tsx
+++ b/packages/landingpage/components/layout/header/desktop/navbar.tsx
@@ -2,15 +2,19 @@ import { useRouter } from 'next/router';
 import styles from './navbar.module.scss';
 import { Routes } from '../../../../utils/routes';
 import LinkItem from '../../linkItem';
-import { InoPopover } from '@elements';
+import { InoPopover, InoSwitch } from '@elements';
 import useTranslation from 'utils/hooks/useTranslation';
 import { ContactButton } from '../../../shared/contactButton';
+import { useTheme } from 'utils/context/ThemeContext';
+import { inDevEnvironment } from 'utils/in-dev-mode';
 
 const POPOVER_OFFSET = 10;
 
 export default function Navbar() {
   const router = useRouter();
   const { t } = useTranslation();
+  const { theme, toggleTheme } = useTheme();
+  const isDarkMode = theme === 'inovex-elements-theme-dark';
 
   function isRouteActive(mainRouteUrl: string, mainRouteName: string) {
     const pathSplit = router.pathname.split('/');
@@ -59,6 +63,10 @@ export default function Navbar() {
         </div>
       ))}
       <ContactButton />
+      {/* TODO: add a toggle Icon with Sun & Moon icons for light and dark mode toggle */}
+      {inDevEnvironment && (
+      <InoSwitch checked={isDarkMode} onCheckedChange={toggleTheme}></InoSwitch>
+    )}
     </nav>
   );
 }

--- a/packages/landingpage/pages/_app.tsx
+++ b/packages/landingpage/pages/_app.tsx
@@ -15,6 +15,18 @@ import UiContextProvider from '../utils/context/UiContext';
 import { VersionProvider } from '../utils/context/VersionContext';
 
 function MyApp({ Component, pageProps }: AppProps) {
+  /*
+    Theme Toggle Implementation:
+    ----------------------------
+    - A theme state should be introduced to manage the current theme (light or dark).
+    - The theme state will be used to toggle a class on a high-level element, like `body`.
+    - This class change will dynamically update the styles of Stencil components used in the application via CSS variables.
+    - The actual theme toggle function (to switch between light and dark) can be implemented and triggered from a UI element like a button.
+    - This setup allows runtime theme switching without causing a full page re-render, as it relies on CSS variable updates.
+
+    NOTE: this probably interfers with "@import '@inovex.de/elements/dist/inovex-elements/inovex-elements.css';" in the landingpage global.css,
+          as we use the same css variables ("--inovex-elements-n-9"). Need to test if this is a problem.
+  */
   useEffect(() => {
     void applyPolyfills().then(() => {
       void defineCustomElements(window);

--- a/packages/landingpage/pages/_app.tsx
+++ b/packages/landingpage/pages/_app.tsx
@@ -13,20 +13,9 @@ import useDefaultLocale from '../translations/useDefaultLocale';
 import { useMount } from 'react-use';
 import UiContextProvider from '../utils/context/UiContext';
 import { VersionProvider } from '../utils/context/VersionContext';
+import { ThemeProvider } from 'utils/context/ThemeContext';
 
 function MyApp({ Component, pageProps }: AppProps) {
-  /*
-    Theme Toggle Implementation:
-    ----------------------------
-    - A theme state should be introduced to manage the current theme (light or dark).
-    - The theme state will be used to toggle a class on a high-level element, like `body`.
-    - This class change will dynamically update the styles of Stencil components used in the application via CSS variables.
-    - The actual theme toggle function (to switch between light and dark) can be implemented and triggered from a UI element like a button.
-    - This setup allows runtime theme switching without causing a full page re-render, as it relies on CSS variable updates.
-
-    NOTE: this probably interfers with "@import '@inovex.de/elements/dist/inovex-elements/inovex-elements.css';" in the landingpage global.css,
-          as we use the same css variables ("--inovex-elements-n-9"). Need to test if this is a problem.
-  */
   useEffect(() => {
     void applyPolyfills().then(() => {
       void defineCustomElements(window);
@@ -40,9 +29,11 @@ function MyApp({ Component, pageProps }: AppProps) {
     <UiContextProvider>
       <LanguageProvider localization={pageProps.localization}>
         <VersionProvider>
-          <Layout>
-            <Component {...pageProps} />
-          </Layout>
+          <ThemeProvider>
+            <Layout>
+              <Component {...pageProps} />
+            </Layout>
+          </ThemeProvider>
         </VersionProvider>
       </LanguageProvider>
     </UiContextProvider>

--- a/packages/landingpage/utils/context/ThemeContext.tsx
+++ b/packages/landingpage/utils/context/ThemeContext.tsx
@@ -1,0 +1,28 @@
+import { ReactNode, createContext, useContext, useState } from 'react';
+import { inDevEnvironment } from 'utils/in-dev-mode';
+
+const ThemeContext = createContext({
+  theme: 'inovex-elements-theme',
+  toggleTheme: () => {}
+});
+
+export const useTheme = () => useContext(ThemeContext);
+
+
+export const ThemeProvider = ({ children }: { children: ReactNode }) => {
+  const [theme, setTheme] = useState('inovex-elements-theme');
+
+  const toggleTheme = () => {
+    if (!inDevEnvironment) return;
+
+    setTheme(current => 
+      current === 'inovex-elements-theme' ? 'inovex-elements-theme-dark' : 'inovex-elements-theme'
+    );
+  };
+
+  return (
+    <ThemeContext.Provider value={{ theme, toggleTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+};

--- a/packages/storybook/config/main.js
+++ b/packages/storybook/config/main.js
@@ -14,6 +14,7 @@ module.exports = {
   addons: [
     '@storybook/addon-essentials',
     '@pxtrn/storybook-addon-docs-stencil',
+    'storybook-addon-themes'
   ],
   managerEntries: ['./addons/post-current-story'],
   typescript: {

--- a/packages/storybook/config/preview.js
+++ b/packages/storybook/config/preview.js
@@ -27,6 +27,8 @@ setStencilDocJson(docsJson);
 
 applyPolyfills().then(() => defineCustomElements(window));
 
+const isInDevEnvironment = process && process.env.NODE_ENV === 'development';
+
 // Explicit order for the docs section
 export const parameters = {
   viewMode: 'docs',
@@ -58,4 +60,14 @@ export const parameters = {
       ],
     },
   },
+  // using storybook-addon-themes https://storybook.js.org/addons/storybook-addon-themes
+  ...(isInDevEnvironment && {
+    themes: {
+      default: 'light',
+      list: [
+        { name: 'light', class: 'inovex-elements-theme', color: '#ffffff' },
+        { name: 'dark', class: 'inovex-elements-theme-dark', color: '#000000' },
+      ],
+    },
+  }),
 };

--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -63,6 +63,7 @@
     "sass": "^1.49.7",
     "sass-loader": "^12.6.0",
     "story-description-loader": "^1.0.0",
+    "storybook-addon-themes": "^6.1.0",
     "typescript": "^4.5.5",
     "webpack": "^5.0.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -6174,7 +6174,7 @@
     prop-types "^15.7.2"
     regenerator-runtime "^0.13.7"
 
-"@storybook/addons@6.5.16":
+"@storybook/addons@6.5.16", "@storybook/addons@^6.0.0":
   version "6.5.16"
   resolved "https://registry.npmjs.org/@storybook/addons/-/addons-6.5.16.tgz#07e8f2205f86fa4c9dada719e3e096cb468e3cdd"
   integrity sha512-p3DqQi+8QRL5k7jXhXmJZLsE/GqHqyY6PcoA1oNTJr0try48uhTGUOYkgzmqtDaa/qPFO5LP+xCPzZXckGtquQ==
@@ -6191,7 +6191,7 @@
     global "^4.4.0"
     regenerator-runtime "^0.13.7"
 
-"@storybook/api@6.5.16", "@storybook/api@^6.4.9":
+"@storybook/api@6.5.16", "@storybook/api@^6.0.0", "@storybook/api@^6.4.9":
   version "6.5.16"
   resolved "https://registry.npmjs.org/@storybook/api/-/api-6.5.16.tgz#897915b76de05587fd702951d5d836f708043662"
   integrity sha512-HOsuT8iomqeTMQJrRx5U8nsC7lJTwRr1DhdD0SzlqL4c80S/7uuCy4IZvOt4sYQjOzW5fOo/kamcoBXyLproTA==
@@ -6378,7 +6378,7 @@
     core-js "^3.8.2"
     global "^4.4.0"
 
-"@storybook/components@6.5.16":
+"@storybook/components@6.5.16", "@storybook/components@^6.0.0":
   version "6.5.16"
   resolved "https://registry.npmjs.org/@storybook/components/-/components-6.5.16.tgz#f8dc51213bc08fe32154be964e1e8b0e2f670ed6"
   integrity sha512-LzBOFJKITLtDcbW9jXl0/PaG+4xAz25PK8JxPZpIALbmOpYWOAPcO6V9C2heX6e6NgWFMUxjplkULEk9RCQMNA==
@@ -6474,7 +6474,7 @@
     util-deprecate "^1.0.2"
     webpack "4"
 
-"@storybook/core-events@6.5.16":
+"@storybook/core-events@6.5.16", "@storybook/core-events@^6.0.0":
   version "6.5.16"
   resolved "https://registry.npmjs.org/@storybook/core-events/-/core-events-6.5.16.tgz#b1c265dac755007dae172d9d4b72656c9e5d7bb3"
   integrity sha512-qMZQwmvzpH5F2uwNUllTPg6eZXr2OaYZQRRN8VZJiuorZzDNdAFmiVWMWdkThwmyLEJuQKXxqCL8lMj/7PPM+g==
@@ -6790,7 +6790,7 @@
     read-pkg-up "^7.0.1"
     regenerator-runtime "^0.13.7"
 
-"@storybook/theming@6.5.16", "@storybook/theming@^6.5.8":
+"@storybook/theming@6.5.16", "@storybook/theming@^6.0.0", "@storybook/theming@^6.5.8":
   version "6.5.16"
   resolved "https://registry.npmjs.org/@storybook/theming/-/theming-6.5.16.tgz#b999bdb98945b605b93b9dfdf7408535b701e2aa"
   integrity sha512-hNLctkjaYLRdk1+xYTkC1mg4dYz2wSv6SqbLpcKMbkPHTE0ElhddGPHQqB362md/w9emYXNkt1LSMD8Xk9JzVQ==
@@ -10614,7 +10614,7 @@ commander@^10.0.0:
   resolved "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz#881ee46b4f77d1c1dccc5823433aa39b022cbe06"
   integrity sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==
 
-commander@^2.20.0:
+commander@^2.20.0, commander@~2.20.3:
   version "2.20.3"
   resolved "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
   integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
@@ -10638,11 +10638,6 @@ commander@^8.3.0:
   version "8.3.0"
   resolved "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz#4837ea1b2da67b9c616a67afbb0fafee567bca66"
   integrity sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==
-
-commander@~2.19.0:
-  version "2.19.0"
-  resolved "https://registry.npmjs.org/commander/-/commander-2.19.0.tgz#f6198aa84e5b83c46054b94ddedbfed5ee9ff12a"
-  integrity sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg==
 
 common-ancestor-path@^1.0.1:
   version "1.0.1"
@@ -11049,6 +11044,11 @@ core-js@^3.0.4, core-js@^3.2.1, core-js@^3.6.5, core-js@^3.8.2:
   version "3.33.0"
   resolved "https://registry.npmjs.org/core-js/-/core-js-3.33.0.tgz#70366dbf737134761edb017990cf5ce6c6369c40"
   integrity sha512-HoZr92+ZjFEKar5HS6MC776gYslNOKHt75mEBKWKnPeFDpZ6nH5OeF3S6HFT1mUAUZKrzkez05VboaX8myjSuw==
+
+core-js@^3.6.4:
+  version "3.33.3"
+  resolved "https://registry.npmjs.org/core-js/-/core-js-3.33.3.tgz#3c644a323f0f533a0d360e9191e37f7fc059088d"
+  integrity sha512-lo0kOocUlLKmm6kv/FswQL8zbkH7mVsLJ/FULClOhv8WRVmKLVcs6XPNQAzstfeJTCHMyButEwG+z1kHxHoDZw==
 
 core-util-is@~1.0.0:
   version "1.0.3"
@@ -12194,6 +12194,11 @@ elliptic@^6.5.3, elliptic@^6.5.4:
     inherits "^2.0.4"
     minimalistic-assert "^1.0.1"
     minimalistic-crypto-utils "^1.0.1"
+
+emittery@^0.13.1:
+  version "0.13.1"
+  resolved "https://registry.npmjs.org/emittery/-/emittery-0.13.1.tgz#c04b8c3457490e0847ae51fced3af52d338e3dad"
+  integrity sha512-DeWwawk6r5yR9jFgnDKYt4sLS0LmHJJi3ZOnb5/JdbYwj3nW+FxQnHIjhBKz8YLC7oRNPVM9NQ47I3CVx34eqQ==
 
 emittery@^0.7.1:
   version "0.7.2"
@@ -15919,6 +15924,13 @@ jest-docblock@^26.0.0:
   dependencies:
     detect-newline "^3.0.0"
 
+jest-docblock@^29.7.0:
+  version "29.7.0"
+  resolved "https://registry.npmjs.org/jest-docblock/-/jest-docblock-29.7.0.tgz#8fddb6adc3cdc955c93e2a87f61cfd350d5d119a"
+  integrity sha512-q617Auw3A612guyaFgsbFeYpNP5t2aoUNLwBUbc/0kD1R4t9ixDbyFTHd1nok4epoVFpr7PmeWHrhvuV3XaJ4g==
+  dependencies:
+    detect-newline "^3.0.0"
+
 jest-each@^26.6.2:
   version "26.6.2"
   resolved "https://registry.npmjs.org/jest-each/-/jest-each-26.6.2.tgz#02526438a77a67401c8a6382dfe5999952c167cb"
@@ -16065,6 +16077,14 @@ jest-leak-detector@^26.6.2:
     jest-get-type "^26.3.0"
     pretty-format "^26.6.2"
 
+jest-leak-detector@^29.7.0:
+  version "29.7.0"
+  resolved "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-29.7.0.tgz#5b7ec0dadfdfec0ca383dc9aa016d36b5ea4c728"
+  integrity sha512-kYA8IJcSYtST2BY9I+SMC32nDpBT3J2NvWJx8+JCuCdl/CR1I4EKUJROiP8XtCcxqgTTBGJNdbB1A8XRKbTetw==
+  dependencies:
+    jest-get-type "^29.6.3"
+    pretty-format "^29.7.0"
+
 jest-matcher-utils@^26.6.2:
   version "26.6.2"
   resolved "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-26.6.2.tgz#8e6fd6e863c8b2d31ac6472eeb237bc595e53e7a"
@@ -16185,7 +16205,7 @@ jest-resolve@^29.4.1, jest-resolve@^29.7.0:
     resolve.exports "^2.0.0"
     slash "^3.0.0"
 
-jest-runner@^26.6.2, jest-runner@^26.6.3, jest-runner@^29.7.0:
+jest-runner@^26.6.3:
   version "26.6.3"
   resolved "https://registry.npmjs.org/jest-runner/-/jest-runner-26.6.3.tgz#2d1fed3d46e10f233fd1dbd3bfaa3fe8924be159"
   integrity sha512-atgKpRHnaA2OvByG/HpGA4g6CSPS/1LK0jK3gATJAoptC1ojltpmVlYC3TYgdmGp+GLuhzpH30Gvs36szSL2JQ==
@@ -16210,6 +16230,33 @@ jest-runner@^26.6.2, jest-runner@^26.6.3, jest-runner@^29.7.0:
     jest-worker "^26.6.2"
     source-map-support "^0.5.6"
     throat "^5.0.0"
+
+jest-runner@^29.7.0:
+  version "29.7.0"
+  resolved "https://registry.npmjs.org/jest-runner/-/jest-runner-29.7.0.tgz#809af072d408a53dcfd2e849a4c976d3132f718e"
+  integrity sha512-fsc4N6cPCAahybGBfTRcq5wFR6fpLznMg47sY5aDpsoejOcVYFb07AHuSnR0liMcPTgBsA3ZJL6kFOjPdoNipQ==
+  dependencies:
+    "@jest/console" "^29.7.0"
+    "@jest/environment" "^29.7.0"
+    "@jest/test-result" "^29.7.0"
+    "@jest/transform" "^29.7.0"
+    "@jest/types" "^29.6.3"
+    "@types/node" "*"
+    chalk "^4.0.0"
+    emittery "^0.13.1"
+    graceful-fs "^4.2.9"
+    jest-docblock "^29.7.0"
+    jest-environment-node "^29.7.0"
+    jest-haste-map "^29.7.0"
+    jest-leak-detector "^29.7.0"
+    jest-message-util "^29.7.0"
+    jest-resolve "^29.7.0"
+    jest-runtime "^29.7.0"
+    jest-util "^29.7.0"
+    jest-watcher "^29.7.0"
+    jest-worker "^29.7.0"
+    p-limit "^3.1.0"
+    source-map-support "0.5.13"
 
 jest-runtime@^26.6.3:
   version "26.6.3"
@@ -16387,6 +16434,20 @@ jest-watcher@^26.6.2:
     ansi-escapes "^4.2.1"
     chalk "^4.0.0"
     jest-util "^26.6.2"
+    string-length "^4.0.1"
+
+jest-watcher@^29.7.0:
+  version "29.7.0"
+  resolved "https://registry.npmjs.org/jest-watcher/-/jest-watcher-29.7.0.tgz#7810d30d619c3a62093223ce6bb359ca1b28a2f2"
+  integrity sha512-49Fg7WXkU3Vl2h6LbLtMQ/HyB6rXSIX7SqvBLQmssRBGN9I0PNvPmAmCWSOY6SOvrjhI/F7/bGAv9RtnsPA03g==
+  dependencies:
+    "@jest/test-result" "^29.7.0"
+    "@jest/types" "^29.6.3"
+    "@types/node" "*"
+    ansi-escapes "^4.2.1"
+    chalk "^4.0.0"
+    emittery "^0.13.1"
+    jest-util "^29.7.0"
     string-length "^4.0.1"
 
 jest-worker@^26.5.0, jest-worker@^26.6.2:
@@ -23142,6 +23203,14 @@ source-map-resolve@^0.5.0:
     source-map-url "^0.4.0"
     urix "^0.1.0"
 
+source-map-support@0.5.13:
+  version "0.5.13"
+  resolved "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.13.tgz#31b24a9c2e73c2de85066c0feb7d44767ed52932"
+  integrity sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==
+  dependencies:
+    buffer-from "^1.0.0"
+    source-map "^0.6.0"
+
 source-map-support@0.5.19:
   version "0.5.19"
   resolved "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.19.tgz#a98b62f86dcaf4f67399648c085291ab9e8fed61"
@@ -23414,6 +23483,20 @@ story-description-loader@^1.0.0:
     "@babel/plugin-transform-typescript" "^7.8.3"
     loader-utils "^1.4.0"
     schema-utils "^2.6.4"
+
+storybook-addon-themes@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.npmjs.org/storybook-addon-themes/-/storybook-addon-themes-6.1.0.tgz#5d7afe293cd4bc28a8f634aa466dbd8fd2f9222e"
+  integrity sha512-ZT8aNgrwFVNEOmOPBLNS0WBacjvMFo/bZ83P8MmsJ3Ewqt0AbmPioghTZccARUn/EQ+LrDxyh2D0QgmLaKo07Q==
+  dependencies:
+    "@storybook/addons" "^6.0.0"
+    "@storybook/api" "^6.0.0"
+    "@storybook/components" "^6.0.0"
+    "@storybook/core-events" "^6.0.0"
+    "@storybook/theming" "^6.0.0"
+    core-js "^3.6.4"
+    global "^4.4.0"
+    memoizerific "^1.11.3"
 
 stream-browserify@^2.0.1:
   version "2.0.2"
@@ -24551,18 +24634,13 @@ uc.micro@^1.0.1, uc.micro@^1.0.5:
   resolved "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz#9c411a802a409a91fc6cf74081baba34b24499ac"
   integrity sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==
 
-uglify-js@3.4.x:
-  version "3.4.10"
-  resolved "https://registry.npmjs.org/uglify-js/-/uglify-js-3.4.10.tgz#9ad9563d8eb3acdfb8d38597d2af1d815f6a755f"
-  integrity sha512-Y2VsbPVs0FIshJztycsO2SfPk7/KAF/T72qzv9u5EpQ4kB2hQoHlhNQTsNyy6ul7lQtqJN/AoWeS23OzEiEFxw==
+uglify-js@3.4.x, uglify-js@3.6.4, uglify-js@^3.1.4:
+  version "3.6.4"
+  resolved "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.4.tgz#88cc880c6ed5cf9868fdfa0760654e7bed463f1d"
+  integrity sha512-9Yc2i881pF4BPGhjteCXQNaXx1DCwm3dtOyBaG2hitHjLWOczw/ki8vD1bqyT3u6K0Ms/FpCShkmfg+FtlOfYA==
   dependencies:
-    commander "~2.19.0"
+    commander "~2.20.3"
     source-map "~0.6.1"
-
-uglify-js@^3.1.4:
-  version "3.17.4"
-  resolved "https://registry.npmjs.org/uglify-js/-/uglify-js-3.17.4.tgz#61678cf5fa3f5b7eb789bb345df29afb8257c22c"
-  integrity sha512-T9q82TJI9e/C1TAxYvfb16xO120tMVFZrGA3f9/P4424DNu6ypK103y0GPFVa17yotwSyZW5iYXgjYHkGrJW/g==
 
 unbox-primitive@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
Closes #1057

**Theme switch example** _(highlighted green only for the accordion--expanded component currently)_:


https://github.com/inovex/elements/assets/81302108/56816cb5-db5c-4910-8171-c7dfaa5b49bc



### Notes: 

- Defined new primary/neutral/alert colors in our global `styles.scss`
- Enable our inovex Elements components to be theme aware by using CSS variables (` var(--inovex-elements-p-1);` instead of `theme.$p-1;`).
- Switch the css class in the landingpage and storybook to `.inovex-elements-theme` & `.inovex-elements-theme-dark`
- Disabled all features for production using `isInDevEnvironment` flag

## TODOS for 100% light- & dark-mode support

1. Add a dark theme color pallete covering all our neutral, primary and alert colors to our global styles.scss in the elements package

2. Stencil Components: Switch to CSS variables for light- & dark theme support _(enables theme-awareness at runtime)_

3. Design two new Ino-Icons for theme switch on landingpage: sun & moon icon _(light & dark ino-switch toggle)_




