### PR TITLE
fix(elements/ino-nav-drawer): reinit listeners properly when switching between variants 

### DIFF
--- a/packages/elements/src/components/ino-nav-drawer/ino-nav-drawer.e2e.ts
+++ b/packages/elements/src/components/ino-nav-drawer/ino-nav-drawer.e2e.ts
@@ -274,5 +274,8 @@ describe('InoNavDrawer', () => {
         'mdc-drawer--anchor-right',
       ]);
     });
+
+    it.todo('should switch between variants');
+    it.todo('should toggle after changing variant');
   });
 });

--- a/packages/elements/src/components/ino-nav-drawer/ino-nav-drawer.tsx
+++ b/packages/elements/src/components/ino-nav-drawer/ino-nav-drawer.tsx
@@ -38,7 +38,11 @@ export class NavDrawer implements ComponentInterface {
    */
   private drawerInstance: MDCDrawer;
   private drawerEl: HTMLElement;
-  private reinitialize: boolean;
+  /**
+   * We need this flag because the MDCDrawer needs to initialize after ui updates.
+   * The property watcher is executed before rendering and initializing the MDCDrawer every component update is not needed.
+   */
+  private reinitializeAfterVariantChange: boolean;
   @Element() el!: HTMLInoNavDrawerElement;
 
   /**
@@ -71,7 +75,7 @@ export class NavDrawer implements ComponentInterface {
     } else {
       this.deactivateMobileMode();
     }
-    this.reinitialize = true;
+    this.reinitializeAfterVariantChange = true;
   }
 
   /**
@@ -103,10 +107,10 @@ export class NavDrawer implements ComponentInterface {
   }
 
   componentDidUpdate() {
-    if (this.reinitialize) {
+    if (this.reinitializeAfterVariantChange) {
       this.drawerInstance?.destroy();
       this.initDrawerInstance();
-      this.reinitialize = false;
+      this.reinitializeAfterVariantChange = false;
     }
   }
 


### PR DESCRIPTION
Closes #1204 

## Proposed Changes

- reinitialize instance of MDCDrawer on variant change

<!--
## Things to check

- [ ] Does the change need to be documented?
- [ ] Does any existing example code needs to be updated?
- [ ] Is the change properly tested?
- [ ] Is it helpful to provide another example to demonstrate the new feature?
- [ ] Are there other code lines that need to be modified?
-->
