### PR TITLE
feat(ui-patterns): add functionality to patterns

### DIFF
--- a/packages/ui-patterns/package.json
+++ b/packages/ui-patterns/package.json
@@ -14,13 +14,11 @@
   "files": [
     "dist"
   ],
-  "dependencies": {
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0"
-  },
   "devDependencies": {
     "@types/react": "^18.2.15",
     "@types/react-dom": "^18.2.7",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
     "@vitejs/plugin-react": "^4.0.3",
     "autoprefixer": "^10.4.16",
     "eslint-plugin-react-hooks": "^4.6.0",
@@ -34,7 +32,7 @@
   },
   "peerDependencies": {
     "@inovex.de/elements-react": "^9.0.0",
-    "react": "18.x",
-    "react-dom": "18.x"
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
   }
 }

--- a/packages/ui-patterns/src/patterns/login/Login.tsx
+++ b/packages/ui-patterns/src/patterns/login/Login.tsx
@@ -1,8 +1,47 @@
-import htmlContent from './login.html?raw';
-import PatternWrapper from '../PatternWrapper';
+import { useState } from 'react';
+import { InoInput, InoCheckbox, InoButton } from '@inovex.de/elements-react';
 
-function Login() {
-  return <PatternWrapper htmlContent={htmlContent} />;
-}
+const Login = () => {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [rememberMe, setRememberMe] = useState(false);
+
+  return (
+    <div className="h-[682px] w-[565px] bg-white rounded-2xl border border-solid border-inovex-p-5 shadow-2xl grid grid-rows-auto gap-y-8 px-24 py-28">
+      <h1 className="text-left">Login to your account</h1>
+      <p className="text-left body-l text-inovex-n-11 pb-8">
+        Welcome back! Enter your credentials to access your account. This modern
+        login interface is crafted with inovex Elements and Tailwind CSS.
+      </p>
+      <InoInput
+        label="Email"
+        outline
+        type="email"
+        value={email}
+        onValueChange={(e) => setEmail(e.detail)}
+      />
+      <InoInput
+        label="Password"
+        outline
+        type="password"
+        value={password}
+        onValueChange={(e) => setPassword(e.detail)}
+      />
+      <div className="flex justify-between items-center">
+        <label className="flex items-center cursor-pointer">
+          <InoCheckbox
+            checked={rememberMe}
+            onCheckedChange={() => setRememberMe(!rememberMe)}
+          />
+          <span className="body-l text-inovex-n-11 ml-2">Remember me</span>
+        </label>
+        <a className="body-l cursor-pointer">Forgot your password?</a>
+      </div>
+      <div className="flex justify-end">
+        <InoButton variant="filled">Login</InoButton>
+      </div>
+    </div>
+  );
+};
 
 export default Login;

--- a/packages/ui-patterns/vite.config.ts
+++ b/packages/ui-patterns/vite.config.ts
@@ -16,18 +16,14 @@ export default defineConfig({
       entry: resolve(__dirname, 'src/index.ts'),
       formats: ['es'],
     },
-    /* TODO: optimize bundle by externalizing react
     rollupOptions: {
-      external: ['react', 'react-dom', '@inovex.de/elements-react', 'react/jsx-runtime'],
+      external: ['react', 'react-dom'],
       output: {
         globals: {
           react: 'React',
           'react-dom': 'ReactDOM',
-          '@inovex.de/elements-react': '@inovex.de/elements-react' ,
-          'react/jsx-runtime': 'react/jsx-runtime'
         },
       },
     },
-    */
   },
 });


### PR DESCRIPTION
Closes #1165 

### Notes:

- Externalized React and ReactDOM in the vite build configuration of the ui-patterns lib, ensuring that it does not bundle its own instance of React

- Given our new approach of creating functional React components while also providing static HTML for easy copying, is the PatternWrapper component still necessary? (originally devised for wrapping raw HTML content with React)

Preview:

https://github.com/inovex/elements/assets/81302108/d656561c-6f8d-4c9a-a8c8-cc3ee2095194


