### PR TITLE
style(elements): use new color scheme

### DIFF
--- a/packages/elements/src/components/base/_tooltip-base.scss
+++ b/packages/elements/src/components/base/_tooltip-base.scss
@@ -6,7 +6,7 @@
 @import '../base/typography';
 
 $border-radius: 10px;
-$shadow-color: rgba(93, 91, 105, 0.3);
+$shadow-color: rgba(theme.$n-10, 0.35);
 
 @mixin tooltip($background-color, $font-color) {
   background: $background-color;

--- a/packages/elements/src/components/base/_tooltip_base.scss
+++ b/packages/elements/src/components/base/_tooltip_base.scss
@@ -6,7 +6,7 @@
 @import '../base/typography';
 
 $border-radius: 10px;
-$shadow-color: rgba(93, 91, 105, 0.3);
+$shadow-color: rgba(theme.$n-10, 0.35);
 
 @mixin tooltip($background-color, $font-color) {
   background: $background-color;

--- a/packages/elements/src/components/ino-chip/ino-chip.scss
+++ b/packages/elements/src/components/ino-chip/ino-chip.scss
@@ -3,16 +3,17 @@
 @use '@material/chips/styles';
 @use '../base/new-theme' as theme;
 
-$border-focused: rgba(45, 93, 255, 0.3);
+$border-focused: theme.$primary-focus;
 
 $chip-outlined-color-enabled: transparent;
-$chip-outlined-color-hover: #e8edff;
+$chip-outlined-color-hover: theme.$p-1;
 
-$chip-solid-color-enabled: #e8edff;
-$chip-solid-color-hover: #d7e0fe;
+$chip-solid-color-enabled: theme.$p-2;
+$chip-solid-color-hover: theme.$p-3;
+$chip-solid-font-color-hover: theme.$p-6;
 
-$chip-color-focus: #2d5dff4d;
-$chip-color-font: theme.$primary;
+$chip-color-focus: theme.$primary-focus;
+$chip-color-font: theme.$p-5;
 
 $icon-size: 16px;
 
@@ -28,13 +29,14 @@ ino-chip {
     width: inherit;
     height: inherit;
     @include chips.ripple-color(transparent);
-    @include chips.trailing-action-color(theme.$primary);
+    @include chips.trailing-action-color(theme.$p-5);
     @include chips.trailing-action-ripple-size(0px);
-    @include chips.text-label-color(theme.$primary);
-    @include chips.icon-color(theme.$primary);
-    @include chips.checkmark-color(theme.$primary);
+    @include chips.text-label-color(theme.$p-5);
+    @include chips.icon-color(theme.$p-5);
+    @include chips.checkmark-color(theme.$p-5);
     @include chips.height(inherit);
     @include chips.shape-radius(100%);
+    @include chips.text-label-color($chip-color-font);
     transition: ease-in-out 0.15s;
 
     .ino-chip-leading-icon {
@@ -77,10 +79,10 @@ ino-chip {
     @include chips.outline-style(solid);
     @include chips.outline-width(1px);
     @include chips.container-color($chip-outlined-color-enabled);
-    @include chips.outline-color(theme.$primary);
+    @include chips.outline-color(theme.$p-5);
 
     ino-icon {
-      --icon-color: #{theme.$primary};
+      --icon-color: #{theme.$p-5};
     }
 
     &:hover,
@@ -94,12 +96,13 @@ ino-chip {
     @include chips.container-color($chip-solid-color-enabled);
 
     ino-icon {
-      --icon-color: theme.$primary;
+      --icon-color: theme.$p-5;
     }
 
     &:hover,
     &:focus {
       @include chips.container-color($chip-solid-color-hover);
+      @include chips.text-label-color($chip-solid-font-color-hover);
     }
   }
 

--- a/packages/elements/src/components/ino-datepicker/ino-datepicker.scss
+++ b/packages/elements/src/components/ino-datepicker/ino-datepicker.scss
@@ -1,9 +1,8 @@
 @use '../base/typography';
-@use '../base/theme';
+@use '../base/new-theme' as theme;
 @import '~flatpickr/dist/flatpickr';
 @import '~flatpickr/dist/plugins/monthSelect/style';
 
-$light-blue: #d0d0e6; // rgba(theme.color(primary), 0.1);
 $padding-vertical: 12px;
 $padding-horizontal: 24px;
 
@@ -24,11 +23,11 @@ ino-datepicker {
 
 // Customize flatpickr styles
 
-$hover-color: lighten(theme.color(primary), 36.5%);
+$hover-color: theme.$p-3;
 
 .flatpickr-calendar {
   @include typography.font(sans-serif, s, regular);
-  box-shadow: 0 3px 20px 0 rgba(0, 0, 0, 0.2);
+  box-shadow: 0 3px 20px 0 rgba(theme.$n-10, 0.35);
   border-radius: 0 6px 6px 6px;
   margin-top: 4px;
 
@@ -73,7 +72,7 @@ $hover-color: lighten(theme.color(primary), 36.5%);
   padding: 0 20px 0 6px;
   margin-bottom: 10px;
   border-radius: 24px;
-  // background-color: theme.$light-blue;
+  // background-color: theme.theme.$n-3;
   width: 100%;
 
   .flatpickr-month {
@@ -101,7 +100,7 @@ $hover-color: lighten(theme.color(primary), 36.5%);
 
     --ino-icon-height: 12px;
     --ino-icon-width: 12px;
-    --ino-icon-color: #{theme.color(primary)};
+    --ino-icon-color: #{theme.$p-5};
   }
 }
 
@@ -140,28 +139,28 @@ $hover-color: lighten(theme.color(primary), 36.5%);
 
   // Text color
   &:not(.flatpickr-disabled)#{$notSelected} {
-    color: theme.color(dark);
+    color: theme.$n-7;
   }
 
   &.nextMonthDay:not(.flatpickr-disabled)#{$notSelected},
   &.prevMonthDay:not(.flatpickr-disabled)#{$notSelected} {
-    color: theme.color(dark, light);
+    color: theme.$n-4;
   }
 
   &:hover:not(.flatpickr-disabled)#{$notSelected},
   &:focus:not(.flatpickr-disabled)#{$notSelected} {
-    color: theme.color(primary);
-    background-color: $light-blue;
-    border-color: $light-blue;
+    color: theme.$p-5;
+    background-color: theme.$n-3;
+    border-color: theme.$n-3;
   }
 
   // Today
   &.today:not(.flatpickr-disabled)#{$notSelected} {
-    color: theme.color(primary);
+    color: theme.$p-5;
     // Only add border if its not in a range
     // (provides problems with the background color logic of flatpickr)
     &:not(.inRange) {
-      border: 1px solid theme.color(primary);
+      border: 1px solid theme.$p-5;
     }
   }
 
@@ -171,8 +170,8 @@ $hover-color: lighten(theme.color(primary), 36.5%);
   &.endRange:hover,
   &.startRange,
   &.startRange:hover {
-    background-color: theme.color(primary);
-    border-color: theme.color(primary);
+    background-color: theme.$p-5;
+    border-color: theme.$p-5;
     color: white;
     font-weight: typography.font-weight(semibold);
     line-height: $size;
@@ -180,14 +179,14 @@ $hover-color: lighten(theme.color(primary), 36.5%);
 
   // Background within a range
   &.inRange:not(.selected) {
-    border-color: $light-blue;
-    background-color: $light-blue;
-    box-shadow: -12px 0 0 $light-blue, 12px 0 0 $light-blue;
+    border-color: theme.$n-3;
+    background-color: theme.$n-3;
+    box-shadow: -12px 0 0 theme.$n-3, 12px 0 0 theme.$n-3;
   }
 
   &.selected.startRange + .endRange:not(:nth-child(7n + 1)),
   &.startRange.startRange + .endRange:not(:nth-child(7n + 1)) {
-    box-shadow: -12px 0 0 $light-blue;
+    box-shadow: -12px 0 0 theme.$n-3;
   }
 }
 
@@ -208,19 +207,19 @@ $hover-color: lighten(theme.color(primary), 36.5%);
     align-items: center;
 
     &.selected {
-      background-color: theme.color(primary);
-      border-color: theme.color(primary);
+      background-color: theme.$p-5;
+      border-color: theme.$p-5;
       font-weight: typography.font-weight(semibold);
       color: white;
     }
 
     &.today {
-      border-color: theme.color(primary);
-      color: theme.color(primary);
+      border-color: theme.$p-5;
+      color: theme.$p-5;
     }
 
     &:hover:not(.selected) {
-      background-color: $light-blue;
+      background-color: theme.$n-3;
     }
   }
 }

