### PR TITLE
ci: fix calculation of release version

### DIFF
--- a/.github/workflows/deploy-prerelease.yml
+++ b/.github/workflows/deploy-prerelease.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - master
+    tags-ignore:
+      - v*
     paths:
       - packages/elements/**
       - packages/elements-angular/**
@@ -11,17 +13,24 @@ on:
       - packages/elements-vue/**
 
 jobs:
-  canary-release:
+  check-commit:
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/master'
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check if commit has tag
+        run: git describe --exact-match HEAD
+  prerelease:
+    runs-on: ubuntu-latest
+    needs:
+      - check-commit
+    if: ${{ failure() && github.ref == 'refs/heads/master' }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Track master branch to make nx affected work
-        run: |
-          git branch --track main origin/master
+        run: git branch --track main origin/master
       - uses: actions/setup-node@v3
         with:
           node-version-file: '.nvmrc'

--- a/.github/workflows/deploy-prerelease.yml
+++ b/.github/workflows/deploy-prerelease.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Check if commit has tag
+      - name: Ensure that that prerelease not executed for releases with tags
         run: git describe --exact-match HEAD
   prerelease:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy-storybook.yml
+++ b/.github/workflows/deploy-storybook.yml
@@ -8,9 +8,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/master'
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ./.github/workflows/dependencies-install
       - run: npm config set scripts-prepend-node-path true
       - name: Build Storybook
@@ -25,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout pages branch
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: pages
       - name: Download Storybook artifact

--- a/nx.json
+++ b/nx.json
@@ -50,7 +50,7 @@
       "ui-patterns-playground"
     ],
     "git": {
-      "commitMessage": "chore: publish {version}"
+      "commitMessage": "chore: publish {version} [no ci]"
     },
     "changelog": {
       "projectChangelogs": false,

--- a/nx.json
+++ b/nx.json
@@ -50,7 +50,7 @@
       "ui-patterns-playground"
     ],
     "git": {
-      "commitMessage": "chore: publish {version} [no ci]"
+      "commitMessage": "chore: publish {version}"
     },
     "changelog": {
       "projectChangelogs": false,

--- a/nx.json
+++ b/nx.json
@@ -37,6 +37,7 @@
   "cacheDirectory": ".nx-cache",
   "release": {
     "projects": [
+      "workspace",
       "elements",
       "elements-angular",
       "elements-react",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "core",
-  "version": "9.0.0",
+  "version": "9.0.1",
   "private": true,
   "description": "This is a Monorepo root package which is used to execute build scripts.",
   "engines": {

--- a/scripts/publish.ts
+++ b/scripts/publish.ts
@@ -39,14 +39,14 @@ function getNxVersionCmd(
   dryRun?: boolean,
   createTag?: boolean,
   stageChanges?: boolean,
+  usePreid?: boolean,
 ) {
   const base = ['nx release version', version, '--git-commit=false'];
 
   if (dryRun) base.push('--dry-run');
-
   if (createTag) base.push('--git-tag');
-
   if (stageChanges) base.push('--stage-changes');
+  if (usePreid) base.push('--preid next');
 
   return base.join(' ');
 }
@@ -91,6 +91,7 @@ async function getLatestReleaseCommitSha(): Promise<string> {
 async function getNextVersion(): Promise<string> {
   const { releaseType } = await conventionalRecommendedBump({
     preset: 'angular',
+    skipUnstable: true,
   });
   if (!releaseType) {
     echo(getIcon(0), 'ReleaseType could not be determine');
@@ -174,7 +175,7 @@ function checkGithubToken() {
 
   if (isPreRelease) {
     echo(`Running Pre-Release (Dry run: ${getIcon(isDryRun)})`);
-    if (run(getNxVersionCmd('prerelease', isDryRun, true)) !== 0) {
+    if (run(getNxVersionCmd('prerelease', isDryRun, true, false, true)) !== 0) {
       echo(getIcon(0), 'nx release version prerelease failed! ', getIcon(0));
       exit(1);
     }

--- a/scripts/publish.ts
+++ b/scripts/publish.ts
@@ -161,7 +161,7 @@ function checkGithubToken() {
       getIcon(0),
       'You need to login into NPM with the respective permissions if publishing to registry fails',
     );
-    exit(1);
+    if (!isDryRun) exit(1);
   }
 
   if (!isPreRelease && !hasGitHubToken) {
@@ -170,7 +170,7 @@ function checkGithubToken() {
       getIcon(),
       'You need to install the github cli locally and login via gh auth login!',
     );
-    exit(1);
+    if (!isDryRun) exit(1);
   }
 
   if (isPreRelease) {


### PR DESCRIPTION
Closes #1196 

## Proposed Changes

- use `preid` flag for prereleases
- skip unstable versions for calculating new release version
- skip prerelease workflow when normal release was executed

<!--
## Things to check

- [ ] Does the change need to be documented?
- [ ] Does any existing example code needs to be updated?
- [ ] Is the change properly tested?
- [ ] Is it helpful to provide another example to demonstrate the new feature?
- [ ] Are there other code lines that need to be modified?
-->
