### PR TITLE
ci: deploy storybook in release workflow

### DIFF
--- a/.github/workflows/deploy-release.yml
+++ b/.github/workflows/deploy-release.yml
@@ -64,7 +64,7 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       - name: Get current package version
         id: package-version
-        uses: martinbeentjes/npm-get-version-action@v1
+        uses: martinbeentjes/npm-get-version-action@v1.3.1
 
   ShowVersion:
     needs: release

--- a/.github/workflows/deploy-release.yml
+++ b/.github/workflows/deploy-release.yml
@@ -78,4 +78,4 @@ jobs:
     if: ${{ inputs.configuration == 'release' }}
     uses: ./.github/workflows/deploy-storybook.yml
     with:
-     version: ${{ needs.release.outputs.version }}
+      version: ${{ needs.release.outputs.version }}

--- a/.github/workflows/deploy-release.yml
+++ b/.github/workflows/deploy-release.yml
@@ -28,6 +28,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write # needed for GitHub releases
+    outputs:
+      version: v${{ steps.package-version.outputs.current-version }}
     if: github.ref == 'refs/heads/master' || inputs.configuration == 'dryRun'
     steps:
       - name: Checkout repository
@@ -37,7 +39,7 @@ jobs:
           token: ${{ secrets.PUSH_PAT }}
       - name: Track master branch to make nx affected work
         run: git branch --track main origin/master
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version-file: '.nvmrc'
           registry-url: https://registry.npmjs.org
@@ -60,3 +62,20 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: Get current package version
+        id: package-version
+        uses: martinbeentjes/npm-get-version-action@v1
+
+  ShowVersion:
+    needs: release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Show version
+        run: echo ${{ needs.release.outputs.version }}
+
+  deployStorybook:
+    needs: release
+    if: ${{ inputs.configuration == 'release' }}
+    uses: ./.github/workflows/deploy-storybook.yml
+    with:
+     version: ${{ needs.release.outputs.version }}

--- a/.github/workflows/deploy-storybook.yml
+++ b/.github/workflows/deploy-storybook.yml
@@ -1,13 +1,23 @@
 name: 'Deploy Storybook'
 
 on:
-  push:
-    tags:
-      - 'v[0-9]+.[0-9]+.[0-9]+'
+  workflow_call:
+    inputs:
+      version:
+        description: Latest elements version in format v[0-9].[0-9].[0-9]
+        required: true
+        type: string
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Latest elements version in format v[0-9].[0-9].[0-9]
+        required: true
+        type: string
 
 jobs:
   build:
     runs-on: ubuntu-latest
+    if: startsWith(${{ inputs.version }}, 'v')
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/workflows/dependencies-install
@@ -15,10 +25,11 @@ jobs:
         run: yarn nx run storybook:build
         env:
           NX_REJECT_UNKNOWN_LOCAL_CACHE: 0
-      - name: Upload Storybook artifact
-        uses: ./.github/workflows/artifacts-upload
+      - name: Upload Storybook artifact ⬆️
+        uses: actions/upload-artifact@v4
         with:
-          upload-storybook-artifact: true
+          name: storybook
+          path: packages/storybook/dist/
 
   deploy:
     needs: build
@@ -29,15 +40,13 @@ jobs:
         with:
           ref: pages
       - name: Download Storybook artifact
-        uses: dawidd6/action-download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: storybook
-          path: version/${{ github.ref_name }} # Push to the proper directory on gh pages branch.
-          check-artifacts: true # search in current workflow run
-          workflow-conclusion: 'in_progress' # need to change to in_progress, cause current workflow run is always running
+          path: version/${{ inputs.version }}
       - name: Provide latest symlink
-        if: ${{ ! contains( github.ref_name, '-' ) }} # only link to latest for releases (e.g. v7.0.0), not pre-releases (e.g. v.7.0.0-1)
-        run: cd version && rm -f latest && ln -s ${{ github.ref_name }} latest
+        if: ${{ ! contains( inputs.version, '-' ) }} # only link to latest for releases (e.g. v7.0.0), not pre-releases (e.g. v.7.0.0-1)
+        run: cd version && rm -f latest && ln -s ${{ inputs.version }} latest
         shell: bash
 
       # Crawls the version dir on current pages branch HEAD.
