### PR TITLE
fix(elements/ino-markdown-editor): adjust list spacings

### DIFF
--- a/packages/elements/src/components/ino-markdown-editor/ino-markdown-editor.scss
+++ b/packages/elements/src/components/ino-markdown-editor/ino-markdown-editor.scss
@@ -207,6 +207,10 @@ ino-markdown-editor {
       p {
         margin: 0;
       }
+
+      li {
+        margin: 2px 0;
+      }
     }
 
     :is(ul, ol)[data-type='taskList'] {

--- a/packages/elements/src/components/ino-markdown-editor/ino-markdown-editor.scss
+++ b/packages/elements/src/components/ino-markdown-editor/ino-markdown-editor.scss
@@ -203,12 +203,14 @@ ino-markdown-editor {
       list-style: none;
     }
 
-    :is(ul, ol)[data-type='taskList'] {
-      padding-left: 12px;
-
+    :is(ul, ol) {
       p {
         margin: 0;
       }
+    }
+
+    :is(ul, ol)[data-type='taskList'] {
+      padding-left: 12px;
 
       li {
         display: flex;


### PR DESCRIPTION
Closes #1194 

## Proposed Changes

- remove `p` spacing for `ul` and `ol` too

<!--
## Things to check

- [ ] Does the change need to be documented?
- [ ] Does any existing example code needs to be updated?
- [ ] Is the change properly tested?
- [ ] Is it helpful to provide another example to demonstrate the new feature?
- [ ] Are there other code lines that need to be modified?
-->
