### PR TITLE
fix(landingpage): align mobile menu item content vertically

### DIFF
--- a/packages/landingpage/components/layout/header/mobile/header.mobile.module.scss
+++ b/packages/landingpage/components/layout/header/mobile/header.mobile.module.scss
@@ -46,6 +46,7 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
+  margin: 0.5rem 0;
 }
 
 .routes {
@@ -57,7 +58,7 @@
   margin-left: 2px;
   display: flex;
   flex-direction: column;
-  gap: 16px;
+  gap: 0.25rem;
 
   overflow: hidden;
   height: 0;

--- a/packages/landingpage/components/layout/header/mobile/header.mobile.tsx
+++ b/packages/landingpage/components/layout/header/mobile/header.mobile.tsx
@@ -78,6 +78,7 @@ export default function HeaderMobile() {
                   <div className={styles.menuItem}>
                     <LinkItem
                       url={mainRouteUrl}
+                      noMargin={true}
                       name={t(`common.navigation.${mainRouteName}.name`)}
                     />
                     <InoIcon

--- a/packages/landingpage/components/layout/linkItem.module.scss
+++ b/packages/landingpage/components/layout/linkItem.module.scss
@@ -34,7 +34,7 @@ p.linkDense {
   font-weight: lighter !important;
   font-size: large !important;
   margin: 0;
-  padding: 10px 15px;
+  padding: 10px 0 10px 15px;
   transition: color 200ms ease-in-out, background-color 200ms ease-in-out;
 }
 p.footerDense {
@@ -44,7 +44,7 @@ p.footerDense {
 }
 p.linkSubItem {
   @extend .linkDense;
-  border-radius: 99px 0px 99px 99px;
+  border-radius: 99px 0 99px 99px;
 
   &:hover {
     color: var(--inovex-elements-p-6);
@@ -53,7 +53,7 @@ p.linkSubItem {
 }
 
 @media only screen and (max-width: 1000px) {
-  p:not(.linkDense) {
+  p:not(.linkDense, .noMargin) {
     margin: 21px 0 0;
   }
 }


### PR DESCRIPTION
Closes #1188 

## Proposed Changes

- align text and icon of mobile muenu item vertically
- optimzie spacing in mobile menu to prevent letter break in german

<!--
## Things to check

- [ ] Does the change need to be documented?
- [ ] Does any existing example code needs to be updated?
- [ ] Is the change properly tested?
- [ ] Is it helpful to provide another example to demonstrate the new feature?
- [ ] Are there other code lines that need to be modified?
-->
