### PR TITLE
refactor(elements/ino-nav-drawer): switch to a bigger typography preset

### DIFF
--- a/packages/elements/src/components/ino-nav-drawer/ino-nav-drawer.scss
+++ b/packages/elements/src/components/ino-nav-drawer/ino-nav-drawer.scss
@@ -234,14 +234,6 @@
     .mdc-drawer__content {
       margin-top: 87px;
     }
-    .mdc-drawer__header {
-      font-size: 12px;
-      ::slotted(div) {
-        display: flex;
-        align-items: center;
-        gap: 13px;
-      }
-    }
 
     & + .mdc-drawer-app-content {
       box-shadow: none;

--- a/packages/elements/src/components/ino-nav-item/ino-nav-item.scss
+++ b/packages/elements/src/components/ino-nav-item/ino-nav-item.scss
@@ -28,10 +28,10 @@ ino-nav-item {
     height: 60px;
     background-color: var(--nav-item-background-color);
     color: var(--nav-item-color);
-    font-size: 14px;
+    @include typography.typo(label-l);
 
-    .mdc-list-item__secondary-text {
-      font-size: 12px;
+    &__secondary-text {
+      @include typography.typo(label-l);
     }
 
     // icon
@@ -75,8 +75,6 @@ ino-nav-item {
   &.mobile-nav-item {
     .mdc-deprecated-list-item,
     ino-list-item .mdc-deprecated-list-item {
-      @include typography.typo(label-s);
-
       &__graphic {
         margin-right: 0px;
       }
@@ -85,8 +83,8 @@ ino-nav-item {
       ::slotted(ino-icon),
       ino-icon,
       .ino-list-item__icon {
-        --icon-width: 16px;
-        --icon-height: 16px;
+        --icon-width: 18px;
+        --icon-height: 18px;
       }
     }
   }

--- a/packages/elements/src/components/ino-nav-item/ino-nav-item.scss
+++ b/packages/elements/src/components/ino-nav-item/ino-nav-item.scss
@@ -36,7 +36,6 @@ ino-nav-item {
 
     &__secondary-text {
       display: block !important;
-      @include typography.typo(label-l);
     }
 
     // icon

--- a/packages/elements/src/components/ino-nav-item/ino-nav-item.scss
+++ b/packages/elements/src/components/ino-nav-item/ino-nav-item.scss
@@ -28,13 +28,15 @@ ino-nav-item {
     height: 60px;
     background-color: var(--nav-item-background-color);
     color: var(--nav-item-color);
-    @include typography.typo(label-l);
+    font-size: 16px; // 2px bigger than typo(label-l)
+    font-weight: 500; // same as typo(label-l)
 
     &__text {
       display: block !important;
     }
 
     &__secondary-text {
+      @include typography.typo(label-l);
       display: block !important;
     }
 

--- a/packages/elements/src/components/ino-nav-item/ino-nav-item.scss
+++ b/packages/elements/src/components/ino-nav-item/ino-nav-item.scss
@@ -30,7 +30,12 @@ ino-nav-item {
     color: var(--nav-item-color);
     @include typography.typo(label-l);
 
+    &__text {
+      display: block !important;
+    }
+
     &__secondary-text {
+      display: block !important;
       @include typography.typo(label-l);
     }
 

--- a/packages/storybook/src/stories/ino-nav-drawer/ino-nav-drawer.spec.ts
+++ b/packages/storybook/src/stories/ino-nav-drawer/ino-nav-drawer.spec.ts
@@ -1,0 +1,22 @@
+import { expect, Locator, test } from '@playwright/test';
+import { goToStory } from '../test-utils';
+
+test.describe('ino-nav-drawer', () => {
+  let expandButton: Locator;
+
+  test.beforeEach(({ page }) => {
+    expandButton = page.locator('button:has-text("Toggle Navigation")');
+  });
+
+  test('can be opened properly', async ({ page }) => {
+    await goToStory(page, ['structure', 'ino-nav-drawer', 'default']);
+
+    const navDrawer = page.locator('ino-nav-drawer');
+
+    await expect(navDrawer).toHaveAttribute('open', '');
+
+    await expandButton.click();
+
+    await expect(navDrawer).toHaveAttribute('open', 'false');
+  });
+});


### PR DESCRIPTION
Closes #1202 & #1205

#### Notes:

I've adjusted the ino-nav-items to follow our typography preset (`label-l`). For the mobile ino-nav-drawer, I've matched the font sizes to the default settings but opted for slightly smaller icons to maintain balance. I tested a range of phone sizes to guarantee the design remains intuitive and readable in different environments.

>- [x] The font size of the subtitle has been increased. 

Previously, it was 12px, but it has now been updated to 14px (`label-l`). Due to this the primary text is bigger by 2px but keeps the same font weight (Refer to the attached screenshot below for details, 150% zoom.) 

![image](https://github.com/inovex/elements/assets/81302108/99676e2c-1a0c-459c-9117-d8727cbeebe2)


> - [x]  Font size for the mobile variant in ino-nav-drawer is increased to an appropriate and readable level.
> - [x]  The adjustment maintains a visually consistent and harmonious design with the overall application.
> - [x]  Thorough testing confirms that the font size is visually appealing on various mobile devices.

### Mobile view previews (#1202): 

**iPhone SE:**

![image](https://github.com/inovex/elements/assets/81302108/8454afd4-5333-4d24-bcad-9fcd2970b527)

**iPhone XR**:

![image](https://github.com/inovex/elements/assets/81302108/922eedab-4273-4035-afa6-cdd7f2db6c90)

**iPhone 14 Pro Max**:

![image](https://github.com/inovex/elements/assets/81302108/5f7beed0-dc4d-473d-af77-5233a4452823)

  

> - [x] Overflowing fonts in the mobile variant of ino-nav-drawer are appropriately handled (e.g. truncated with ...).
> - [x]  Switching to the mobile variant results in a font size that is readable and visually consistent with the overall application.
> - [x]  Thorough testing confirms that font sizes are visually appealing on various mobile devices.
> - [x]  The font-size of the subtitle is increased

### Preview from docked to mobile and initially loading mobile (#1205):

https://github.com/inovex/elements/assets/81302108/529ee939-227b-421f-84ed-7780b4f56ee1



