### PR TITLE
refactor(elements/ino-list-item): migrate stencil e2e tests to jest spec tests

### DIFF
--- a/packages/elements/src/components/ino-list-item/ino-list-item.spec.ts
+++ b/packages/elements/src/components/ino-list-item/ino-list-item.spec.ts
@@ -1,0 +1,57 @@
+import { newSpecPage, SpecPage } from '@stencil/core/testing';
+import { listenForEvent } from '../../util/test-utils';
+import { ListItem } from './ino-list-item';
+
+describe('InoListItem', () => {
+  let page: SpecPage;
+  let inoListItem: HTMLInoListElement;
+  let liElement: HTMLLIElement;
+
+  beforeEach(async () => {
+    page = await newSpecPage({
+      components: [ListItem],
+      html: `<ino-list-item/>`,
+    });
+    inoListItem = page.body.querySelector('ino-list-item');
+    liElement = inoListItem.querySelector('li');
+  });
+
+  it('should disable the list-item if disabled property is set to true', async () => {
+    expect(liElement).not.toHaveClass('mdc-deprecated-list-item--disabled');
+    inoListItem.setAttribute('disabled', 'true');
+    await page.waitForChanges();
+    expect(liElement).toHaveClass('mdc-deprecated-list-item--disabled');
+  });
+
+  it('should render with the selected property set to true', async () => {
+    expect(liElement).not.toHaveClass('mdc-deprecated-list-item--selected');
+    inoListItem.setAttribute('selected', 'true');
+    await page.waitForChanges();
+    expect(liElement).toHaveClass('mdc-deprecated-list-item--selected');
+  });
+
+  it('should render with the activated property set to true', async () => {
+    expect(liElement).not.toHaveClass('mdc-deprecated-list-item--activated');
+    inoListItem.setAttribute('activated', 'true');
+    await page.waitForChanges();
+    expect(liElement).toHaveClass('mdc-deprecated-list-item--activated');
+  });
+
+  it('should emit a clickEl event upon clicking a list item', async () => {
+    const { eventSpy } = listenForEvent(page, 'clickEl');
+    inoListItem.click();
+    await page.waitForChanges();
+    expect(eventSpy).toHaveBeenCalled();
+  });
+
+  it('should not emit a clickEl event upon clicking a list item if inoDisabled is true', async () => {
+    const { eventSpy } = listenForEvent(page, 'clickEl');
+
+    inoListItem.setAttribute('disabled', 'true');
+    await page.waitForChanges();
+    inoListItem.click();
+    await page.waitForChanges();
+
+    expect(eventSpy).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Part of #1258 

## Proposed Changes

- migrate existing stencil e2e tests to jest spec tests

<!--
## Things to check

- [ ] Does the change need to be documented?
- [ ] Does any existing example code needs to be updated?
- [ ] Is the change properly tested?
- [ ] Is it helpful to provide another example to demonstrate the new feature?
- [ ] Are there other code lines that need to be modified?
-->
