### PR TITLE
refactor(elements/ino-datepicker): migrate stencil e2e tests to playwright

### DIFF
--- a/packages/elements/setupSpecTests.ts
+++ b/packages/elements/setupSpecTests.ts
@@ -4,11 +4,13 @@
   observe() {}
 };
 
-jest.mock('@material/textfield', () => ({
-  ...jest.requireActual('@material/textfield'),
-  MDCTextField: class {
-    public focus = jest.fn();
-    public destroy = jest.fn();
-    public value = '';
-  },
-}));
+HTMLInputElement.prototype.checkValidity = jest.fn();
+HTMLInputElement.prototype.setSelectionRange = jest.fn();
+
+global.XMLSerializer = class XmlSerializerWrapper {
+  public serializeToString() {
+    return '';
+  }
+};
+
+jest.mock('@material/textfield');

--- a/packages/elements/src/components/ino-datepicker/ino-datepicker.e2e.ts
+++ b/packages/elements/src/components/ino-datepicker/ino-datepicker.e2e.ts
@@ -47,57 +47,6 @@ describe('InoDatepicker', () => {
       expect(flatpickrInputEl).toHaveClass('mdc-text-field--focused');
     });
 
-    it('should render with disabled set to true', async () => {
-      const page = await setupPageWithContent(INO_DATEPICKER);
-
-      const inoDatepickerEl = await page.find(DATEPICKER);
-      expect(inoDatepickerEl).toBeDefined();
-
-      const inputEl = await page.find(INPUT);
-      expect(inputEl).toBeDefined();
-      expect(inputEl).not.toHaveAttribute('disabled');
-
-      inoDatepickerEl.setAttribute('disabled', 'true');
-      await page.waitForChanges();
-
-      expect(inputEl).toHaveAttribute('disabled');
-    });
-
-    it('should render with required set to true', async () => {
-      const page = await setupPageWithContent(INO_DATEPICKER);
-
-      const inoDatepickerEl = await page.find(DATEPICKER);
-      expect(inoDatepickerEl).toBeDefined();
-
-      const inoInputEL = await page.find(INPUT);
-      expect(inoInputEL).toBeDefined();
-      expect(inoInputEL).not.toHaveAttribute('required');
-
-      inoDatepickerEl.setAttribute('required', 'true');
-      await page.waitForChanges();
-      expect(inoDatepickerEl).toHaveAttribute('required');
-    });
-
-    it('should render with inoOutline set to true', async () => {
-      const page = await setupPageWithContent(INO_DATEPICKER);
-
-      const inoDatepickerEl = await page.find(DATEPICKER);
-      expect(inoDatepickerEl).toBeDefined();
-
-      let mdcLineRipple = await page.find('.mdc-line-ripple');
-      let mdcNotchedOutline = await page.find('.mdc-notched-outline');
-      expect(mdcLineRipple).toBeDefined();
-      expect(mdcNotchedOutline).toBeNull();
-
-      inoDatepickerEl.setAttribute('outline', 'true');
-      await page.waitForChanges();
-
-      mdcLineRipple = await page.find('.mdc-line-ripple');
-      mdcNotchedOutline = await page.find('.mdc-notched-outline');
-      expect(mdcLineRipple).toBeNull();
-      expect(mdcNotchedOutline).toBeDefined();
-    });
-
     it('should render with min date', async () => {
       let page = await setupPageWithContent(INO_DATEPICKER);
 
@@ -180,34 +129,6 @@ describe('InoDatepicker', () => {
       await page.waitForChanges();
 
       expect(flatpickrInputEl).toHaveClass('mdc-text-field--invalid');
-    });
-  });
-
-  describe('Events', () => {
-    it('should emit a valueChange event upon changing the input', async () => {
-      const page = await setupPageWithContent(INO_DATEPICKER);
-      const input = await page.find(INPUT);
-      const valueChangeEvent = await page.spyOnEvent('valueChange');
-
-      await input.type('1');
-      await page.waitForChanges();
-
-      expect(valueChangeEvent).toHaveReceivedEvent();
-    });
-
-    it('should not emit a valueChange event if datepicker is disabled', async () => {
-      const page = await setupPageWithContent(INO_DATEPICKER);
-      const datepicker = await page.find(DATEPICKER);
-      const input = await page.find(INPUT);
-      const valueChangeEvent = await page.spyOnEvent('valueChange');
-
-      await datepicker.setAttribute('disabled', true);
-      await page.waitForChanges();
-
-      await input.type('1');
-      await page.waitForChanges();
-
-      expect(valueChangeEvent).not.toHaveReceivedEvent();
     });
   });
 

