### PR TITLE
fix(elements): override tailwind css preflight border-styles

### DIFF
--- a/packages/elements/src/components/ino-input/ino-input.scss
+++ b/packages/elements/src/components/ino-input/ino-input.scss
@@ -9,6 +9,11 @@
 @use '../base/new-theme' as theme;
 @use '../base/typography';
 
+// Tailwind CSS Preflight border-style countermeasures (https://tailwindcss.com/docs/preflight#border-styles-are-reset-globally)
+ino-input * {
+  border-style: none;
+}
+
 $default-text-field: 'not(.mdc-text-field--outlined):not(.mdc-text-field--textarea)';
 $placeholder-color: rgba(0, 0, 0, 0.6);
 $padding-top: 24px;
@@ -173,6 +178,8 @@ ino-input .mdc-text-field--outlined {
   @include textfield.focused-outline-color(var(--input-line-color));
   @include textfield.outline-shape-radius(20px);
   @include textfield.outlined-height($outline-input-height);
+
+  border-style: none !important;
 
   // style outline with corner for helpertext
   &.mdc-text-field--has-helpertext.mdc-text-field--focused,

--- a/packages/elements/src/components/ino-select/ino-select.scss
+++ b/packages/elements/src/components/ino-select/ino-select.scss
@@ -7,6 +7,11 @@
 @use '../base/new-theme' as theme;
 @use '../ino-label/ino-label';
 
+// Tailwind CSS Preflight border-style countermeasures (https://tailwindcss.com/docs/preflight#border-styles-are-reset-globally)
+ino-select * {
+  border-style: none;
+}
+
 @include list.deprecated-core-styles;
 
 $not-outlined-select: 'not(.mdc-select--outlined)';


### PR DESCRIPTION
Closes #1037 

Instead of disabling tailwinds preflight styles we can override it with our own custom css like so:

`ino-select * {
  border-style: none;
}
`

more about this here: https://tailwindcss.com/docs/preflight#border-styles-are-reset-globally

Preview(before and after the changes):

https://github.com/inovex/elements/assets/81302108/6c9223ce-9893-43f5-a53d-a299c2d63db3


