### PR TITLE
feat(elements|ino-snackbar): improve a11y

### DIFF
--- a/packages/elements/src/components/ino-snackbar/ino-snackbar.tsx
+++ b/packages/elements/src/components/ino-snackbar/ino-snackbar.tsx
@@ -153,6 +153,7 @@ export class Snackbar implements ComponentInterface {
           class={snackbarClasses}
           aria-live="assertive"
           aria-atomic="true"
+          role="alert"
         >
           <div class="mdc-snackbar__surface ino-snackbar-container">
             <div class="mdc-snackbar__actions ino-snackbar-icon-container">


### PR DESCRIPTION
Closes #994 

- improved a11y of the snackbar component by adding the role "alert" to the outer container
