### PR TITLE
refactor(elements): align ino-icon vertically and adjust parent components for consistency

### DIFF
--- a/packages/elements/src/components/ino-button/ino-button.scss
+++ b/packages/elements/src/components/ino-button/ino-button.scss
@@ -62,6 +62,7 @@ ino-button {
   }
 
   .icon__wrapper {
+    display: inline-flex;
     height: 16px;
   }
 

--- a/packages/elements/src/components/ino-chip/ino-chip.scss
+++ b/packages/elements/src/components/ino-chip/ino-chip.scss
@@ -40,6 +40,9 @@ ino-chip {
     transition: ease-in-out 0.15s;
 
     .ino-chip-leading-icon {
+      display: flex;
+      justify-content: center;
+
       --ino-icon-width: #{$icon-size};
       --ino-icon-height: #{$icon-size};
     }

--- a/packages/elements/src/components/ino-icon-button/ino-icon-button.scss
+++ b/packages/elements/src/components/ino-icon-button/ino-icon-button.scss
@@ -41,6 +41,10 @@ ino-icon-button {
     background-color: $background-color;
     border-radius: 50%;
 
+    &__icon {
+      display: inline-flex;
+    }
+
     .mdc-icon-button__ripple::before,
     .mdc-icon-button__ripple::after {
       background-color: $background-active-color;

--- a/packages/elements/src/components/ino-icon/ino-icon.scss
+++ b/packages/elements/src/components/ino-icon/ino-icon.scss
@@ -21,6 +21,7 @@
   display: inline-flex;
   flex-direction: column;
   justify-content: center;
+  vertical-align: middle;
 
   i {
     font-size: inherit;

--- a/packages/elements/src/components/ino-select/ino-select.scss
+++ b/packages/elements/src/components/ino-select/ino-select.scss
@@ -137,7 +137,7 @@ ino-select {
     }
 
     .mdc-select__icon {
-      margin-top: 12px;
+      margin-top: 6px;
     }
 
     .mdc-select__dropdown-icon {
@@ -168,6 +168,10 @@ ino-select {
   .mdc-select--outlined {
     .mdc-select__selected-text {
       margin-top: 16px;
+    }
+
+    .mdc-select__icon {
+      margin-top: 2px;
     }
 
     .mdc-floating-label.mdc-floating-label--float-above {

--- a/packages/storybook/src/stories/ino-button/ino-button.scss
+++ b/packages/storybook/src/stories/ino-button/ino-button.scss
@@ -1,8 +1,6 @@
 @import '../utils';
 
-#story--buttons-ino-button--leading-and-trailing-icon-inner {
-  @include story-container {
-    display: flex;
-    column-gap: 20px;
-  }
+#root-inner {
+  display: flex;
+  gap: 25px;
 }

--- a/packages/storybook/src/stories/ino-button/ino-button.scss
+++ b/packages/storybook/src/stories/ino-button/ino-button.scss
@@ -1,6 +1,9 @@
 @import '../utils';
 
-#root-inner {
-  display: flex;
-  gap: 25px;
+#story--buttons-ino-button--leading-and-trailing-icon-inner {
+  @include story-container {
+    display: flex;
+    justify-content: center;
+    column-gap: 20px;
+  }
 }


### PR DESCRIPTION
Closes #1340

## Proposed Changes

- Added `vertical-alignment: middle;` to the ino-icon.
- Adjusted alignment settings for all parent components that are affected by this change to ensure consistent vertical alignment

Parent components that needed adjustment:
- [x] ino-button
- [x] ino-chip
- [x] ino-icon-button (this also seemed to fix the misaligned ripple issue that has been reocurring before)
- [x] ino-select

other components like the ino-avatar didnt need any refactoring

![image](https://github.com/inovex/elements/assets/81302108/eb7788ad-3db8-4a7a-893e-f5b1198313fa)

![image](https://github.com/inovex/elements/assets/81302108/199a15f3-4d73-42f6-88c2-f06b35b1441d)

![image](https://github.com/inovex/elements/assets/81302108/af7e1a71-34f7-4c0d-a2bf-3a8faab9a4a8)

![image](https://github.com/inovex/elements/assets/81302108/5caacbe5-5160-4f0b-91fd-43e3a668806f)

![image](https://github.com/inovex/elements/assets/81302108/09063466-1599-40b8-9ee9-e96823f3051d)

![image](https://github.com/inovex/elements/assets/81302108/bb19e3d5-7d88-4f7c-a665-b95392a24795)

![image](https://github.com/inovex/elements/assets/81302108/81cc4e47-bfca-41cf-af1e-48236b6a6305)

![image](https://github.com/inovex/elements/assets/81302108/489cdd48-4579-4251-94ac-fc1336ea79e6)

![image](https://github.com/inovex/elements/assets/81302108/519a5eb3-896c-4400-aa33-782f90dcbfbb)