--- a/packages/elements/src/components/ino-fab/ino-fab.scss
+++ b/packages/elements/src/components/ino-fab/ino-fab.scss
@@ -56,10 +56,7 @@ $extended-edged-borders: (
    * @prop --fab-icon-color-disabled: Color of the slotted icon if disabled
    */
   --fab-color: var(--ino-fab-color, white);
-  --fab-background-color: var(
-    --ino-fab-background-color,
-    #{theme.$p-6}
-  );
+  --fab-background-color: var(--ino-fab-background-color, #{theme.$p-6});
   --fab-background-color-hover: var(
     --ino-fab-background-color-hover,
     #{theme.$p-5}
@@ -68,14 +65,8 @@ $extended-edged-borders: (
     --ino-fab-background-color-active,
     #{theme.$p-7}
   );
-  --fab-icon-color: var(
-    --ino-fab-icon-color,
-    #{theme.$white}
-  );
-  --fab-color-disabled: var(
-    --ino-fab-color-disabled,
-    #{theme.$white}
-  );
+  --fab-icon-color: var(--ino-fab-icon-color, #{theme.$white});
+  --fab-color-disabled: var(--ino-fab-color-disabled, #{theme.$white});
   --fab-background-color-disabled: var(
     --ino-background-color-disabled,
     #{theme.$n-4}

--- a/packages/elements/src/components/ino-fab/ino-fab.scss
+++ b/packages/elements/src/components/ino-fab/ino-fab.scss
@@ -1,7 +1,7 @@
 @use '../base/mdc-customize';
 @use '@material/fab/mdc-fab';
 @use '@material/fab';
-@use '../base/theme';
+@use '../base/new-theme' as theme;
 @use '../base/animation';
 
 @include fab.core-styles;
@@ -58,31 +58,31 @@ $extended-edged-borders: (
   --fab-color: var(--ino-fab-color, white);
   --fab-background-color: var(
     --ino-fab-background-color,
-    #{theme.color(primary)}
+    #{theme.$p-6}
   );
   --fab-background-color-hover: var(
     --ino-fab-background-color-hover,
-    #{theme.color(primary, light)}
+    #{theme.$p-5}
   );
   --fab-background-color-active: var(
     --ino-fab-background-color-active,
-    #{theme.color(primary, dark)}
+    #{theme.$p-7}
   );
   --fab-icon-color: var(
     --ino-fab-icon-color,
-    #{theme.color(primary, contrast)}
+    #{theme.$white}
   );
   --fab-color-disabled: var(
     --ino-fab-color-disabled,
-    #{theme.color(primary, contrast)}
+    #{theme.$white}
   );
   --fab-background-color-disabled: var(
     --ino-background-color-disabled,
-    #{theme.color(dark, light)}
+    #{theme.$n-4}
   );
   --fab-icon-color-disabled: var(
     --ino-fab-icon-color-disabled,
-    #{theme.color(primary, contrast)}
+    #{theme.$white}
   );
 }
 

--- a/packages/elements/src/components/ino-icon-button/ino-icon-button.scss
+++ b/packages/elements/src/components/ino-icon-button/ino-icon-button.scss
@@ -20,10 +20,7 @@ ino-icon-button {
   $icon-size: var(--ino-icon-button-icon-size, 24px);
   $icon-color: var(--ino-icon-button-icon-color, theme.$p-5);
   $background-color: var(--ino-icon-button-background-color, transparent);
-  $icon-active-color: var(
-    --ino-icon-button-icon-active-color,
-    theme.$p-5
-  );
+  $icon-active-color: var(--ino-icon-button-icon-active-color, theme.$p-5);
   $background-active-color: var(
     --ino-icon-button-background-active-color,
     theme.$p-5

--- a/packages/elements/src/components/ino-icon-button/ino-icon-button.scss
+++ b/packages/elements/src/components/ino-icon-button/ino-icon-button.scss
@@ -1,5 +1,5 @@
 @use '../base/mdc-customize';
-@use '../base/theme';
+@use '../base/new-theme' as theme;
 @use '@material/icon-button/mdc-icon-button';
 @use '@material/icon-button';
 @use '@material/ripple/ripple-theme';
@@ -18,15 +18,15 @@ ino-icon-button {
 
   $button-size: var(--ino-icon-button-size, 48px);
   $icon-size: var(--ino-icon-button-icon-size, 24px);
-  $icon-color: var(--ino-icon-button-icon-color, theme.color(primary));
+  $icon-color: var(--ino-icon-button-icon-color, theme.$p-5);
   $background-color: var(--ino-icon-button-background-color, transparent);
   $icon-active-color: var(
     --ino-icon-button-icon-active-color,
-    theme.color(primary)
+    theme.$p-5
   );
   $background-active-color: var(
     --ino-icon-button-background-active-color,
-    theme.color(primary)
+    theme.$p-5
   );
 
   ino-icon {
@@ -58,10 +58,10 @@ ino-icon-button {
   }
 
   &.ino-icon-button--filled {
-    --ino-icon-button-icon-color: #{theme.color(primary, contrast)};
-    --ino-icon-button-icon-active-color: #{theme.color(primary, contrast)};
-    --ino-icon-button-background-color: #{theme.color(primary)};
-    --ino-icon-button-background-active-color: #{theme.color(primary, contrast)};
+    --ino-icon-button-icon-color: #{theme.$white};
+    --ino-icon-button-icon-active-color: #{theme.$white};
+    --ino-icon-button-background-color: #{theme.$p-6};
+    --ino-icon-button-background-active-color: #{theme.$white};
   }
 }
 
@@ -70,11 +70,11 @@ ino-icon-button {
 .ino-icon-button--disabled.ino-icon-button-filled {
   --ino-icon-button-background-color: var(
     --ino-icon-button-background-disabled-color,
-    #{theme.color(dark, light)}
+    #{theme.$n-4}
   );
 
   ino-icon {
-    --ino-icon-button-icon-color: #fff;
+    --ino-icon-button-icon-color: #{theme.$white};
   }
 }
 
@@ -82,7 +82,7 @@ ino-icon-button {
   ino-icon {
     --ino-icon-button-icon-color: var(
       --ino-icon-button-icon-disabled-color,
-      #{theme.color(dark, light)}
+      #{theme.$n-4}
     );
   }
 }

--- a/packages/elements/src/components/ino-input/ino-input.scss
+++ b/packages/elements/src/components/ino-input/ino-input.scss
@@ -6,7 +6,7 @@
 @use '@material/floating-label/mdc-floating-label';
 @use '@material/floating-label';
 @use '@material/notched-outline/mdc-notched-outline';
-@use '../base/theme';
+@use '../base/new-theme' as theme;
 @use '../base/typography';
 
 $default-text-field: 'not(.mdc-text-field--outlined):not(.mdc-text-field--textarea)';
@@ -63,10 +63,10 @@ ino-input {
    * @prop --ino-input-icon-color: icon color
    */
   --input-color: var(--ino-input-color, #{textfield.$ink-color});
-  --input-caret-color: var(--ino-input-caret-color, #{theme.color(primary)});
-  --input-label-color: var(--ino-input-label-color, #{theme.color(primary)});
-  --input-line-color: var(--ino-input-line-color, #{theme.color(primary)});
-  --input-icon-color: var(--ino-input-icon-color, #{theme.color(primary)});
+  --input-caret-color: var(--ino-input-caret-color, #{theme.$p-5});
+  --input-label-color: var(--ino-input-label-color, #{theme.$p-5});
+  --input-line-color: var(--ino-input-line-color, #{theme.$p-5});
+  --input-icon-color: var(--ino-input-icon-color, #{theme.$p-5});
 
   display: block;
   @include icon.icon-core-styles;
@@ -107,8 +107,8 @@ ino-input {
   }
 
   .mdc-text-field--invalid {
-    @include textfield.label-color(theme.color(error));
-    @include setIconColors(theme.color(error));
+    @include textfield.label-color(theme.$error);
+    @include setIconColors(theme.$error);
   }
 
   :not(.mdc-text-field--disabled) {
@@ -127,7 +127,7 @@ ino-input .mdc-text-field--filled {
   @include textfield.line-ripple-color(var(--input-line-color));
 
   &.mdc-text-field--invalid {
-    @include textfield.line-ripple-color(theme.color(error));
+    @include textfield.line-ripple-color(theme.$error);
   }
 
   &:not([class*='--with-leading-icon']) {
@@ -189,7 +189,7 @@ ino-input .mdc-text-field--outlined {
   }
 
   &.mdc-text-field--invalid {
-    @include textfield.focused-outline-color(theme.color(error));
+    @include textfield.focused-outline-color(theme.$error);
   }
 
   &[class*='--with-leading-icon']

--- a/packages/elements/src/components/ino-list-divider/ino-list-divider.scss
+++ b/packages/elements/src/components/ino-list-divider/ino-list-divider.scss
@@ -1,8 +1,13 @@
 @use '../base/mdc-customize';
+@use '../base/new-theme' as theme;
 @use '@material/list';
 
 @include list.deprecated-core-styles;
 
 ino-list-divider {
   display: block;
+
+  .mdc-deprecated-list-divider {
+    border-bottom-color: theme.$n-2;
+  }
 }

--- a/packages/elements/src/components/ino-list-item/ino-list-item.scss
+++ b/packages/elements/src/components/ino-list-item/ino-list-item.scss
@@ -38,11 +38,10 @@ ino-list-item {
     #{theme.$p-2}
   );
 
-
   --list-item-deselected-color: var(
-    --ino-list-item-deselected-color, 
-      #{theme.$n-11}
-    );
+    --ino-list-item-deselected-color,
+    #{theme.$n-11}
+  );
   --list-item-deselected-background-color: var(
     --ino-list-item-deselected-background-color,
     #{theme.$transparent}
@@ -130,7 +129,7 @@ ino-list-item {
 
     &:hover {
       background-color: var(--list-item-deselected-background-color-hover);
-    } 
+    }
 
     &:focus {
       background-color: var(--list-item-deselected-background-color-focus);

--- a/packages/elements/src/components/ino-list-item/ino-list-item.scss
+++ b/packages/elements/src/components/ino-list-item/ino-list-item.scss
@@ -1,6 +1,6 @@
 @use '../base/mdc-customize';
 @use '@material/list';
-@use '../base/theme';
+@use '../base/new-theme' as theme;
 
 @include list.deprecated-core-styles;
 
@@ -19,36 +19,45 @@ ino-list-item {
    */
   --list-item-selected-color: var(
     --ino-list-item-selected-color,
-    #{theme.color(primary)}
+    #{theme.$p-5}
   );
   --list-item-selected-background-color: var(
     --ino-list-item-selected-background-color,
-    #{rgba(theme.color(primary, base), 0.05)}
+    #{theme.$p-1}
   );
   --list-item-selected-background-color-hover: var(
     --ino-list-item-selected-background-color-hover,
-    #{rgba(theme.color(primary, base), 0.1)}
+    #{theme.$p-2}
   );
   --list-item-selected-background-color-active: var(
     --ino-list-item-selected-background-color-active,
-    #{rgba(theme.color(primary, base), 0.3)}
+    #{theme.$p-2}
   );
   --list-item-selected-background-color-focus: var(
     --ino-list-item-selected-background-color-focus,
-    #{rgba(theme.color(primary, base), 0.15)}
+    #{theme.$p-2}
   );
-  --list-item-deselected-color: var(--ino-list-item-deselected-color);
+
+
+  --list-item-deselected-color: var(
+    --ino-list-item-deselected-color, 
+      #{theme.$n-11}
+    );
   --list-item-deselected-background-color: var(
-    --ino-list-item-deselected-background-color
+    --ino-list-item-deselected-background-color,
+    #{theme.$transparent}
   );
   --list-item-deselected-background-color-hover: var(
-    --ino-list-item-deselected-background-color-hover
+    --ino-list-item-deselected-background-color-hover,
+    #{theme.$n-1}
   );
   --list-item-deselected-background-color-active: var(
-    --ino-list-item-deselected-background-color-active
+    --ino-list-item-deselected-background-color-active,
+    #{theme.$n-1}
   );
   --list-item-deselected-background-color-focus: var(
-    --ino-list-item-deselected-background-color-focus
+    --ino-list-item-deselected-background-color-focus,
+    #{theme.$n-1}
   );
 }
 
@@ -121,7 +130,7 @@ ino-list-item {
 
     &:hover {
       background-color: var(--list-item-deselected-background-color-hover);
-    }
+    } 
 
     &:focus {
       background-color: var(--list-item-deselected-background-color-focus);

--- a/packages/elements/src/components/ino-markdown-editor/ino-markdown-editor.scss
+++ b/packages/elements/src/components/ino-markdown-editor/ino-markdown-editor.scss
@@ -69,9 +69,10 @@ ino-markdown-editor {
     background-color: transparent;
     font-size: 22px;
 
-    &:hover, &--active {
+    &:hover,
+    &--active {
       --ino-icon-color-primary: #{theme.$p-6};
-      background-color:  theme.$p-2;
+      background-color: theme.$p-2;
       color: theme.$p-6;
       cursor: pointer;
     }

--- a/packages/elements/src/components/ino-markdown-editor/ino-markdown-editor.scss
+++ b/packages/elements/src/components/ino-markdown-editor/ino-markdown-editor.scss
@@ -1,5 +1,4 @@
-@use '../base/theme';
-@use '../base/new-theme' as new_theme;
+@use '../base/new-theme' as theme;
 @use '@material/textfield';
 
 /**
@@ -15,7 +14,7 @@
 }
 
 .ino-dialog-delete ino-icon {
-  --ino-icon-button-icon-color: #{new_theme.$error};
+  --ino-icon-button-icon-color: #{theme.$error};
 }
 
 .ino-dialog-form {
@@ -48,7 +47,7 @@ ino-markdown-editor {
   .markdown-editor__error-text {
     display: block;
     padding: 10px;
-    color: theme.color(error, dark);
+    color: theme.$error;
   }
 
   .markdown-editor__toolbar {
@@ -56,13 +55,13 @@ ino-markdown-editor {
     grid-template-columns: auto auto;
     justify-content: space-between;
     border-radius: $border-radius;
-    background-color: lighten(theme.color(light), 22%);
+    background-color: theme.$n-1;
     padding: 10px 20px;
     margin-bottom: 10px;
   }
 
   .toolbar__action-button {
-    --ino-icon-color-primary: #{theme.color(dark, light)};
+    --ino-icon-color-primary: #{theme.$n-9};
     border: 0;
     margin: 0;
     padding: 1px 2px;
@@ -70,18 +69,15 @@ ino-markdown-editor {
     background-color: transparent;
     font-size: 22px;
 
-    &:hover {
-      --ino-icon-color-primary: #{theme.color(primary, dark)};
-      background-color: rgba(theme.color(primary, dark), 0.1);
-      color: theme.color(primary, dark);
+    &:hover, &--active {
+      --ino-icon-color-primary: #{theme.$p-6};
+      background-color:  theme.$p-2;
+      color: theme.$p-6;
       cursor: pointer;
     }
 
     &--active {
-      --ino-icon-color-primary: #{theme.color(primary, dark)};
-      background-color: rgba(theme.color(primary, dark), 0.1);
-      color: theme.color(primary, dark);
-      box-shadow: inset 0 3px 6px rgba(0, 0, 0, 0.16);
+      box-shadow: inset 0 3px 6px rgba(theme.$p-7, 0.16);
     }
 
     ino-icon {
@@ -125,8 +121,8 @@ ino-markdown-editor {
       height: 100%;
 
       .mdc-text-field--textarea.mdc-text-field--outlined {
-        @include textfield.outline-color(theme.color(light, light));
-        @include textfield.hover-outline-color(theme.color(light, dark));
+        @include textfield.outline-color(theme.$n-2);
+        @include textfield.hover-outline-color(theme.$n-4);
 
         display: flex;
         .mdc-text-field__input {
@@ -150,14 +146,14 @@ ino-markdown-editor {
     min-height: var(--ino-markdown-editor-min-height, 100px);
     padding: 15px;
     border-radius: 4px;
-    border: 1px solid theme.color(light, light);
+    border: 1px solid theme.$n-2;
     color: rgba(0, 0, 0, 0.87);
 
     &:hover:not(&-focused) {
-      border-color: theme.color(light, dark);
+      border-color: theme.$n-4;
     }
     &-focused {
-      outline: theme.color(primary) auto 1px;
+      outline: theme.$p-5 auto 1px;
     }
 
     *:first-child {
@@ -171,7 +167,7 @@ ino-markdown-editor {
 
     blockquote {
       padding-left: 10px;
-      border-left: 3px solid theme.color(light);
+      border-left: 3px solid theme.$n-3;
     }
 
     p {
@@ -181,7 +177,7 @@ ino-markdown-editor {
 
     pre code {
       display: block;
-      background-color: rgba(theme.color(light), $alpha: 0.15);
+      background-color: rgba(theme.$n-3, 0.15);
       white-space: pre;
       -webkit-overflow-scrolling: touch;
       overflow-x: auto;
@@ -215,7 +211,7 @@ ino-markdown-editor {
         }
 
         input[type='checkbox'] {
-          accent-color: theme.color(primary);
+          accent-color: theme.$p-5;
         }
       }
     }

--- a/packages/elements/src/components/ino-nav-drawer/ino-nav-drawer.scss
+++ b/packages/elements/src/components/ino-nav-drawer/ino-nav-drawer.scss
@@ -28,10 +28,7 @@
     171px
   );
   --nav-drawer-height: var(--ino-nav-drawer-height, 100%);
-  --nav-drawer-background: var(
-    --ino-nav-drawer-background,
-    #{theme.$white}
-  );
+  --nav-drawer-background: var(--ino-nav-drawer-background, #{theme.$white});
   --nav-drawer-text-color: var(--ino-nav-drawer-text-color, #{theme.$p-7});
   --nav-drawer-transition-duration: var(
     --ino-nav-drawer-transition-duration,

--- a/packages/elements/src/components/ino-nav-drawer/ino-nav-drawer.scss
+++ b/packages/elements/src/components/ino-nav-drawer/ino-nav-drawer.scss
@@ -2,8 +2,7 @@
 @use '@material/drawer/mdc-drawer';
 @use '@material/drawer';
 @use '@material/list';
-@use '../base/theme' as theme;
-@use '../base/new-theme' as new-theme;
+@use '../base/new-theme' as theme;
 
 @include drawer.core-styles;
 @include drawer.dismissible-core-styles;
@@ -31,9 +30,9 @@
   --nav-drawer-height: var(--ino-nav-drawer-height, 100%);
   --nav-drawer-background: var(
     --ino-nav-drawer-background,
-    #{theme.color(primary, contrast)}
+    #{theme.$white}
   );
-  --nav-drawer-text-color: var(--ino-nav-drawer-text-color, #{new-theme.$p-7});
+  --nav-drawer-text-color: var(--ino-nav-drawer-text-color, #{theme.$p-7});
   --nav-drawer-transition-duration: var(
     --ino-nav-drawer-transition-duration,
     0.25s

--- a/packages/elements/src/components/ino-nav-item/ino-nav-item.scss
+++ b/packages/elements/src/components/ino-nav-item/ino-nav-item.scss
@@ -1,6 +1,6 @@
 @use '../base/mdc-customize';
 @use '@material/list/mdc-list';
-@use '../base/theme';
+@use '../base/new-theme' as theme;
 @use '../base/typography-new' as typography;
 
 ino-nav-item {
@@ -11,15 +11,15 @@ ino-nav-item {
    * @prop --ino-nav-item-background-color-active: Active color of the background of one item.
    */
 
-  --nav-item-color: var(--ino-nav-item-color, #{theme.color(dark, dark)});
+  --nav-item-color: var(--ino-nav-item-color, #{theme.$n-11});
   --nav-item-color-active: var(
     --ino-nav-item-color-active,
-    #{theme.color(primary, base)}
+    #{theme.$p-5}
   );
-  --nav-item-background-color: var(--ino-nav-item-background-color, white);
+  --nav-item-background-color: var(--ino-nav-item-background-color, theme.$white);
   --nav-item-background-color-active: var(
     --ino-nav-item-background-color-active,
-    #{rgba(theme.color(light, contrast), 0.04)}
+    #{theme.$n-2}
   );
 
   .mdc-deprecated-list-item,

--- a/packages/elements/src/components/ino-nav-item/ino-nav-item.scss
+++ b/packages/elements/src/components/ino-nav-item/ino-nav-item.scss
@@ -12,11 +12,11 @@ ino-nav-item {
    */
 
   --nav-item-color: var(--ino-nav-item-color, #{theme.$n-11});
-  --nav-item-color-active: var(
-    --ino-nav-item-color-active,
-    #{theme.$p-5}
+  --nav-item-color-active: var(--ino-nav-item-color-active, #{theme.$p-5});
+  --nav-item-background-color: var(
+    --ino-nav-item-background-color,
+    theme.$white
   );
-  --nav-item-background-color: var(--ino-nav-item-background-color, theme.$white);
   --nav-item-background-color-active: var(
     --ino-nav-item-background-color-active,
     #{theme.$n-2}

--- a/packages/elements/src/components/ino-progress-bar/ino-progress-bar.scss
+++ b/packages/elements/src/components/ino-progress-bar/ino-progress-bar.scss
@@ -1,14 +1,16 @@
 @use '../base/mdc-customize';
 @use '@material/linear-progress/mdc-linear-progress';
 @use '@material/linear-progress';
-@use '../base/theme';
+@use '../base/new-theme' as theme;
 
 :host {
   /**
    * @prop --progress-bar--bar-color: Color of the progress bar
    */
-  --progress-bar--bar-color: #{theme.color(primary)};
+  --progress-bar--bar-color: #{theme.$p-5};
 
   @include linear-progress.core-styles;
   @include linear-progress.bar-color(var(--progress-bar--bar-color));
+  @include linear-progress.buffer-color(theme.$n-2);
+
 }

--- a/packages/elements/src/components/ino-progress-bar/ino-progress-bar.scss
+++ b/packages/elements/src/components/ino-progress-bar/ino-progress-bar.scss
@@ -12,5 +12,4 @@
   @include linear-progress.core-styles;
   @include linear-progress.bar-color(var(--progress-bar--bar-color));
   @include linear-progress.buffer-color(theme.$n-2);
-
 }

--- a/packages/elements/src/components/ino-range/ino-range.scss
+++ b/packages/elements/src/components/ino-range/ino-range.scss
@@ -10,9 +10,9 @@ $range_hover-control_hover: #4b4eff;
 
 ino-range {
   .mdc-slider {
-    @include slider-mixins.track-active-color(theme.$primary);
+    @include slider-mixins.track-active-color(theme.$p-5);
     @include slider-mixins.track-inactive-color(theme.$n-6);
-    @include slider-mixins.thumb-color(theme.$primary);
+    @include slider-mixins.thumb-color(theme.$p-5);
     @include slider-mixins.thumb-ripple-color(theme.$transparent);
     @include slider-mixins.tick-mark-inactive-color(theme.$black);
     @include slider-mixins.value-indicator-text-color(theme.$white);

--- a/packages/elements/src/components/ino-segment-button/ino-segment-button.scss
+++ b/packages/elements/src/components/ino-segment-button/ino-segment-button.scss
@@ -11,9 +11,9 @@ $round-border: 24px 24px 24px 24px;
 $edged-border: 24px 0 24px 24px;
 
 /* Colors: */
-$button_outlined_text_pressed: #d7e0ff;
-$button_outlined_text_hover: #e8edff;
-$text-active: #3b14f9;
+$button_pressed-bg: theme.$p-3;
+$button-active-bg: theme.$p-2;
+$text-active:  theme.$p-5;
 
 ino-segment-button {
   .button {
@@ -60,12 +60,12 @@ ino-segment-button {
     &:active {
       box-shadow: none;
       color: $text-active;
-      background-color: $button_outlined_text_pressed;
+      background-color: $button_pressed-bg;
     }
 
     &--active {
       color: $text-active;
-      background-color: $button_outlined_text_hover;
+      background-color: $button-active-bg;
     }
 
     &:disabled {

--- a/packages/elements/src/components/ino-segment-button/ino-segment-button.scss
+++ b/packages/elements/src/components/ino-segment-button/ino-segment-button.scss
@@ -13,7 +13,7 @@ $edged-border: 24px 0 24px 24px;
 /* Colors: */
 $button_pressed-bg: theme.$p-3;
 $button-active-bg: theme.$p-2;
-$text-active:  theme.$p-5;
+$text-active: theme.$p-5;
 
 ino-segment-button {
   .button {

--- a/packages/elements/src/components/ino-select/ino-select.scss
+++ b/packages/elements/src/components/ino-select/ino-select.scss
@@ -4,7 +4,7 @@
 @use '@material/menu/mdc-menu';
 @use '@material/select/mdc-select';
 @use '@material/select';
-@use '../base/theme';
+@use '../base/new-theme' as theme;
 @use '../ino-label/ino-label';
 
 @include list.deprecated-core-styles;
@@ -12,6 +12,8 @@
 $not-outlined-select: 'not(.mdc-select--outlined)';
 $placeholder-color: rgba(0, 0, 0, 0.6);
 $border-radius: 0.7rem;
+
+$icon-drop-down-size: 24px;
 
 @mixin setIconColors($color) {
   .mdc-select__icon {
@@ -28,7 +30,7 @@ ino-select {
   * @prop --ino-border-radius: Border-radius of the open select menu
   */
   --select-height: auto;
-  --select-icon-color: var(--ino-select-icon-color, #{theme.color(primary)});
+  --select-icon-color: var(--ino-select-icon-color, #{theme.$p-5});
   --border-radius: var(var(--ino-border-radius), $border-radius);
 
   display: block;
@@ -64,24 +66,24 @@ ino-select {
     @include setIconColors(var(--select-icon-color));
 
     .mdc-select__anchor {
-      @include select.dropdown-icon-color(theme.color(primary));
+      @include select.dropdown-icon-color(theme.$p-5);
     }
   }
 
   .mdc-select {
     @include select.label-color(
       (
-        focus: theme.color(primary),
+        focus: theme.$p-5,
       )
     );
     @include select.bottom-line-color(
       (
-        focus: theme.color(primary),
+        focus: theme.$p-5,
       )
     );
     @include select.outline-color(
       (
-        focus: theme.color(primary),
+        focus: theme.$p-5,
       )
     );
     @include select.container-fill-color(
@@ -96,12 +98,12 @@ ino-select {
     }
 
     .mdc-select__dropdown-icon {
-      width: 24px;
-      height: 24px;
+      width: $icon-drop-down-size;
+      height: $icon-drop-down-size;
 
       ino-icon {
-        --icon-width: 24px;
-        --icon-height: 24px;
+        --icon-width: $icon-drop-down-size;
+        --icon-height: $icon-drop-down-size;
       }
     }
 
@@ -155,7 +157,7 @@ ino-select {
 
   // make sure the border-color is the default if focused and invalid
   .mdc-select.mdc-select--outlined.mdc-select--invalid.mdc-select--focused {
-    @include ino-label.outline-border-color(theme.color(primary));
+    @include ino-label.outline-border-color(theme.$p-5);
   }
 
   .mdc-select--outlined {

--- a/packages/elements/src/components/ino-snackbar/ino-snackbar.scss
+++ b/packages/elements/src/components/ino-snackbar/ino-snackbar.scss
@@ -2,23 +2,23 @@
 @use '../base/mdc-customize';
 @use '@material/snackbar/mdc-snackbar';
 @use '../base/typography';
-@use '../base/theme';
+@use '../base/new-theme' as theme;
 @use '../base/animation';
 
 $snackbar-types: 'info', 'error', 'success';
 
 $snackbar-color-map-by-type: (
   info: (
-    color: theme.color(primary),
-    color-light: theme.color(primary, light),
+    color: #{theme.$p-5},
+    color-light: #{theme.$p-2},
   ),
   error: (
-    color: theme.color(error),
-    color-light: theme.color(error, light),
+    color: #{theme.$error},
+    color-light: #{theme.$error-light},
   ),
   success: (
-    color: theme.color(success),
-    color-light: theme.color(success, light),
+    color: #{theme.$success},
+    color-light: #{theme.$success-light},
   ),
 );
 
@@ -63,10 +63,7 @@ ino-snackbar {
   @each $type in $snackbar-types {
     &.ino-snackbar--type-#{$type} {
       --snackbar-color: #{color($type, color)};
-      --snackbar-color-light: #{sass-color.adjust(
-          color($type, color-light),
-          $lightness: 30%
-        )}; // FIXME use light color of new color pallet
+      --snackbar-color-light: #{color($type, color-light)}; 
     }
   }
 

--- a/packages/elements/src/components/ino-snackbar/ino-snackbar.scss
+++ b/packages/elements/src/components/ino-snackbar/ino-snackbar.scss
@@ -63,7 +63,7 @@ ino-snackbar {
   @each $type in $snackbar-types {
     &.ino-snackbar--type-#{$type} {
       --snackbar-color: #{color($type, color)};
-      --snackbar-color-light: #{color($type, color-light)}; 
+      --snackbar-color-light: #{color($type, color-light)};
     }
   }
 

--- a/packages/elements/src/components/ino-spinner/ino-spinner.scss
+++ b/packages/elements/src/components/ino-spinner/ino-spinner.scss
@@ -1,4 +1,4 @@
-@use '../base/theme';
+@use '../base/new-theme' as theme;
 
 // Import the different spinner styles
 @use './mixins/bounce';
@@ -30,7 +30,7 @@ ino-spinner {
     position: relative;
   }
 
-  @include set-spinner-color(theme.color(primary));
+  @include set-spinner-color(theme.$p-5);
 
   // Modal
   &.ino-spinner--modal {
@@ -41,7 +41,7 @@ ino-spinner {
     width: 100%;
     height: 100%;
 
-    background: rgba(255, 255, 255, 0.95);
+    background: rgba(theme.$white, 0.95);
 
     .ino-spinner__composer {
       top: 50%;

--- a/packages/elements/src/components/ino-tab/ino-tab.scss
+++ b/packages/elements/src/components/ino-tab/ino-tab.scss
@@ -6,7 +6,6 @@
 @use '../base/new-theme' as theme;
 @use '../base/typography';
 
-
 ino-tab {
   .mdc-tab {
     @include typography.font(sans-serif, s, regular);
@@ -18,7 +17,13 @@ ino-tab {
     @include ripple.surface;
     @include ripple.radius-bounded;
     @include ripple.states-base-color(theme.$p-2);
-    @include ripple.states-opacities((hover: .5, focus: 0.8, press: 0.8));
+    @include ripple.states-opacities(
+      (
+        hover: 0.5,
+        focus: 0.8,
+        press: 0.8,
+      )
+    );
     overflow: hidden;
 
     ino-icon {

--- a/packages/elements/src/components/ino-tab/ino-tab.scss
+++ b/packages/elements/src/components/ino-tab/ino-tab.scss
@@ -2,26 +2,35 @@
 @use '@material/tab/mdc-tab';
 @use '@material/tab';
 @use '@material/tab-indicator/mdc-tab-indicator';
-@use '../base/theme';
+@use '@material/ripple';
+@use '../base/new-theme' as theme;
 @use '../base/typography';
+
 
 ino-tab {
   .mdc-tab {
     @include typography.font(sans-serif, s, regular);
-    @include tab.active-text-label-color(theme.color(primary));
-    @include tab.active-states-color(theme.color(primary));
-    @include tab.states-color(theme.color(primary));
+    @include tab.active-text-label-color(theme.$p-5);
+    @include tab.active-states-color(theme.$transparent);
+    @include tab.states-color(theme.$transparent);
+
+    // new ripple because a lower opacity on theme.$p-5 as base color looks to violet
+    @include ripple.surface;
+    @include ripple.radius-bounded;
+    @include ripple.states-base-color(theme.$p-2);
+    @include ripple.states-opacities((hover: .5, focus: 0.8, press: 0.8));
+    overflow: hidden;
 
     ino-icon {
-      --icon-color: buttontext;
+      --icon-color: #{theme.$p-5};
     }
 
     &.mdc-tab--active ino-icon {
-      --icon-color: #{theme.color(primary)};
+      --icon-color: #{theme.$p-5};
     }
 
     .mdc-tab-indicator__content--underline {
-      border-color: theme.color(primary);
+      border-color: theme.$p-5;
     }
   }
 

--- a/packages/elements/src/components/ino-table-header-cell/ino-table-header-cell.scss
+++ b/packages/elements/src/components/ino-table-header-cell/ino-table-header-cell.scss
@@ -96,7 +96,7 @@ ino-table ino-table-header-cell {
 
     .ino-table-header-cell__popover-content {
       border-radius: inherit;
-      box-shadow: 0px 25px 50px -12px theme.$primary-focus; 
+      box-shadow: 0px 25px 50px -12px theme.$primary-focus;
     }
   }
   &.ino-table-header-cell--searched {

--- a/packages/elements/src/components/ino-table-header-cell/ino-table-header-cell.scss
+++ b/packages/elements/src/components/ino-table-header-cell/ino-table-header-cell.scss
@@ -1,5 +1,5 @@
 @use '../base/mdc-customize';
-@use '../base/theme';
+@use '../base/new-theme' as theme;
 @use '../base/typography';
 @use '@material/data-table';
 
@@ -17,12 +17,15 @@ ino-table ino-table-header-cell {
 
   &.mdc-data-table__header-cell {
     padding: 2px 0 4px 0;
+    border-bottom: 2px solid theme.$n-3;
+    color: theme.$n-4;
   }
 
   .mdc-data-table__header-cell-wrapper {
     padding: 0 10px;
     height: 100%;
     border-radius: 10px;
+    border-color: theme.$n-2;
     outline: 0;
     margin-right: $margin-right;
   }
@@ -78,8 +81,8 @@ ino-table ino-table-header-cell {
     &:focus-within,
     &.ino-table-header-cell--active {
       .mdc-data-table__header-cell-wrapper {
-        color: theme.color(primary);
-        background: rgba(theme.color(light), 0.32);
+        color: theme.$p-5;
+        background: theme.$n-2;
       }
       .ino-table-header-cell__search-icon {
         display: block;
@@ -93,11 +96,11 @@ ino-table ino-table-header-cell {
 
     .ino-table-header-cell__popover-content {
       border-radius: inherit;
-      box-shadow: 0px 25px 50px -12px rgba(#1e2125, 0.25); // TODO move color
+      box-shadow: 0px 25px 50px -12px theme.$primary-focus; 
     }
   }
   &.ino-table-header-cell--searched {
-    border-bottom-color: theme.color(primary);
+    border-bottom-color: theme.$p-5;
   }
 
   // TODO: Add proper icons for all directions

--- a/packages/elements/src/components/ino-table/_table-row.scss
+++ b/packages/elements/src/components/ino-table/_table-row.scss
@@ -1,8 +1,8 @@
-@use '../base/theme';
+@use '../base/new-theme' as theme;
 
-$row-active-color: theme.color(secondary);
-$row-hover-border-color: #d4ddea; // TODO: Move color
-$row-alt-background-color: #f6f8fb; // TODO: Move color
+$row-active-color: #{theme.$success};
+$row-hover-border-color: #{theme.$n-3};
+$row-alt-background-color: #{theme.$n-1};
 $row-alt-hover-background-color: $row-alt-background-color;
 
 @mixin core-styles() {
@@ -28,7 +28,7 @@ $row-alt-hover-background-color: $row-alt-background-color;
     th,
     th:first-child,
     th:last-child {
-      border-color: rgba($row-active-color, 0.64);
+      border-color: $row-active-color;
     }
 
     &:hover {

--- a/packages/elements/src/components/ino-table/ino-table.scss
+++ b/packages/elements/src/components/ino-table/ino-table.scss
@@ -1,5 +1,4 @@
 @use '../base/mdc-customize';
-@use '../base/theme';
 @use '@material/data-table/data-table';
 
 @use './table-row';

--- a/packages/elements/src/components/ino-textarea/ino-textarea.scss
+++ b/packages/elements/src/components/ino-textarea/ino-textarea.scss
@@ -10,18 +10,9 @@ ino-textarea {
    * @prop --ino-textarea-caret-color: color of the caret
    * @prop --ino-textarea-label-color: color of the label
    */
-  --textarea-outline-color: var(
-    --ino-textarea-outline-color,
-    #{theme.$p-5}
-  );
-  --textarea-caret-color: var(
-    --ino-textarea-caret-color,
-    #{theme.$p-5}
-  );
-  --textarea-label-color: var(
-    --ino-textarea-label-color,
-    #{theme.$p-5}
-  );
+  --textarea-outline-color: var(--ino-textarea-outline-color, #{theme.$p-5});
+  --textarea-caret-color: var(--ino-textarea-caret-color, #{theme.$p-5});
+  --textarea-label-color: var(--ino-textarea-label-color, #{theme.$p-5});
 }
 
 ino-textarea {

--- a/packages/elements/src/components/ino-textarea/ino-textarea.scss
+++ b/packages/elements/src/components/ino-textarea/ino-textarea.scss
@@ -2,7 +2,7 @@
 @use '@material/textfield/mdc-text-field';
 @use '@material/floating-label/mdc-floating-label';
 @use '@material/textfield';
-@use '../base/theme';
+@use '../base/new-theme' as theme;
 
 ino-textarea {
   /**
@@ -12,15 +12,15 @@ ino-textarea {
    */
   --textarea-outline-color: var(
     --ino-textarea-outline-color,
-    #{theme.color(primary)}
+    #{theme.$p-5}
   );
   --textarea-caret-color: var(
     --ino-textarea-caret-color,
-    #{theme.color(primary)}
+    #{theme.$p-5}
   );
   --textarea-label-color: var(
     --ino-textarea-label-color,
-    #{theme.color(primary)}
+    #{theme.$p-5}
   );
 }
 


### PR DESCRIPTION
Closes #859 

## Proposed Changes

- use new color scheme in the following components
ino-autocomplete
 ino-currency-input
 ino-datepicker
 ino-input
 ino-markdown-editor
 ino-option-group
 ino-option
 ino-range
 ino-select
 ino-textarea
 ino-chip
 ino-fab-set
 ino-icon-button
 ino-segment-button
 ino-segment-group
 ino-control-item
 ino-list-divider
 ino-list-item
 ino-list
 ino-menu
 ino-nav-drawer
 ino-nav-item
 ino-tab-bar
 ino-tab
 ino-table-header-cell
 ino-table
 ino-progress-bar
 ino-nackbar
 ino-spinner
 ino-tooltip