@@ -46,9 +55,9 @@ jobs:
         run: find ./version/* -type d -maxdepth 0 | cut -c 11- | jq -R -s -c 'split("\n")[:-1]' > ./hosted-versions.json
 
       - name: Deploy to Github Pages 🚀
-        uses: JamesIves/github-pages-deploy-action@4.1.7
+        uses: JamesIves/github-pages-deploy-action@v4
         with:
           branch: pages
-          commit-message: Deploying version ${{ github.ref_name }} 🚀
+          commit-message: Deploying version ${{ inputs.version }} 🚀
           folder: '.'
           clean: false # Important to keep other versions.

--- a/.github/workflows/deploy-storybook.yml
+++ b/.github/workflows/deploy-storybook.yml
@@ -11,13 +11,15 @@ on:
     inputs:
       version:
         description: Latest elements version in format v[0-9].[0-9].[0-9]
-        required: true
+        required: false
         type: string
 
 jobs:
   build:
     runs-on: ubuntu-latest
-    if: startsWith(${{ inputs.version }}, 'v')
+    outputs:
+      version: v${{ steps.version.outputs.current-version }}
+      isNew: v${{ steps.version-check.outputs.isNew }}
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/workflows/dependencies-install
@@ -30,6 +32,12 @@ jobs:
         with:
           name: storybook
           path: packages/storybook/dist/
+      - name: Get current package version
+        id: version
+        uses: martinbeentjes/npm-get-version-action@v1.3.1
+      - name: Check for new version deployment
+        id: version-check
+        run: echo "isNew=${{ startsWith(inputs.version, 'v') }}" >> "$GITHUB_OUTPUT"
 
   deploy:
     needs: build
@@ -43,21 +51,22 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: storybook
-          path: version/${{ inputs.version }}
+          path: version/${{ needs.build.outputs.isNew && inputs.version || needs.build.outputs.version }}
       - name: Provide latest symlink
-        if: ${{ ! contains( inputs.version, '-' ) }} # only link to latest for releases (e.g. v7.0.0), not pre-releases (e.g. v.7.0.0-1)
+        if: needs.build.outputs.isNew
         run: cd version && rm -f latest && ln -s ${{ inputs.version }} latest
         shell: bash
 
       # Crawls the version dir on current pages branch HEAD.
       # Jq extracts the directory name of the versions and transfers it to an array of the form ["0.1.1", "0.2.1"].
       - name: Update Hosted Versions
+        if: needs.build.outputs.isNew
         run: find ./version/* -type d -maxdepth 0 | cut -c 11- | jq -R -s -c 'split("\n")[:-1]' > ./hosted-versions.json
 
       - name: Deploy to Github Pages 🚀
         uses: JamesIves/github-pages-deploy-action@v4
         with:
           branch: pages
-          commit-message: Deploying version ${{ inputs.version }} 🚀
+          commit-message: ${{ needs.build.outputs.isNew && 'Deploying version ${{ inputs.version }} 🚀' || 'Update storybook' }}
           folder: '.'
           clean: false # Important to keep other versions.


### PR DESCRIPTION
Closes #1277

Because we checkout the `pages` branch, we are not able to build the storybook directly. But I align the deployment of the storybook with the landingpage deployment.

**To be discussed**
Now I need a version as input for the deployment. But we can omit this.

To do this we can read the latest version from the root `package.json`. Same as now in the release workflow (see changes). During this it is not possible to deploy an other version than the latest one, but I do not know if this is needed.

## Proposed Changes

- provide manual storybook deployment
- deploy storybook with release workflow

<!--
## Things to check

- [ ] Does the change need to be documented?
- [ ] Does any existing example code needs to be updated?
- [ ] Is the change properly tested?
- [ ] Is it helpful to provide another example to demonstrate the new feature?
- [ ] Are there other code lines that need to be modified?
-->
