### PR TITLE
fix(storybook): restore typography page

### DIFF
--- a/packages/storybook/src/stories/docs/styleguide/styles.scss
+++ b/packages/storybook/src/stories/docs/styleguide/styles.scss
@@ -45,9 +45,7 @@ html {
 .typo-box {
   display: flex;
   gap: 100px;
-
-  p {
-  }
+  padding-top: 2rem;
 
   h2 {
     border-bottom: unset; // reset storybook styles

--- a/packages/storybook/src/stories/docs/styleguide/typography.stories.mdx
+++ b/packages/storybook/src/stories/docs/styleguide/typography.stories.mdx
@@ -1,3 +1,4 @@
+import './styles.scss'
 import {Meta} from "@storybook/addon-docs";
 
 <Meta title={'Docs/Styleguide/Typography'}/>
@@ -7,103 +8,59 @@ import {Meta} from "@storybook/addon-docs";
 <div class="typo-box">
   <div class="typo-description">
     <p class="title-l">Display</p>
-    <p class="body-s">
-      Short, important text or numerals; work best on Large Screens; (optional: choosing a more expressive font e.g.
-      handwritten - script style)
-    </p>
+    <p class="body-s">Short, important text or numerals; work best on Large Screens; (optional: choosing a more expressive font e.g. handwritten - script style)</p>
   </div>
   <div>
-    <h1 class="display no-top-margin">
-      D1 Display Large
-    </h1>
-    <h2 class="display">
-      D2 Display Medium
-    </h2>
-    <h3 class="display">
-      D3 Display Small
-    </h3>
+    <h1 class="display no-top-margin">D1 Display Large</h1>
+    <h2 class="display">D2 Display Medium</h2>
+    <h3 class="display">D3 Display Small</h3>
   </div>
 </div>
 
 <div class="typo-box">
   <div class="typo-description">
     <p class="title-l">Headlines</p>
-    <p class="body-s">
-      Short, high-emphasis text on smaller screens, important regions of content; (optional: can also use an expressive
-      typeface)
-    </p>
+    <p class="body-s">Short, high-emphasis text on smaller screens, important regions of content; (optional: can also use an expressive typeface)</p>
   </div>
   <div>
-    <h1 class="no-top-margin">
-      H1 Headline Large
-    </h1>
-    <h2>
-      H2 Headline Medium
-    </h2>
-    <h3>
-      H3 Headline Small
-    </h3>
+    <h1 class="no-top-margin">H1 Headline Large</h1>
+    <h2>H2 Headline Medium</h2>
+    <h3>H3 Headline Small</h3>
   </div>
 </div>
 
 <div class="typo-box">
   <div class="typo-description">
     <p class="title-l no-top-margin">Titles</p>
-    <p class="body-s">
-      Smaller than Headlines - Usage for medium-emphasis, short text; divide secondary passages of text or secondary
-      content
-    </p>
+    <p class="body-s">Smaller than Headlines - Usage for medium-emphasis, short text; divide secondary passages of text or secondary content</p>
   </div>
   <div>
-    <h4 class="no-top-margin">
-      H4 Title Large
-    </h4>
-    <h5>
-      H5 Title Medium
-    </h5>
-    <h6>
-      H6 Title Small
-    </h6>
+    <h4 class="no-top-margin">H4 Title Large</h4>
+    <h5>H5 Title Medium</h5>
+    <h6>H6 Title Small</h6>
   </div>
 </div>
 
 <div class="typo-box">
   <div class="typo-description">
     <p class="title-l no-top-margin">Labels</p>
-    <p class="body-s">
-      Text inside components, very small text in the content body e. g. Captions; should enable quick reading at small
-      sizes
-    </p>
+    <p class="body-s">Text inside components, very small text in the content body e. g. Captions; should enable quick reading at small sizes</p>
   </div>
   <div>
-    <div class="label-l">
-      Label Large
-    </div>
-    <div class="label-m">
-      Label Medium
-    </div>
-    <div class="label-s">
-      Label Small
-    </div>
+    <div class="label-l">Label Large</div>
+    <div class="label-m">Label Medium</div>
+    <div class="label-s">Label Small</div>
   </div>
 </div>
 
 <div class="typo-box">
   <div class="typo-description">
     <p class="title-l no-top-margin">Body</p>
-    <p class="body-s">
-      used for longer passages of text
-    </p>
+    <p class="body-s">used for longer passages of text</p>
   </div>
   <div>
-    <div class="body-l">
-      Body Large
-    </div>
-    <div class="body-m">
-      Body Medium
-    </div>
-    <div class="body-s">
-      Body Small
-    </div>
+    <div class="body-l">Body Large</div>
+    <div class="body-m">Body Medium</div>
+    <div class="body-s">Body Small</div>
   </div>
 </div>


### PR DESCRIPTION
Closes #1128

## Proposed Changes

- Problem was that MDX created a `<p>` when a text was broken in a new line, e.g.:

```mdx
<div>
  <h1>
    My totally valid Headline
  </h1>
</div>
```

was parsed to 

```html
<div>
  <h1>
    <p>My totally valid Headline</p>
  </h1>
</div>
```