### PR TITLE
ci: use only npm libraries for next version calculation

### DIFF
--- a/.github/workflows/deploy-prerelease.yml
+++ b/.github/workflows/deploy-prerelease.yml
@@ -13,17 +13,20 @@ on:
       - packages/elements-vue/**
 
 jobs:
-  check-commit:
+  check:
     runs-on: ubuntu-latest
+    outputs:
+      hasTag: ${{ steps.checkForTag.outputs.hasTag }}
     steps:
       - uses: actions/checkout@v4
-      - name: Ensure that that prerelease not executed for releases with tags
-        run: git describe --exact-match HEAD
+      - id: checkForTag
+        name: Ensure that that prerelease not executed for releases with tags
+        run: git describe --exact-match HEAD || echo "hasTag=false" >> "$GITHUB_OUTPUT"
   prerelease:
     runs-on: ubuntu-latest
     needs:
-      - check-commit
-    if: ${{ failure() && github.ref == 'refs/heads/master' }}
+      - check
+    if: ${{ needs.check.outputs.hasTag == 'false' && github.ref == 'refs/heads/master' }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/scripts/publish.ts
+++ b/scripts/publish.ts
@@ -181,7 +181,7 @@ function checkGithubToken() {
       createTag: true,
       usePreid: true,
     });
-    echo('Run command: ' + versionCmd);
+
     echo(`Running Pre-Release (Dry run: ${getIcon(isDryRun)})`);
     if (run(versionCmd) !== 0) {
       echo(getIcon(0), 'nx release version prerelease failed! ', getIcon(0));

--- a/scripts/publish.ts
+++ b/scripts/publish.ts
@@ -1,7 +1,7 @@
 const { echo, exec, exit } = require('shelljs');
 const conventionalRecommendedBump = require('conventional-recommended-bump');
 const semver = require('semver');
-const { version } = require('../package.json');
+const { version: workspaceVersion } = require('../package.json');
 
 /**
  * constants
@@ -99,7 +99,7 @@ async function getNextVersion(): Promise<string> {
     exit(1);
   }
 
-  const nextVersion = semver.inc(version, releaseType!);
+  const nextVersion = semver.inc(workspaceVersion, releaseType!);
   if (nextVersion === null) {
     echo(getIcon(0), 'Next version could not be calculated!');
     exit(1);

--- a/scripts/publish.ts
+++ b/scripts/publish.ts
@@ -7,10 +7,10 @@ const { version } = require('../package.json');
  * constants
  */
 const PACKAGES_TO_PUBLISH = [
-  'elements',
-  'elements-angular',
-  'elements-react',
-  'elements-vue',
+  'packages/elements',
+  'packages/elements-angular',
+  'packages/elements-react',
+  'packages/elements-vue',
 ];
 
 const isDryRun = process.argv.some((a) => a.includes('dryRun=true'));
@@ -91,6 +91,7 @@ async function getLatestReleaseCommitSha(): Promise<string> {
 async function getNextVersion(): Promise<string> {
   const { releaseType } = await conventionalRecommendedBump({
     preset: 'angular',
+    path: PACKAGES_TO_PUBLISH,
     skipUnstable: true,
   });
   if (!releaseType) {
@@ -110,7 +111,7 @@ async function getNextVersion(): Promise<string> {
 
 function runNpmPublish(npmPackage: string, npmTag: string, isDryRun: boolean) {
   const dryRunArg = isDryRun ? '--dry-run' : '';
-  const publishCmd = `npm publish -w packages/${npmPackage} --tag ${npmTag} ${dryRunArg}`;
+  const publishCmd = `npm publish -w ${npmPackage} --tag ${npmTag} ${dryRunArg}`;
 
   if (exec(publishCmd).code === 0) {
     echo(`@inovex.de/${npmPackage} ${getIcon(1)}\n`);

--- a/scripts/publish.ts
+++ b/scripts/publish.ts
@@ -41,7 +41,7 @@ function getNxVersionCmd(options: {
   stageChanges?: boolean;
   usePreid?: boolean;
 }) {
-  const base = ['nx release version', version, '--git-commit=false'];
+  const base = ['nx release version', options.version, '--git-commit=false'];
 
   if (options.dryRun) base.push('--dry-run');
   if (options.createTag) base.push('--git-tag');
@@ -181,7 +181,7 @@ function checkGithubToken() {
       createTag: true,
       usePreid: true,
     });
-
+    echo('Run command: ' + versionCmd);
     echo(`Running Pre-Release (Dry run: ${getIcon(isDryRun)})`);
     if (run(versionCmd) !== 0) {
       echo(getIcon(0), 'nx release version prerelease failed! ', getIcon(0));


### PR DESCRIPTION
Closes #1197 

## Proposed Changes

- provide code paths 
- exit gracefully in check tag step in prerelease workflow

A workspace changelog only with changes that relates to the npm libraries is currently not possible. By creating a project-based changelog this is possible.

<!--
## Things to check

- [ ] Does the change need to be documented?
- [ ] Does any existing example code needs to be updated?
- [ ] Is the change properly tested?
- [ ] Is it helpful to provide another example to demonstrate the new feature?
- [ ] Are there other code lines that need to be modified?
-->
