### PR TITLE
refactor(storybook): improve testing config in pipeline

### DIFF
--- a/packages/storybook/playwright.config.ts
+++ b/packages/storybook/playwright.config.ts
@@ -28,6 +28,9 @@ export default defineConfig({
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: 'on-first-retry',
   },
+  expect: {
+    timeout: process.env.CI ? 10000 : 5000,
+  },
   reporter: process.env.CI ? 'dot' : 'list',
   /* Run your local dev server before starting the tests */
   webServer: {

--- a/packages/storybook/project.json
+++ b/packages/storybook/project.json
@@ -73,8 +73,7 @@
           "headed": false,
           "quiet": true,
           "passWithNoTests": false,
-          "skipInstall": true,
-          "timeout": 30000
+          "skipInstall": true
         },
         "headless": {
           "headed": false

--- a/packages/storybook/project.json
+++ b/packages/storybook/project.json
@@ -70,11 +70,11 @@
       "configurations": {
         "ci": {
           "forbidOnly": true,
-          "globalTimeout": 30000,
           "headed": false,
           "quiet": true,
           "passWithNoTests": false,
-          "skipInstall": true
+          "skipInstall": true,
+          "timeout": 30000
         },
         "headless": {
           "headed": false

--- a/packages/storybook/project.json
+++ b/packages/storybook/project.json
@@ -68,6 +68,14 @@
       },
       "defaultConfiguration": "headless",
       "configurations": {
+        "ci": {
+          "forbidOnly": true,
+          "globalTimeout": 30000,
+          "headed": false,
+          "quiet": true,
+          "passWithNoTests": false,
+          "skipInstall": true
+        },
         "headless": {
           "headed": false
         },


### PR DESCRIPTION
Improve pipeline configs:
- `forbidOnly`: useful because often forgotten
- `globalTimeout`: increase the timeout to cope with reduced performance of random github runner
- `quiet`: Prevent spam of output
- `passWithNoTests`: prevents false positives if for some reason test were not executed properly
- `skipInstall`: We check if playwright was installed before in order to restore the cache -> should save some time