### PR TITLE
fix(elements-angular): directives matching on multiple components

### DIFF
--- a/packages/elements-angular/src/directives/control-value-accesors/fs-value-accessor.directive.ts
+++ b/packages/elements-angular/src/directives/control-value-accesors/fs-value-accessor.directive.ts
@@ -4,7 +4,7 @@ import { NG_VALUE_ACCESSOR } from '@angular/forms';
 import { ValueAccessorDirective } from './value-accessor.directive';
 
 @Directive({
-  selector: 'ino-input-file,input[type=file]',
+  selector: 'ino-input-file,ino-input[type=file]',
   providers: [
     {
       provide: NG_VALUE_ACCESSOR,

--- a/packages/elements-angular/src/directives/control-value-accesors/text-value-accessor.directive.ts
+++ b/packages/elements-angular/src/directives/control-value-accesors/text-value-accessor.directive.ts
@@ -5,7 +5,7 @@ import { ValueAccessorDirective } from './value-accessor.directive';
 
 @Directive({
   selector:
-    'ino-autocomplete,ino-currency-input,ino-input,ino-markdown-editor,ino-textarea,ino-range,ino-select,ino-datepicker,ino-segment-group',
+    'ino-autocomplete,ino-currency-input,ino-input:not([type=number]):not([type=file]),ino-markdown-editor,ino-textarea,ino-select,ino-datepicker,ino-segment-group',
   providers: [
     {
       provide: NG_VALUE_ACCESSOR,


### PR DESCRIPTION
Closes #1213 

- We reworked our directives in #865 
- This lead to directives matching for multiple components, e.g. the example below was matched by our `NumericValueAccessorDirective` as well as `TextValueAccessorDirective` which led to runtime errors.
```html
<ino-input [formControl]="myFormControl" type="number"></ino-input>
```