--- a/packages/elements/src/components/ino-datepicker/ino-datepicker.spec.ts
+++ b/packages/elements/src/components/ino-datepicker/ino-datepicker.spec.ts
@@ -1,0 +1,85 @@
+import { newSpecPage, SpecPage } from '@stencil/core/testing';
+import { listenForEvent } from '../../util/test-utils';
+import { Datepicker } from './ino-datepicker';
+import { Input } from '../ino-input/ino-input';
+import { Label } from '../ino-label/ino-label';
+
+describe('InoDatepicker', () => {
+  let page: SpecPage;
+  let inoDatepicker: HTMLInoDatepickerElement;
+  let inputEl: HTMLInputElement;
+
+  const type = async (value: string) => {
+    const arr = [...value];
+    inputEl.value = '';
+    arr.forEach((char) => {
+      inputEl.value += char;
+      inputEl.dispatchEvent(new Event('input'));
+    });
+    await page.waitForChanges();
+  };
+
+  beforeEach(async () => {
+    page = await newSpecPage({
+      components: [Datepicker, Input, Label],
+      html: `<ino-datepicker></ino-datepicker>`,
+    });
+    inoDatepicker = page.body.querySelector('ino-datepicker');
+    inputEl = inoDatepicker.querySelector('input');
+  });
+
+  describe('Events', () => {
+    it('should emit a valueChange event upon changing the input', async () => {
+      const { eventSpy } = listenForEvent(page, 'valueChange');
+
+      await type('1');
+      expect(eventSpy).toHaveBeenCalled();
+    });
+
+    it('should not emit a valueChange event if datepicker is disabled', async () => {
+      const { eventSpy } = listenForEvent(page, 'valueChange');
+
+      inoDatepicker.setAttribute('disabled', 'true');
+      await page.waitForChanges();
+
+      await type('1');
+      expect(eventSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Properties', () => {
+    it('should render with disabled set to true', async () => {
+      expect(inputEl).not.toHaveAttribute('disabled');
+
+      inoDatepicker.setAttribute('disabled', 'true');
+      await page.waitForChanges();
+
+      expect(inputEl).toHaveAttribute('disabled');
+    });
+
+    it('should render with required set to true', async () => {
+      expect(inputEl).not.toHaveAttribute('required');
+
+      inoDatepicker.setAttribute('required', 'true');
+      await page.waitForChanges();
+      expect(inputEl).toHaveAttribute('required');
+    });
+
+    it('should render with inoOutline set to true', async () => {
+      let mdcLineRipple = page.body.querySelector('.mdc-line-ripple');
+      let mdcNotchedOutline = page.body.querySelector('.mdc-notched-outline');
+      expect(mdcLineRipple).toBeTruthy();
+      expect(mdcNotchedOutline).toBeNull();
+
+      page = await newSpecPage({
+        components: [Datepicker, Input, Label],
+        html: `<ino-datepicker outline></ino-datepicker>`,
+      });
+
+      mdcLineRipple = page.body.querySelector('.mdc-line-ripple');
+      mdcNotchedOutline = page.body.querySelector('.mdc-notched-outline');
+      expect(mdcLineRipple).toBeNull();
+      expect(mdcNotchedOutline).toBeTruthy();
+    });
+  });
+});

--- a/packages/elements/src/components/ino-datepicker/validator.spec.ts
+++ b/packages/elements/src/components/ino-datepicker/validator.spec.ts
@@ -1,7 +1,20 @@
 import { Validator } from './validator';
 
+const originalConsole = console;
+
 describe('DateValidator', () => {
   let dateValidator: Validator;
+
+  beforeAll(() => {
+    global.console = {
+      ...console,
+      warn: jest.fn(),
+    };
+  });
+
+  afterAll(() => {
+    global.console = originalConsole;
+  });
 
   beforeEach(() => {
     dateValidator = new Validator({

--- a/packages/elements/src/components/ino-input/ino-input.tsx
+++ b/packages/elements/src/components/ino-input/ino-input.tsx
@@ -1,6 +1,8 @@
-import { MDCTextField } from '@material/textfield';
-import { MDCTextFieldHelperText } from '@material/textfield/helper-text';
-import { MDCTextFieldIcon } from '@material/textfield/icon';
+import {
+  MDCTextField,
+  MDCTextFieldHelperText,
+  MDCTextFieldIcon,
+} from '@material/textfield';
 import {
   Component,
   ComponentInterface,
@@ -395,6 +397,8 @@ export class Input implements ComponentInterface {
   // ----
 
   private handleNativeInputChange = (e) => {
+    if (this.disabled) return;
+
     let value = e.target.value;
 
     if (this.userInputInterceptorFn) {


### PR DESCRIPTION
Part of #1258

## Proposed Changes

- migrate existing stencil e2e tests to playwright

<!--
## Things to check

- [ ] Does the change need to be documented?
- [ ] Does any existing example code needs to be updated?
- [ ] Is the change properly tested?
- [ ] Is it helpful to provide another example to demonstrate the new feature?
- [ ] Are there other code lines that need to be modified?
-->
