### PR TITLE
fix(landingpage): hotfix ino-icon-buttons

### DIFF
--- a/packages/landingpage/app/[lang]/explore/_components/examples.tsx
+++ b/packages/landingpage/app/[lang]/explore/_components/examples.tsx
@@ -56,7 +56,7 @@ function Examples() {
         <InoIconButton
           class={styles.arrowButton}
           icon="arrow_left"
-          activated
+          filled={false}
           onClick={() => decrement()}
         ></InoIconButton>
         <div className={styles.carouselContainer}>
@@ -88,7 +88,7 @@ function Examples() {
         <InoIconButton
           class={styles.arrowButton}
           icon="arrow_right"
-          activated
+          filled={false}
           onClick={() => increment()}
         ></InoIconButton>
       </div>


### PR DESCRIPTION
Hot fix for ino-icon-buttons because icons where misaligned