### PR TITLE
fix: displays ino-button as inline-block element

### DIFF
--- a/packages/elements/src/components/ino-button/ino-button.scss
+++ b/packages/elements/src/components/ino-button/ino-button.scss
@@ -30,6 +30,8 @@ $edged-border: 24px 0 24px 24px;
 }
 
 ino-button {
+  display: inline-block;
+
   .button {
     display: flex;
     flex-direction: row;


### PR DESCRIPTION
Closes #1198 

## Proposed Changes

- `ino-button` is now an `inline-block` element

<!--
## Things to check

- [ ] Does the change need to be documented?
- [ ] Does any existing example code needs to be updated?
- [ ] Is the change properly tested?
- [ ] Is it helpful to provide another example to demonstrate the new feature?
- [ ] Are there other code lines that need to be modified?
-->
