### PR TITLE
fix(elements|ino-icon): improve vertical alignment

### DIFF
--- a/packages/elements/src/components/ino-icon/ino-icon.scss
+++ b/packages/elements/src/components/ino-icon/ino-icon.scss
@@ -21,6 +21,7 @@
   display: inline-flex;
   flex-direction: column;
   justify-content: center;
+  vertical-align: middle;
 
   i {
     font-size: inherit;

--- a/packages/elements/src/components/ino-icon/readme.md
+++ b/packages/elements/src/components/ino-icon/readme.md
@@ -45,11 +45,11 @@ Alternatively, you can also just provide the URL to your preferred icon by setti
 
 ## CSS Custom Properties
 
-| Name                | Description        |
-| ------------------- | ------------------ |
-| `--ino-icon-color`  | Color of the icon  |
-| `--ino-icon-height` | Height of the icon |
-| `--ino-icon-width`  | Width of the icon  |
+| Name                | Description                        |
+| ------------------- | ---------------------------------- |
+| `--ino-icon-color`  | Color of the icon. [color:#3d40f5] |
+| `--ino-icon-height` | Height of the icon. [size:1em]     |
+| `--ino-icon-width`  | Width of the icon. [size:1em]      |
 
 
 ## Dependencies

--- a/packages/elements/src/components/ino-icon/readme.md
+++ b/packages/elements/src/components/ino-icon/readme.md
@@ -45,11 +45,11 @@ Alternatively, you can also just provide the URL to your preferred icon by setti
 
 ## CSS Custom Properties
 
-| Name                | Description                        |
-| ------------------- | ---------------------------------- |
-| `--ino-icon-color`  | Color of the icon. [color:#3d40f5] |
-| `--ino-icon-height` | Height of the icon. [size:1em]     |
-| `--ino-icon-width`  | Width of the icon. [size:1em]      |
+| Name                | Description        |
+| ------------------- | ------------------ |
+| `--ino-icon-color`  | Color of the icon  |
+| `--ino-icon-height` | Height of the icon |
+| `--ino-icon-width`  | Width of the icon  |
 
 
 ## Dependencies


### PR DESCRIPTION
Closes #1172 

## Proposed Changes

- set `vertical-align: middle` on ino-icon element

<!--
## Things to check

- [ ] Does the change need to be documented?
- [ ] Does any existing example code needs to be updated?
- [ ] Is the change properly tested?
- [ ] Is it helpful to provide another example to demonstrate the new feature?
- [ ] Are there other code lines that need to be modified?
-->
